### PR TITLE
chore: ignore local output artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ docker-compose.override.yml
 
 # Jupyter Notebook
 .ipynb_checkpoints
+
+# Local QA evidence artifacts
+output/qa-*/
+output/


### PR DESCRIPTION
Add output/ to gitignore to prevent local automation artifact noise.