### PR TITLE
chore(api): deprecate PAS advanced analytics endpoints

### DIFF
--- a/src/services/query_service/app/routers/concentration.py
+++ b/src/services/query_service/app/routers/concentration.py
@@ -13,7 +13,12 @@ router = APIRouter(prefix="/portfolios", tags=["Concentration Analytics"])
 @router.post(
     "/{portfolio_id}/concentration",
     response_model=ConcentrationResponse,
-    summary="Calculate On-the-Fly Portfolio Concentration Analytics",
+    summary="[Deprecated] Calculate On-the-Fly Portfolio Concentration Analytics",
+    description=(
+        "Deprecated: concentration analytics ownership has moved to PA. "
+        "Use PA analytics contracts for concentration metrics."
+    ),
+    deprecated=True,
 )
 async def calculate_concentration(
     portfolio_id: str,

--- a/src/services/query_service/app/routers/performance.py
+++ b/src/services/query_service/app/routers/performance.py
@@ -18,8 +18,12 @@ router = APIRouter(prefix="/portfolios", tags=["Performance"])
     "/{portfolio_id}/performance",
     response_model=PerformanceResponse,
     response_model_exclude_none=True,
-    summary="Calculate On-the-Fly Portfolio Performance (TWR)",
-    description="Calculates time-weighted return (TWR) for a portfolio over one or more specified periods, with support for various period types, breakdowns, and currency conversion.",
+    summary="[Deprecated] Calculate On-the-Fly Portfolio Performance (TWR)",
+    description=(
+        "Deprecated: advanced performance analytics ownership has moved to PA. "
+        "Use PA APIs for authoritative performance calculations."
+    ),
+    deprecated=True,
 )
 async def calculate_performance(
     portfolio_id: str, request: PerformanceRequest, db: AsyncSession = Depends(get_async_db_session)
@@ -50,10 +54,12 @@ async def calculate_performance(
 @router.post(
     "/{portfolio_id}/performance/mwr",
     response_model=MWRResponse,
-    # --- THIS IS THE FIX ---
-    # response_model_exclude_none=True, # REMOVED
-    # --- END FIX ---
-    summary="Calculate Money-Weighted Return (MWR / IRR) for a Portfolio",
+    summary="[Deprecated] Calculate Money-Weighted Return (MWR / IRR) for a Portfolio",
+    description=(
+        "Deprecated: advanced performance analytics ownership has moved to PA. "
+        "Use PA APIs for authoritative MWR calculations."
+    ),
+    deprecated=True,
 )
 async def calculate_mwr(
     portfolio_id: str, request: MWRRequest, db: AsyncSession = Depends(get_async_db_session)

--- a/src/services/query_service/app/routers/risk.py
+++ b/src/services/query_service/app/routers/risk.py
@@ -21,8 +21,12 @@ def get_risk_service(db: AsyncSession = Depends(get_async_db_session)) -> RiskSe
     "/{portfolio_id}/risk",
     response_model=RiskResponse,
     response_model_exclude_none=True,
-    summary="Calculate On-the-Fly Portfolio Risk Analytics",
-    description="Calculates a set of portfolio risk metrics (e.g., Volatility, Sharpe, VaR) for one or more specified periods.",
+    summary="[Deprecated] Calculate On-the-Fly Portfolio Risk Analytics",
+    description=(
+        "Deprecated: advanced risk analytics ownership has moved to PA. "
+        "Use PA APIs for authoritative risk calculations."
+    ),
+    deprecated=True,
 )
 async def calculate_risk(
     portfolio_id: str, request: RiskRequest, risk_service: RiskService = Depends(get_risk_service)


### PR DESCRIPTION
## Summary
- mark PAS performance, risk, and concentration query endpoints as deprecated
- align PAS boundary with PA authoritative advanced analytics ownership
- preserve backward compatibility during transition (no runtime endpoint removal yet)

## Validation
- python -m pytest tests/integration/services/query_service/test_performance_router.py -q
- python -m pytest tests/integration/services/query_service/test_risk_router_dependency.py -q
- python -m pytest tests/integration/services/query_service/test_concentration_router.py -q