### PR TITLE
Hide migrated query endpoints from Swagger and repoint risk/concentration

### DIFF
--- a/src/services/query_service/app/routers/concentration.py
+++ b/src/services/query_service/app/routers/concentration.py
@@ -9,18 +9,19 @@ router = APIRouter(prefix="/portfolios", tags=["Concentration Analytics"])
 
 @router.post(
     "/{portfolio_id}/concentration",
+    include_in_schema=False,
     status_code=status.HTTP_410_GONE,
     responses={
         status.HTTP_410_GONE: legacy_gone_response(
             capability="concentration_analytics",
-            target_service="lotus-performance",
-            target_endpoint="/portfolios/{portfolio_id}/concentration",
+            target_service="lotus-risk",
+            target_endpoint="/analytics/risk/concentration",
         )
     },
     summary="[Deprecated] Calculate On-the-Fly Portfolio Concentration Analytics",
     description=(
-        "Deprecated: concentration analytics ownership has moved to lotus-performance. "
-        "Use lotus-performance analytics contracts for concentration metrics."
+        "Deprecated: concentration analytics ownership has moved to lotus-risk. "
+        "Use lotus-risk analytics contracts for concentration metrics."
     ),
     deprecated=True,
 )
@@ -31,6 +32,6 @@ async def calculate_concentration(
     _ = (portfolio_id, request)
     raise_legacy_endpoint_gone(
         capability="concentration_analytics",
-        target_service="lotus-performance",
-        target_endpoint="/portfolios/{portfolio_id}/concentration",
+        target_service="lotus-risk",
+        target_endpoint="/analytics/risk/concentration",
     )

--- a/src/services/query_service/app/routers/performance.py
+++ b/src/services/query_service/app/routers/performance.py
@@ -10,6 +10,7 @@ router = APIRouter(prefix="/portfolios", tags=["Performance"])
 
 @router.post(
     "/{portfolio_id}/performance",
+    include_in_schema=False,
     status_code=status.HTTP_410_GONE,
     responses={
         status.HTTP_410_GONE: legacy_gone_response(
@@ -36,6 +37,7 @@ async def calculate_performance(portfolio_id: str, request: PerformanceRequest):
 
 @router.post(
     "/{portfolio_id}/performance/mwr",
+    include_in_schema=False,
     status_code=status.HTTP_410_GONE,
     responses={
         status.HTTP_410_GONE: legacy_gone_response(

--- a/src/services/query_service/app/routers/review.py
+++ b/src/services/query_service/app/routers/review.py
@@ -9,6 +9,7 @@ router = APIRouter(prefix="/portfolios", tags=["Portfolio Review"])
 
 @router.post(
     "/{portfolio_id}/review",
+    include_in_schema=False,
     status_code=status.HTTP_410_GONE,
     responses={
         status.HTTP_410_GONE: legacy_gone_response(

--- a/src/services/query_service/app/routers/risk.py
+++ b/src/services/query_service/app/routers/risk.py
@@ -9,18 +9,19 @@ router = APIRouter(prefix="/portfolios", tags=["Risk Analytics"])
 
 @router.post(
     "/{portfolio_id}/risk",
+    include_in_schema=False,
     status_code=status.HTTP_410_GONE,
     responses={
         status.HTTP_410_GONE: legacy_gone_response(
             capability="risk_analytics",
-            target_service="lotus-performance",
-            target_endpoint="/portfolios/{portfolio_id}/risk",
+            target_service="lotus-risk",
+            target_endpoint="/analytics/risk/calculate",
         )
     },
     summary="[Deprecated] Calculate On-the-Fly Portfolio Risk Analytics",
     description=(
-        "Deprecated: advanced risk analytics ownership has moved to lotus-performance. "
-        "Use lotus-performance APIs for authoritative risk calculations."
+        "Deprecated: advanced risk analytics ownership has moved to lotus-risk. "
+        "Use lotus-risk APIs for authoritative risk calculations."
     ),
     deprecated=True,
 )
@@ -28,6 +29,6 @@ async def calculate_risk(portfolio_id: str, request: RiskRequest):
     _ = (portfolio_id, request)
     raise_legacy_endpoint_gone(
         capability="risk_analytics",
-        target_service="lotus-performance",
-        target_endpoint="/portfolios/{portfolio_id}/risk",
+        target_service="lotus-risk",
+        target_endpoint="/analytics/risk/calculate",
     )

--- a/src/services/query_service/app/routers/summary.py
+++ b/src/services/query_service/app/routers/summary.py
@@ -9,6 +9,7 @@ router = APIRouter(prefix="/portfolios", tags=["Portfolio Summary"])
 
 @router.post(
     "/{portfolio_id}/summary",
+    include_in_schema=False,
     status_code=status.HTTP_410_GONE,
     responses={
         status.HTTP_410_GONE: legacy_gone_response(

--- a/tests/e2e/test_concentration_pipeline.py
+++ b/tests/e2e/test_concentration_pipeline.py
@@ -52,7 +52,7 @@ def setup_concentration_data(clean_db_module, e2e_api_client: E2EApiClient, poll
 
 def test_bulk_concentration_e2e(setup_concentration_data, e2e_api_client: E2EApiClient):
     """
-    Verifies lotus-core concentration endpoint is hard-disabled and directs callers to lotus-performance.
+    Verifies lotus-core concentration endpoint is hard-disabled and directs callers to lotus-risk.
     """
     portfolio_id = setup_concentration_data["portfolio_id"]
     api_url = f"/portfolios/{portfolio_id}/concentration"
@@ -69,12 +69,12 @@ def test_bulk_concentration_e2e(setup_concentration_data, e2e_api_client: E2EApi
     # ASSERT
     assert response.status_code == 410
     assert data["code"] == "PAS_LEGACY_ENDPOINT_REMOVED"
-    assert data["target_service"] == "lotus-performance"
-    assert data["target_endpoint"] == "/portfolios/{portfolio_id}/concentration"
+    assert data["target_service"] == "lotus-risk"
+    assert data["target_endpoint"] == "/analytics/risk/concentration"
 
 def test_issuer_concentration_e2e(setup_concentration_data, e2e_api_client: E2EApiClient):
     """
-    Verifies lotus-core concentration endpoint is hard-disabled and directs callers to lotus-performance.
+    Verifies lotus-core concentration endpoint is hard-disabled and directs callers to lotus-risk.
     """
     portfolio_id = setup_concentration_data["portfolio_id"]
     api_url = f"/portfolios/{portfolio_id}/concentration"
@@ -91,5 +91,7 @@ def test_issuer_concentration_e2e(setup_concentration_data, e2e_api_client: E2EA
     # ASSERT
     assert response.status_code == 410
     assert data["code"] == "PAS_LEGACY_ENDPOINT_REMOVED"
-    assert data["target_service"] == "lotus-performance"
-    assert data["target_endpoint"] == "/portfolios/{portfolio_id}/concentration"
+    assert data["target_service"] == "lotus-risk"
+    assert data["target_endpoint"] == "/analytics/risk/concentration"
+
+

--- a/tests/integration/services/query_service/test_concentration_router.py
+++ b/tests/integration/services/query_service/test_concentration_router.py
@@ -43,8 +43,8 @@ async def test_calculate_concentration_success(async_test_client):
     assert response.status_code == 410
     detail = response.json()["detail"]
     assert detail["code"] == "PAS_LEGACY_ENDPOINT_REMOVED"
-    assert detail["target_service"] == "lotus-performance"
-    assert detail["target_endpoint"] == "/portfolios/{portfolio_id}/concentration"
+    assert detail["target_service"] == "lotus-risk"
+    assert detail["target_endpoint"] == "/analytics/risk/concentration"
 
     mock_service.calculate_concentration.assert_not_awaited()
 
@@ -62,7 +62,7 @@ async def test_calculate_concentration_portfolio_not_found(async_test_client):
     response = await client.post(f"/portfolios/{portfolio_id}/concentration", json=request_payload)
 
     assert response.status_code == 410
-    assert response.json()["detail"]["target_service"] == "lotus-performance"
+    assert response.json()["detail"]["target_service"] == "lotus-risk"
     mock_service.calculate_concentration.assert_not_awaited()
 
 
@@ -73,5 +73,7 @@ async def test_calculate_concentration_unexpected_error(async_test_client):
     response = await client.post("/portfolios/P1/concentration", json=request_payload)
 
     assert response.status_code == 410
-    assert response.json()["detail"]["target_service"] == "lotus-performance"
+    assert response.json()["detail"]["target_service"] == "lotus-risk"
     mock_service.calculate_concentration.assert_not_awaited()
+
+

--- a/tests/integration/services/query_service/test_main_app.py
+++ b/tests/integration/services/query_service/test_main_app.py
@@ -126,3 +126,16 @@ async def test_openapi_declares_portfolio_not_found_contracts(async_test_client)
         in paths["/integration/portfolios/{portfolio_id}/performance-input"]["post"]["responses"]
     )
     assert "404" in paths["/portfolios/{portfolio_id}/positions-analytics"]["post"]["responses"]
+
+
+async def test_openapi_hides_migrated_legacy_endpoints(async_test_client):
+    response = await async_test_client.get("/openapi.json")
+    assert response.status_code == 200
+    paths = response.json()["paths"]
+
+    assert "/portfolios/{portfolio_id}/summary" not in paths
+    assert "/portfolios/{portfolio_id}/review" not in paths
+    assert "/portfolios/{portfolio_id}/risk" not in paths
+    assert "/portfolios/{portfolio_id}/concentration" not in paths
+    assert "/portfolios/{portfolio_id}/performance" not in paths
+    assert "/portfolios/{portfolio_id}/performance/mwr" not in paths

--- a/tests/integration/services/query_service/test_review_router.py
+++ b/tests/integration/services/query_service/test_review_router.py
@@ -62,10 +62,10 @@ async def test_get_portfolio_review_unexpected_maps_to_500(async_test_client):
     assert "X-Correlation-ID" in response.headers
 
 
-async def test_review_openapi_declares_410_contract(async_test_client):
+async def test_review_openapi_hides_legacy_route(async_test_client):
     client = async_test_client
     response = await client.get("/openapi.json")
 
     assert response.status_code == 200
-    review_responses = response.json()["paths"]["/portfolios/{portfolio_id}/review"]["post"]["responses"]
-    assert "410" in review_responses
+    assert "/portfolios/{portfolio_id}/review" not in response.json()["paths"]
+

--- a/tests/integration/services/query_service/test_risk_router_dependency.py
+++ b/tests/integration/services/query_service/test_risk_router_dependency.py
@@ -31,8 +31,8 @@ async def test_risk_success(async_test_client):
     assert response.status_code == 410
     detail = response.json()["detail"]
     assert detail["code"] == "PAS_LEGACY_ENDPOINT_REMOVED"
-    assert detail["target_service"] == "lotus-performance"
-    assert detail["target_endpoint"] == "/portfolios/{portfolio_id}/risk"
+    assert detail["target_service"] == "lotus-risk"
+    assert detail["target_endpoint"] == "/analytics/risk/calculate"
     assert "X-Correlation-ID" in response.headers
 
 
@@ -42,7 +42,7 @@ async def test_risk_not_found_maps_to_404(async_test_client):
     response = await client.post("/portfolios/P404/risk", json=risk_request_payload())
 
     assert response.status_code == 410
-    assert response.json()["detail"]["target_service"] == "lotus-performance"
+    assert response.json()["detail"]["target_service"] == "lotus-risk"
 
 
 async def test_risk_unexpected_maps_to_500(async_test_client):
@@ -51,4 +51,5 @@ async def test_risk_unexpected_maps_to_500(async_test_client):
     response = await client.post("/portfolios/P500/risk", json=risk_request_payload())
 
     assert response.status_code == 410
-    assert response.json()["detail"]["target_service"] == "lotus-performance"
+    assert response.json()["detail"]["target_service"] == "lotus-risk"
+

--- a/tests/integration/services/query_service/test_risk_service.py
+++ b/tests/integration/services/query_service/test_risk_service.py
@@ -101,7 +101,7 @@ async def test_risk_endpoint_happy_path(
     """
     # ARRANGE
     portfolio_id = setup_risk_integration_data["portfolio_id"]
-    api_url = f"/portfolios/{portfolio_id}/risk"
+    api_url = f"/analytics/risk/calculate"
 
     request_payload = {
         "scope": {"as_of_date": "2025-03-31"},
@@ -117,5 +117,6 @@ async def test_risk_endpoint_happy_path(
     # ASSERT
     assert response.status_code == 410
     assert data["code"] == "PAS_LEGACY_ENDPOINT_REMOVED"
-    assert data["target_service"] == "lotus-performance"
-    assert data["target_endpoint"] == "/portfolios/{portfolio_id}/risk"
+    assert data["target_service"] == "lotus-risk"
+    assert data["target_endpoint"] == "/analytics/risk/calculate"
+


### PR DESCRIPTION
## Summary
- hide migrated legacy query endpoints from OpenAPI/Swagger while keeping runtime 410 behavior
- repoint legacy migration metadata for risk and concentration from lotus-performance to lotus-risk
- update query-service integration/e2e tests for new migration targets
- add OpenAPI contract assertion that migrated legacy routes are not exposed

## Validation
- python -m pytest tests/integration/services/query_service/test_review_router.py tests/integration/services/query_service/test_risk_router_dependency.py tests/integration/services/query_service/test_concentration_router.py tests/integration/services/query_service/test_main_app.py -q
- python -m pytest tests/integration/services/query_service/test_main_app.py::test_openapi_hides_migrated_legacy_endpoints -q