### PR TITLE
chore: align PAS CI/pre-commit with backend foundation standard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,14 @@ jobs:
       - name: Security Audit
         run: make security-audit
 
-      - name: Lint + Typecheck + Unit Tests
-        run: make check
+      - name: Lint
+        run: make lint
+
+      - name: Typecheck
+        run: make typecheck
+
+      - name: Unit Tests
+        run: make test-unit
 
   test-suites:
     name: Tests (${{ matrix.suite }})

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+        args: ["--maxkb=500"]
+      - id: check-merge-conflict
+      - id: debug-statements
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.1
+    hooks:
+      - id: ruff
+        args: ["--ignore", "E501,E701,I001", "src/services/query_service/app", "tests/unit/services/query_service"]
+      - id: ruff-format
+        args: ["src/services/query_service/app", "tests/unit/services/query_service"]
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.19.1
+    hooks:
+      - id: mypy
+        args: ["--config-file", "mypy.ini"]
+        pass_filenames: false


### PR DESCRIPTION
## Summary
- add .pre-commit-config.yaml with ruff + mypy baseline hooks
- make PAS CI quality job explicit for lint/typecheck/unit steps
- keep existing coverage and security gates unchanged

## Why
Enforces RFC-0059/0060 backend foundation conformance and improves gate visibility in CI.