### PR TITLE
ci: improve coverage gate and DPM pipeline alignment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,85 @@ jobs:
           python -m pip install --upgrade pip
           make install
 
-      - name: Run Quality Gate
+      - name: Lint + Typecheck + Unit Tests
         run: make check
+
+  test-suites:
+    name: Tests (${{ matrix.suite }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suite: unit
+            args: tests/unit/services/query_service
+          - suite: integration-lite
+            args: tests/integration/services/query_service/test_concentration_router.py tests/integration/services/query_service/test_position_analytics_router.py tests/integration/services/query_service/test_review_router.py tests/integration/services/query_service/test_summary_router.py
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+
+      - name: Install Tooling and Project Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          make install
+
+      - name: Run ${{ matrix.suite }} tests with coverage data
+        env:
+          COVERAGE_FILE: .coverage.${{ matrix.suite }}
+        run: |
+          python -m pytest ${{ matrix.args }} --cov=src/services/query_service/app --cov-report=
+
+      - name: Upload coverage data (${{ matrix.suite }})
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-data-${{ matrix.suite }}
+          path: .coverage.${{ matrix.suite }}
+          include-hidden-files: true
+          if-no-files-found: error
+
+  coverage-gate:
+    name: Coverage Gate (Combined)
+    needs: [test-suites]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+
+      - name: Install Tooling and Project Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          make install
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-data-*
+          merge-multiple: true
+          path: coverage-data
+
+      - name: Enforce combined coverage threshold
+        run: |
+          python -m coverage combine coverage-data
+          python -m coverage report --fail-under=82
 
   docker-build:
     name: Validate Docker Build
-    needs: [quality]
+    needs: [quality, coverage-gate]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint typecheck test test-unit check docker-build clean
+.PHONY: install lint typecheck test test-unit test-integration-lite check coverage-gate ci-local docker-build clean
 
 install:
 	python scripts/bootstrap_dev.py
@@ -16,7 +16,15 @@ test:
 test-unit:
 	python -m pytest tests/unit/services/query_service -q
 
+test-integration-lite:
+	python -m pytest tests/integration/services/query_service/test_concentration_router.py tests/integration/services/query_service/test_position_analytics_router.py tests/integration/services/query_service/test_review_router.py tests/integration/services/query_service/test_summary_router.py -q
+
 check: lint typecheck test
+
+coverage-gate:
+	python scripts/coverage_gate.py
+
+ci-local: lint typecheck coverage-gate
 
 docker-build:
 	docker build -f src/services/query_service/Dockerfile -t portfolio-analytics-query-service:ci .

--- a/README.md
+++ b/README.md
@@ -132,16 +132,22 @@ To run the enforced unit test gate:
 make test
 ```
 
+To run the integration-lite suite used in CI coverage:
+
+```bash
+make test-integration-lite
+```
+
 To run the query-service unit suite directly:
 
 ```bash
 pytest tests/unit/services/query_service -q
 ```
 
-To run the full local quality gate (lint + mypy + tests):
+To run the full local quality gate (lint + mypy + combined coverage gate):
 
 ```bash
-make check
+make ci-local
 ```
 
 ## Verifying the Workflow
@@ -186,7 +192,17 @@ This project uses a DPM-aligned engineering baseline:
 make lint
 make typecheck
 make check
+make coverage-gate
+make ci-local
 ```
+
+CI workflow shape:
+
+- `Workflow Lint`
+- `Lint, Typecheck, Unit Tests`
+- `Tests (unit)` + `Tests (integration-lite)` coverage data jobs
+- `Coverage Gate (Combined)` with `--fail-under=82`
+- `Validate Docker Build`
 
 ## Tools
 

--- a/docs/RFCs/RFC 030 - CI Coverage Gate and DPM Pipeline Parity Phase 2.md
+++ b/docs/RFCs/RFC 030 - CI Coverage Gate and DPM Pipeline Parity Phase 2.md
@@ -1,0 +1,49 @@
+# RFC 030 - CI Coverage Gate and DPM Pipeline Parity Phase 2
+
+- Status: Proposed
+- Date: 2026-02-23
+- Depends on: RFC 029
+
+## Context
+
+RFC 029 established a DPM-style baseline, but CI remained basic in two areas:
+
+- no matrixed test suites with artifactized coverage data
+- no explicit combined coverage gate
+
+Also, some integration tests currently depend on full Docker orchestration and are not yet stable for mandatory CI gates.
+
+## Decision
+
+Adopt DPM-style phased CI hardening:
+
+1. Add test matrix jobs:
+   - `Tests (unit)`
+   - `Tests (integration-lite)`
+2. Upload per-suite coverage artifacts.
+3. Add `Coverage Gate (Combined)` job enforcing `--fail-under=82`.
+4. Keep `Lint, Typecheck, Unit Tests` and `Validate Docker Build` as protected required checks.
+5. Keep Docker-dependent integration tests out of required gate until migration-runner/docker-compose reliability is hardened.
+
+## Why 82% Now
+
+- Current stable combined scope (unit + integration-lite) reaches ~83%.
+- 82% creates a real guardrail without introducing CI flakiness.
+- Threshold can be ratcheted upward once additional routers/services and Docker-dependent integration tests are stabilized.
+
+## Makefile Alignment
+
+Add standardized commands:
+
+- `make test-integration-lite`
+- `make coverage-gate`
+- `make ci-local`
+
+This keeps local validation aligned with GitHub Actions.
+
+## Next Ratchet (Phase 3)
+
+1. Fix Docker-dependent integration failures in CI (`migration-runner`/env wiring).
+2. Promote selected integration tests into required matrix.
+3. Raise combined coverage gate to `85%+`.
+4. Introduce full-suite coverage gating once non-determinism is removed.

--- a/scripts/coverage_gate.py
+++ b/scripts/coverage_gate.py
@@ -1,0 +1,42 @@
+"""Run stable query-service suites with coverage and enforce a threshold."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+UNIT_ARGS = ["tests/unit/services/query_service"]
+INTEGRATION_LITE_ARGS = [
+    "tests/integration/services/query_service/test_concentration_router.py",
+    "tests/integration/services/query_service/test_position_analytics_router.py",
+    "tests/integration/services/query_service/test_review_router.py",
+    "tests/integration/services/query_service/test_summary_router.py",
+]
+
+SOURCE = "src/services/query_service/app"
+FAIL_UNDER = "82"
+
+
+def run_pytest(args: list[str], coverage_file: str) -> None:
+    env = os.environ.copy()
+    env["COVERAGE_FILE"] = coverage_file
+    cmd = [sys.executable, "-m", "pytest", *args, f"--cov={SOURCE}", "--cov-report="]
+    subprocess.run(cmd, check=True, env=env)
+
+
+def run(cmd: list[str]) -> None:
+    subprocess.run(cmd, check=True)
+
+
+def main() -> int:
+    run_pytest(UNIT_ARGS, ".coverage.unit")
+    run_pytest(INTEGRATION_LITE_ARGS, ".coverage.integration_lite")
+    run([sys.executable, "-m", "coverage", "combine", ".coverage.unit", ".coverage.integration_lite"])
+    run([sys.executable, "-m", "coverage", "report", f"--fail-under={FAIL_UNDER}"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add DPM-style test matrix jobs (unit, integration-lite) with uploaded coverage artifacts
- add combined Coverage Gate (Combined) enforcing --fail-under=82
- keep protected required checks intact and make docker build depend on quality + coverage gate
- add cross-platform scripts/coverage_gate.py and wire make coverage-gate / make ci-local
- document CI shape and commands in README
- add RFC 030 for coverage ratchet roadmap

## Validation
- make ci-local (passes, combined coverage 83%)
- make docker-build