### PR TITLE
feat(pas): harden core snapshot contract with governance and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,23 @@ make test-e2e-smoke
     curl "http://localhost:8201/integration/capabilities?consumerSystem=BFF&tenantId=default"
     ```
 
+    Core snapshot governance/freshness controls (optional):
+
+    - `PAS_INTEGRATION_SNAPSHOT_POLICY_JSON`: policy object for section governance.
+      Supports:
+      - `strictMode`
+      - `consumers` (consumer -> allowed sections)
+      - `tenants` (tenant overrides for `strictMode`, `consumers`, `defaultSections`)
+    - `PAS_DEFAULT_TENANT_ID`: tenant context used by integration snapshot policy resolution.
+    - `PAS_INTEGRATION_MAX_STALENESS_DAYS`: freshness threshold for `metadata.freshnessStatus`.
+
+    Core snapshot response includes `metadata` with:
+    - `generatedAt`
+    - `sourceAsOfDate`
+    - `freshnessStatus`
+    - `lineageRefs`
+    - `sectionGovernance` (`requestedSections`, `effectiveSections`, `droppedSections`, `warnings`)
+
     Integration capability policy overrides (optional):
 
     - `PAS_POLICY_VERSION`: default global policy version label.

--- a/docs/RFCs/RFC 036 - PAS Core Snapshot Contract for PA and DPM.md
+++ b/docs/RFCs/RFC 036 - PAS Core Snapshot Contract for PA and DPM.md
@@ -32,5 +32,7 @@ Introduces a versioned PAS integration contract endpoint that provides a canonic
 
 ## Next Steps
 
-1. Add `v2` with explicit provenance metadata (`source_system`, `correlation_id`, `generated_at`).
-2. Add BFF-level adapters to map PAS contract into UI-specific view models.
+1. Completed via `RFC 043 - PAS Core Snapshot Contract Hardening (Freshness, Lineage, Section Governance)`:
+   - explicit provenance/freshness metadata,
+   - policy-driven section governance controls.
+2. Continue BFF-level adapters to map PAS contract into UI-specific view models.

--- a/docs/RFCs/RFC 043 - PAS Core Snapshot Contract Hardening (Freshness, Lineage, Section Governance).md
+++ b/docs/RFCs/RFC 043 - PAS Core Snapshot Contract Hardening (Freshness, Lineage, Section Governance).md
@@ -1,0 +1,63 @@
+# RFC 043 - PAS Core Snapshot Contract Hardening (Freshness, Lineage, Section Governance)
+
+- Status: IMPLEMENTED
+- Date: 2026-02-24
+- Owners: PAS Query Service
+
+## Context
+
+`POST /integration/portfolios/{portfolio_id}/core-snapshot` is the canonical PAS boundary for
+PA, DPM, and BFF composition. The current response shape is stable but lacks explicit:
+
+1. freshness/provenance metadata,
+2. section governance metadata,
+3. tenant/consumer policy controls for allowed sections.
+
+## Decision
+
+Harden the existing contract while preserving endpoint semantics:
+
+1. Add `metadata` in response with:
+   - `generatedAt`
+   - `sourceAsOfDate`
+   - `freshnessStatus`
+   - `lineageRefs`
+   - `sectionGovernance`
+2. Add backend policy controls via `PAS_INTEGRATION_SNAPSHOT_POLICY_JSON`:
+   - consumer-specific allowed section lists
+   - tenant override allowed section lists
+   - strict mode for disallowed section requests (`403`)
+3. Keep policy enforcement in PAS backend; consumers do not implement section entitlement logic.
+
+## Rationale
+
+1. Strengthens integration readiness for BFF/PA/DPM and support workflows.
+2. Improves productized behavior through backend-driven policy control.
+3. Preserves PAS service boundary as canonical snapshot owner.
+
+## Consequences
+
+Positive:
+
+1. Consumers get explicit freshness/provenance semantics.
+2. Section control behavior is deterministic and testable.
+3. Contract drift risk is reduced by invariants in PAS test suites.
+
+Trade-offs:
+
+1. Slightly larger payload and additional policy configuration complexity.
+
+## Tests
+
+Added/updated:
+
+1. `tests/unit/services/query_service/services/test_integration_service.py`
+2. `tests/integration/services/query_service/test_integration_router_dependency.py`
+
+Coverage includes:
+
+1. metadata shape and default governance behavior,
+2. policy filtering behavior,
+3. strict mode rejection on disallowed section requests,
+4. tenant override behavior.
+

--- a/src/services/query_service/app/routers/integration.py
+++ b/src/services/query_service/app/routers/integration.py
@@ -38,6 +38,8 @@ async def get_portfolio_core_snapshot(
         return await integration_service.get_portfolio_core_snapshot(portfolio_id, request)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    except PermissionError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc))
     except Exception:
         logger.exception("Failed to build PAS integration snapshot for portfolio %s", portfolio_id)
         raise HTTPException(

--- a/src/services/query_service/app/services/integration_service.py
+++ b/src/services/query_service/app/services/integration_service.py
@@ -1,9 +1,25 @@
+import json
+import logging
+import os
+from datetime import UTC, date, datetime
+from typing import Any
+
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..dtos.integration_dto import PortfolioCoreSnapshotRequest, PortfolioCoreSnapshotResponse
+from portfolio_common.logging_utils import correlation_id_var
+
+from ..dtos.integration_dto import (
+    CoreSnapshotLineageRefs,
+    PortfolioCoreSnapshotMetadata,
+    PortfolioCoreSnapshotRequest,
+    PortfolioCoreSnapshotResponse,
+    SectionGovernanceMetadata,
+)
 from ..dtos.review_dto import PortfolioReviewRequest
 from .portfolio_service import PortfolioService
 from .review_service import ReviewService
+
+logger = logging.getLogger(__name__)
 
 
 class IntegrationService:
@@ -15,18 +31,148 @@ class IntegrationService:
         self.portfolio_service = PortfolioService(db)
         self.review_service = ReviewService(db)
 
+    @staticmethod
+    def _load_policy() -> dict[str, Any]:
+        raw = os.getenv("PAS_INTEGRATION_SNAPSHOT_POLICY_JSON")
+        if not raw:
+            return {}
+        try:
+            decoded = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.warning(
+                "Invalid PAS_INTEGRATION_SNAPSHOT_POLICY_JSON; default policy will be used."
+            )
+            return {}
+        if not isinstance(decoded, dict):
+            return {}
+        return decoded
+
+    @staticmethod
+    def _coerce_bool(value: Any, default: bool) -> bool:
+        if isinstance(value, bool):
+            return value
+        return default
+
+    @staticmethod
+    def _normalize_sections(raw: Any) -> list[str] | None:
+        if not isinstance(raw, list):
+            return None
+        normalized: list[str] = []
+        for item in raw:
+            if isinstance(item, str):
+                value = item.strip().upper()
+                if value:
+                    normalized.append(value)
+        return normalized
+
+    def _resolve_governance(
+        self,
+        tenant_id: str,
+        consumer_system: str,
+        requested_sections: list[str],
+    ) -> SectionGovernanceMetadata:
+        policy = self._load_policy()
+
+        strict_mode = self._coerce_bool(policy.get("strictMode"), default=False)
+        allowed_sections = self._normalize_sections(
+            policy.get("consumers", {}).get(consumer_system)
+            if isinstance(policy.get("consumers"), dict)
+            else None
+        )
+
+        tenant_policy_raw = policy.get("tenants", {}).get(tenant_id)
+        if isinstance(tenant_policy_raw, dict):
+            strict_mode = self._coerce_bool(
+                tenant_policy_raw.get("strictMode"), default=strict_mode
+            )
+            tenant_consumers = tenant_policy_raw.get("consumers")
+            tenant_allowed = self._normalize_sections(
+                tenant_consumers.get(consumer_system)
+                if isinstance(tenant_consumers, dict)
+                else tenant_policy_raw.get("defaultSections")
+            )
+            if tenant_allowed is not None:
+                allowed_sections = tenant_allowed
+
+        if allowed_sections is None:
+            effective_sections = list(requested_sections)
+        else:
+            allowed_set = set(allowed_sections)
+            effective_sections = [
+                section for section in requested_sections if section in allowed_set
+            ]
+
+        dropped_sections = [
+            section for section in requested_sections if section not in set(effective_sections)
+        ]
+        warnings: list[str] = []
+        if dropped_sections:
+            if strict_mode:
+                dropped = ", ".join(dropped_sections)
+                raise PermissionError(
+                    f"Requested sections are not allowed by PAS snapshot policy: {dropped}"
+                )
+            warnings.append("SECTIONS_FILTERED_BY_POLICY")
+
+        return SectionGovernanceMetadata(
+            requestedSections=requested_sections,
+            effectiveSections=effective_sections,
+            droppedSections=dropped_sections,
+            warnings=warnings,
+        )
+
+    @staticmethod
+    def _resolve_freshness_status(as_of_date: date) -> str:
+        max_staleness_days = int(os.getenv("PAS_INTEGRATION_MAX_STALENESS_DAYS", "1"))
+        today = date.today()
+        if as_of_date > today:
+            return "UNKNOWN"
+        age_days = (today - as_of_date).days
+        if age_days <= max_staleness_days:
+            return "FRESH"
+        return "STALE"
+
     async def get_portfolio_core_snapshot(
         self, portfolio_id: str, request: PortfolioCoreSnapshotRequest
     ) -> PortfolioCoreSnapshotResponse:
+        consumer_system = (request.consumer_system or "UNKNOWN").upper()
+        tenant_id = os.getenv("PAS_DEFAULT_TENANT_ID", "default")
+        requested_sections = [section.value for section in request.include_sections]
+        governance = self._resolve_governance(
+            tenant_id=tenant_id,
+            consumer_system=consumer_system,
+            requested_sections=requested_sections,
+        )
+        effective_sections = governance.effective_sections
+
+        if not effective_sections:
+            raise PermissionError(
+                "No includeSections are allowed by PAS snapshot policy for the current context."
+            )
+
         portfolio = await self.portfolio_service.get_portfolio_by_id(portfolio_id)
 
         review_request = PortfolioReviewRequest(
-            as_of_date=request.as_of_date, sections=request.include_sections
+            as_of_date=request.as_of_date,
+            sections=effective_sections,
         )
         snapshot = await self.review_service.get_portfolio_review(portfolio_id, review_request)
 
+        metadata = PortfolioCoreSnapshotMetadata(
+            generatedAt=datetime.now(UTC),
+            sourceAsOfDate=request.as_of_date,
+            freshnessStatus=self._resolve_freshness_status(request.as_of_date),
+            lineageRefs=CoreSnapshotLineageRefs(
+                portfolioId=portfolio_id,
+                asOfDate=request.as_of_date,
+                correlationId=correlation_id_var.get(),
+            ),
+            sectionGovernance=governance,
+        )
+
         return PortfolioCoreSnapshotResponse(
-            consumer_system=request.consumer_system,
+            consumerSystem=consumer_system,
             portfolio=portfolio,
             snapshot=snapshot,
+            metadata=metadata,
         )

--- a/tests/unit/services/query_service/services/test_integration_service.py
+++ b/tests/unit/services/query_service/services/test_integration_service.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import UTC, date, datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -41,7 +41,12 @@ async def test_get_portfolio_core_snapshot(
     service: IntegrationService,
     mock_portfolio_service: AsyncMock,
     mock_review_service: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
 ):
+    monkeypatch.delenv("PAS_INTEGRATION_SNAPSHOT_POLICY_JSON", raising=False)
+    monkeypatch.delenv("PAS_DEFAULT_TENANT_ID", raising=False)
+    monkeypatch.setenv("PAS_INTEGRATION_MAX_STALENESS_DAYS", "10")
+
     mock_portfolio_service.get_portfolio_by_id.return_value = {
         "portfolio_id": "P1",
         "base_currency": "USD",
@@ -83,3 +88,86 @@ async def test_get_portfolio_core_snapshot(
     assert response.contract_version == "v1"
     assert response.portfolio.portfolio_id == "P1"
     assert response.snapshot.portfolio_id == "P1"
+    assert response.metadata.source_as_of_date == date(2026, 2, 23)
+    assert response.metadata.freshness_status in {"FRESH", "STALE", "UNKNOWN"}
+    assert response.metadata.lineage_refs.portfolio_id == "P1"
+    assert response.metadata.section_governance.requested_sections == ["OVERVIEW", "HOLDINGS"]
+    assert response.metadata.section_governance.effective_sections == ["OVERVIEW", "HOLDINGS"]
+    assert response.metadata.section_governance.dropped_sections == []
+    assert isinstance(response.metadata.generated_at, datetime)
+    assert response.metadata.generated_at.tzinfo == UTC
+
+    mock_review_service.get_portfolio_review.assert_awaited_once()
+    review_request = mock_review_service.get_portfolio_review.await_args.args[1]
+    assert review_request.sections == ["OVERVIEW", "HOLDINGS"]
+
+
+async def test_get_portfolio_core_snapshot_applies_policy_filter(
+    service: IntegrationService,
+    mock_portfolio_service: AsyncMock,
+    mock_review_service: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    mock_portfolio_service.get_portfolio_by_id.return_value = {
+        "portfolio_id": "P1",
+        "base_currency": "USD",
+        "open_date": date(2025, 1, 1),
+        "close_date": None,
+        "risk_exposure": "MODERATE",
+        "investment_time_horizon": "LONG_TERM",
+        "portfolio_type": "DISCRETIONARY",
+        "objective": "GROWTH",
+        "booking_center": "LON-01",
+        "cif_id": "CIF-1",
+        "is_leverage_allowed": False,
+        "advisor_id": "ADV-1",
+        "status": "ACTIVE",
+    }
+    mock_review_service.get_portfolio_review.return_value = {
+        "portfolio_id": "P1",
+        "as_of_date": date(2026, 2, 23),
+        "overview": None,
+        "allocation": None,
+        "performance": None,
+        "riskAnalytics": None,
+        "incomeAndActivity": None,
+        "holdings": None,
+        "transactions": None,
+    }
+    monkeypatch.setenv(
+        "PAS_INTEGRATION_SNAPSHOT_POLICY_JSON",
+        '{"consumers":{"PA":["OVERVIEW"]},"strictMode":false}',
+    )
+
+    request = PortfolioCoreSnapshotRequest.model_validate(
+        {
+            "asOfDate": "2026-02-23",
+            "consumerSystem": "PA",
+            "includeSections": ["OVERVIEW", "HOLDINGS"],
+        }
+    )
+
+    response = await service.get_portfolio_core_snapshot("P1", request)
+    assert response.metadata.section_governance.effective_sections == ["OVERVIEW"]
+    assert response.metadata.section_governance.dropped_sections == ["HOLDINGS"]
+    assert response.metadata.section_governance.warnings == ["SECTIONS_FILTERED_BY_POLICY"]
+
+
+async def test_get_portfolio_core_snapshot_rejects_disallowed_sections_in_strict_mode(
+    service: IntegrationService,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv(
+        "PAS_INTEGRATION_SNAPSHOT_POLICY_JSON",
+        '{"consumers":{"PA":["OVERVIEW"]},"strictMode":true}',
+    )
+    request = PortfolioCoreSnapshotRequest.model_validate(
+        {
+            "asOfDate": "2026-02-23",
+            "consumerSystem": "PA",
+            "includeSections": ["OVERVIEW", "HOLDINGS"],
+        }
+    )
+
+    with pytest.raises(PermissionError):
+        await service.get_portfolio_core_snapshot("P1", request)


### PR DESCRIPTION
## Summary
- add PAS RFC-043 for core snapshot contract hardening
- add response metadata for provenance/freshness/lineage/section-governance
- add policy-driven section governance via PAS_INTEGRATION_SNAPSHOT_POLICY_JSON
- map policy violations to 403 at integration router
- update tests and README docs
- update RFC-036 next-steps with implemented status

## Cross-cutting alignment
- merged pbwm-platform-docs PR with RFC-0043: https://github.com/sgajbi/pbwm-platform-docs/pull/5

## Validation
- python -m ruff format ... and python -m ruff check ... on changed files
- python -m py_compile ... on changed files
- attempted targeted pytest runs, blocked in this local environment by missing runtime dependencies (pandas, psycopg2) during module import chain
