### PR TITLE
Fix PAS audit dependency pin for Python 3.13 compatibility

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -12,10 +12,9 @@ pytest-asyncio
 # HTTP client for testing APIs
 requests==2.32.4
 httpx
-openpyxl
 
 # Database drivers (sync and async)
-psycopg2-binary==2.9.9
+psycopg2-binary==2.9.10
 asyncpg==0.29.0
 
 # Environment variable management


### PR DESCRIPTION
Bump psycopg2-binary and remove duplicate requirement entry so pip-audit is reliable locally and in CI.