### PR TITLE
chore: enforce OpenAPI gate in PAS quality pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Typecheck
         run: make typecheck
 
+      - name: OpenAPI Gate
+        run: make openapi-gate
+
       - name: Unit Tests
         run: make test-unit
 


### PR DESCRIPTION
Summary: add explicit make openapi-gate step in PAS quality CI job to align with RFC-0061 baseline. Validation: python scripts/openapi_quality_gate.py.