### PR TITLE
chore(pas): deprecate summary and review endpoints in favor of RAS

### DIFF
--- a/src/services/query_service/app/routers/review.py
+++ b/src/services/query_service/app/routers/review.py
@@ -21,8 +21,8 @@ def get_review_service(db: AsyncSession = Depends(get_async_db_session)) -> Revi
     "/{portfolio_id}/review",
     response_model=PortfolioReviewResponse,
     response_model_by_alias=True,
-    # REMOVED: response_model_exclude_none=True
-    summary="Generate a Comprehensive Portfolio Review Report",
+    deprecated=True,
+    summary="Generate a Comprehensive Portfolio Review Report (Deprecated: moved to RAS)",
 )
 async def get_portfolio_review(
     portfolio_id: str,
@@ -30,6 +30,10 @@ async def get_portfolio_review(
     review_service: ReviewService = Depends(get_review_service),
 ):
     """
+    Deprecated: reporting endpoint ownership has moved to RAS.
+    Use `reporting-aggregation-service` endpoint:
+    `POST /reports/portfolios/{portfolio_id}/review`.
+
     Orchestrates and retrieves a consolidated, multi-section report for a portfolio,
     ensuring all data is calculated from a consistent, atomic snapshot of the
     portfolio's active data version.

--- a/src/services/query_service/app/routers/summary.py
+++ b/src/services/query_service/app/routers/summary.py
@@ -21,7 +21,8 @@ def get_summary_service(db: AsyncSession = Depends(get_async_db_session)) -> Sum
     "/{portfolio_id}/summary",
     response_model=SummaryResponse,
     response_model_exclude_none=True,
-    summary="Get a Consolidated Portfolio Summary",
+    deprecated=True,
+    summary="Get a Consolidated Portfolio Summary (Deprecated: moved to RAS)",
 )
 async def get_portfolio_summary(
     portfolio_id: str,
@@ -30,6 +31,10 @@ async def get_portfolio_summary(
 ):
     """
     Retrieves a consolidated, dashboard-style summary for a portfolio.
+
+    Deprecated: reporting endpoint ownership has moved to RAS.
+    Use `reporting-aggregation-service` endpoint:
+    `POST /reports/portfolios/{portfolio_id}/summary`.
 
     This endpoint can calculate various sections in a single call:
     - **Wealth**: Total market value and cash balance.


### PR DESCRIPTION
## Summary\n- mark PAS summary endpoint as deprecated\n- mark PAS review endpoint as deprecated\n- add explicit migration message to RAS reporting endpoints in route docs\n\n## Context\n- aligns service boundary: PAS core data, RAS reporting ownership