### PR TITLE
docs(pas): add central platform-governance pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 
 This system provides a comprehensive suite of services for portfolio analytics, including position tracking, valuation, performance calculation, and risk analysis. It is designed as a distributed, event-driven architecture using Kafka for messaging and PostgreSQL for data persistence.
 
+Platform architecture governance source:
+- `https://github.com/sgajbi/pbwm-platform-docs` (cross-cutting and multi-service decisions)
+
 ## Table of Contents
 
 - [Architectural Overview](#architectural-overview)


### PR DESCRIPTION
## Summary
Aligns PAS repository documentation with central platform governance.

## What Changed
- Updated README.md to explicitly reference:
  - https://github.com/sgajbi/pbwm-platform-docs

## Why
Ensures cross-cutting and multi-service architecture decisions are sourced centrally while PAS repo stays focused on PAS implementation.

## Impact
- Documentation-only change
- No runtime or API behavior changes