### PR TITLE
PAS: enforce 99% query-service coverage gate

### DIFF
--- a/docs/RFCs/RFC 053 - Enforce 99 Percent Query Service Coverage Gate.md
+++ b/docs/RFCs/RFC 053 - Enforce 99 Percent Query Service Coverage Gate.md
@@ -1,0 +1,22 @@
+# RFC 053 - Enforce 99 Percent Query Service Coverage Gate
+
+## Problem Statement
+PAS query-service coverage is measured at 99%, but the enforced gate still allows 95%, which permits regression below platform quality expectations.
+
+## Root Cause
+`scripts/coverage_gate.py` was not updated after coverage hardening wave 2.
+
+## Proposed Solution
+Raise `FAIL_UNDER` in `scripts/coverage_gate.py` from `95` to `99`.
+
+## Architectural Impact
+No runtime or API impact. CI quality gate behavior is tightened.
+
+## Risks and Trade-offs
+- PRs with insufficient tests will fail faster.
+- Minor increase in short-term remediation work for low-coverage changes.
+
+## High-Level Implementation Approach
+1. Update the fail-under threshold to 99.
+2. Run `python scripts/coverage_gate.py`.
+3. Merge and monitor CI.

--- a/scripts/coverage_gate.py
+++ b/scripts/coverage_gate.py
@@ -26,7 +26,7 @@ INTEGRATION_LITE_ARGS = [
 ]
 
 SOURCE = "src/services/query_service/app"
-FAIL_UNDER = "95"
+FAIL_UNDER = "99"
 
 
 def run_pytest(args: list[str], coverage_file: str) -> None:


### PR DESCRIPTION
## Summary\n- add RFC 053 to formalize enforcement of 99% gate\n- raise scripts/coverage_gate.py fail-under threshold from 95 to 99\n\n## Validation\n- python scripts/coverage_gate.py\n  - gate passes with TOTAL 99%\n\n## Impact\n- no runtime behavior change\n- CI policy now blocks coverage regressions below 99%