### PR TITLE
Refactor query performance endpoint to core-local summary mode

### DIFF
--- a/src/services/query_service/app/services/performance_service.py
+++ b/src/services/query_service/app/services/performance_service.py
@@ -1,10 +1,9 @@
-import logging
-import os
+from __future__ import annotations
+
 from datetime import date
 from decimal import Decimal
 from typing import Any
 
-import httpx
 from performance_calculator_engine.helpers import resolve_period
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -18,65 +17,18 @@ from ..dtos.performance_dto import (
 from ..repositories.performance_repository import PerformanceRepository
 from ..repositories.portfolio_repository import PortfolioRepository
 
-logger = logging.getLogger(__name__)
-
 
 class PerformanceService:
-    """Adapter that sources performance analytics from lotus-performance service."""
+    """Core-local performance summary service.
+
+    This service intentionally avoids outbound calls to lotus-performance.
+    lotus-core remains core-data only; advanced analytics are served by lotus-performance.
+    """
 
     def __init__(self, db: AsyncSession):
         self.db = db
         self.repo = PerformanceRepository(db)
         self.portfolio_repo = PortfolioRepository(db)
-        self.base_url = os.getenv("LOTUS_PERFORMANCE_BASE_URL", "http://localhost:8000").rstrip("/")
-        self.timeout_seconds = int(os.getenv("LOTUS_PERFORMANCE_TIMEOUT_SECONDS", "15"))
-
-    @staticmethod
-    def _period_to_pa_type(period_type: str) -> str:
-        mapping = {
-            "MTD": "MTD",
-            "QTD": "QTD",
-            "YTD": "YTD",
-            "THREE_YEAR": "3Y",
-            "FIVE_YEAR": "5Y",
-            "SI": "ITD",
-            "EXPLICIT": "EXPLICIT",
-            "YEAR": "EXPLICIT",
-        }
-        if period_type not in mapping:
-            raise ValueError(
-                f"Unsupported period type for lotus-performance mapping: {period_type}"
-            )
-        return mapping[period_type]
-
-    @staticmethod
-    def _breakdown_to_pa_frequencies(breakdown: str | None) -> list[str]:
-        if not breakdown:
-            return ["monthly"]
-        mapping = {
-            "DAILY": "daily",
-            "WEEKLY": "weekly",
-            "MONTHLY": "monthly",
-            "QUARTERLY": "quarterly",
-        }
-        return [mapping.get(breakdown, "monthly")]
-
-    @staticmethod
-    def _convert_timeseries_to_valuation_points(timeseries_data: list[Any]) -> list[dict[str, Any]]:
-        points: list[dict[str, Any]] = []
-        for index, row in enumerate(timeseries_data, start=1):
-            points.append(
-                {
-                    "day": index,
-                    "perf_date": row.date.isoformat(),
-                    "begin_mv": float(row.bod_market_value or 0),
-                    "bod_cf": float(row.bod_cashflow or 0),
-                    "eod_cf": float(row.eod_cashflow or 0),
-                    "mgmt_fees": float(row.fees or 0),
-                    "end_mv": float(row.eod_market_value or 0),
-                }
-            )
-        return points
 
     @staticmethod
     def _aggregate_attributes_from_timeseries(timeseries_slice: list[Any]) -> PerformanceAttributes:
@@ -94,68 +46,6 @@ class PerformanceService:
             fees=sum((r.fees or Decimal(0)) for r in timeseries_slice),
         )
 
-    @staticmethod
-    def _extract_annualized(period_payload: dict[str, Any]) -> float | None:
-        breakdowns = period_payload.get("breakdowns") or {}
-        for _, items in breakdowns.items():
-            if items:
-                summary = items[-1].get("summary") or {}
-                annualized = summary.get("annualized_return_pct")
-                if annualized is not None:
-                    return float(annualized)
-        return None
-
-    @staticmethod
-    def _extract_breakdown_results(
-        period_payload: dict[str, Any],
-        breakdown: str,
-        default_start: date,
-        default_end: date,
-    ) -> list[PerformanceResult]:
-        key_map = {
-            "DAILY": "daily",
-            "WEEKLY": "weekly",
-            "MONTHLY": "monthly",
-            "QUARTERLY": "quarterly",
-        }
-        freq_key = key_map.get(breakdown)
-        if not freq_key:
-            return []
-
-        items = (period_payload.get("breakdowns") or {}).get(freq_key) or []
-        results: list[PerformanceResult] = []
-        for item in items:
-            summary = item.get("summary") or {}
-            raw_period = item.get("period")
-            item_date = default_end
-            if isinstance(raw_period, str):
-                try:
-                    item_date = date.fromisoformat(raw_period[:10])
-                except ValueError:
-                    item_date = default_end
-
-            payload: dict[str, Any] = {
-                "start_date": item_date,
-                "end_date": item_date,
-                "cumulative_return": summary.get("period_return_pct"),
-                "annualized_return": summary.get("annualized_return_pct"),
-            }
-            value = summary.get("period_return_pct")
-            if breakdown == "DAILY":
-                payload["dailyReturn"] = value
-            elif breakdown == "WEEKLY":
-                payload["weeklyReturn"] = value
-            elif breakdown == "MONTHLY":
-                payload["monthlyReturn"] = value
-            elif breakdown == "QUARTERLY":
-                payload["quarterlyReturn"] = value
-
-            results.append(PerformanceResult.model_validate(payload))
-
-        if not results and items:
-            results.append(PerformanceResult(start_date=default_start, end_date=default_end))
-        return results
-
     async def calculate_performance(
         self, portfolio_id: str, request: PerformanceRequest
     ) -> PerformanceResponse:
@@ -163,7 +53,7 @@ class PerformanceService:
         if not portfolio:
             raise ValueError(f"Portfolio {portfolio_id} not found.")
 
-        resolved_periods: list[tuple[str, date, date, Any]] = []
+        resolved_periods: list[tuple[str, date, date]] = []
         for period in request.periods:
             from_date = getattr(period, "from_date", None)
             to_date = getattr(period, "to_date", None)
@@ -180,7 +70,7 @@ class PerformanceService:
                 inception_date=portfolio.open_date,
                 as_of_date=request.scope.as_of_date,
             )
-            resolved_periods.append((resolved[0], resolved[1], resolved[2], period))
+            resolved_periods.append((resolved[0], resolved[1], resolved[2]))
 
         if not resolved_periods:
             return PerformanceResponse(scope=request.scope, summary={}, breakdowns=None)
@@ -193,85 +83,22 @@ class PerformanceService:
         if not timeseries_data:
             return PerformanceResponse(scope=request.scope, summary={}, breakdowns=None)
 
-        valuation_points = self._convert_timeseries_to_valuation_points(timeseries_data)
         summary: dict[str, PerformanceResult] = {}
         breakdowns: dict[str, PerformanceBreakdown] = {}
 
-        async with httpx.AsyncClient(timeout=self.timeout_seconds) as client:
-            for period_name, start_date, end_date, period in resolved_periods:
-                analyses = [
-                    {
-                        "period": self._period_to_pa_type(period.type),
-                        "frequencies": self._breakdown_to_pa_frequencies(period.breakdown),
-                    }
-                ]
-
-                payload: dict[str, Any] = {
-                    "portfolio_id": portfolio_id,
-                    "performance_start_date": portfolio.open_date.isoformat(),
-                    "metric_basis": request.scope.net_or_gross,
-                    "report_end_date": end_date.isoformat(),
-                    "analyses": analyses,
-                    "valuation_points": valuation_points,
-                    "currency": request.scope.reporting_currency or portfolio.base_currency,
-                    "output": {
-                        "include_cumulative": request.options.include_cumulative,
-                        "include_timeseries": bool(period.breakdown),
-                    },
-                }
-                if self._period_to_pa_type(period.type) == "EXPLICIT":
-                    payload["report_start_date"] = start_date.isoformat()
-
-                response = await client.post(f"{self.base_url}/performance/twr", json=payload)
-                if response.status_code >= 400:
-                    detail = response.text
-                    raise RuntimeError(
-                        "lotus-performance request failed with status "
-                        f"{response.status_code}: {detail}"
-                    )
-
-                body = response.json()
-                period_payload = next(iter((body.get("results_by_period") or {}).values()), None)
-                if period_payload is None:
-                    summary[period_name] = PerformanceResult(
-                        start_date=start_date, end_date=end_date
-                    )
-                    continue
-
-                portfolio_return = period_payload.get("portfolio_return") or {}
-                annualized = self._extract_annualized(period_payload)
-                period_timeseries = [
-                    row for row in timeseries_data if start_date <= row.date <= end_date
-                ]
-
-                summary[period_name] = PerformanceResult(
-                    start_date=start_date,
-                    end_date=end_date,
-                    cumulative_return=(
-                        float(portfolio_return.get("base"))
-                        if request.options.include_cumulative
-                        and portfolio_return.get("base") is not None
-                        else None
-                    ),
-                    annualized_return=(annualized if request.options.include_annualized else None),
-                    attributes=(
-                        self._aggregate_attributes_from_timeseries(period_timeseries)
-                        if request.options.include_attributes
-                        else None
-                    ),
-                )
-
-                if period.breakdown:
-                    breakdown_items = self._extract_breakdown_results(
-                        period_payload=period_payload,
-                        breakdown=period.breakdown,
-                        default_start=start_date,
-                        default_end=end_date,
-                    )
-                    breakdowns[period_name] = PerformanceBreakdown(
-                        breakdown_type=period.breakdown,
-                        results=breakdown_items,
-                    )
+        for period_name, start_date, end_date in resolved_periods:
+            period_slice = [row for row in timeseries_data if start_date <= row.date <= end_date]
+            summary[period_name] = PerformanceResult(
+                start_date=start_date,
+                end_date=end_date,
+                cumulative_return=None,
+                annualized_return=None,
+                attributes=(
+                    self._aggregate_attributes_from_timeseries(period_slice)
+                    if request.options.include_attributes
+                    else None
+                ),
+            )
 
         return PerformanceResponse(
             scope=request.scope, summary=summary, breakdowns=breakdowns or None

--- a/tests/unit/services/query_service/services/test_performance_service.py
+++ b/tests/unit/services/query_service/services/test_performance_service.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 from datetime import date
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -36,15 +35,7 @@ def service() -> PerformanceService:
                 bod_cashflow=0,
                 eod_cashflow=0,
                 fees=0,
-            ),
-            SimpleNamespace(
-                date=date(2025, 1, 3),
-                bod_market_value=101,
-                eod_market_value=102,
-                bod_cashflow=0,
-                eod_cashflow=0,
-                fees=0,
-            ),
+            )
         ]
         portfolio_repo_cls.return_value = portfolio_repo
         perf_repo_cls.return_value = perf_repo
@@ -81,136 +72,15 @@ async def test_calculate_performance_returns_empty_when_no_timeseries(
     service: PerformanceService,
 ) -> None:
     service.repo.get_portfolio_timeseries_for_range.return_value = []
-
     result = await service.calculate_performance("P1", _request())
-
     assert result.summary == {}
     assert result.breakdowns is None
 
 
-async def test_calculate_performance_proxies_to_lotus_performance(
+async def test_calculate_performance_returns_core_local_summary(
     service: PerformanceService,
 ) -> None:
-    response = SimpleNamespace()
-    response.status_code = 200
-    response.json = lambda: {
-        "results_by_period": {
-            "YTD": {
-                "portfolio_return": {"base": 5.5},
-                "breakdowns": {
-                    "daily": [
-                        {"period": "2025-01-02", "summary": {"period_return_pct": 1.0}},
-                        {
-                            "period": "2025-01-03",
-                            "summary": {"period_return_pct": 0.5, "annualized_return_pct": 3.0},
-                        },
-                    ]
-                },
-            }
-        }
-    }
-
-    with patch(
-        "src.services.query_service.app.services.performance_service.httpx.AsyncClient"
-    ) as client_cls:
-        client = AsyncMock()
-        client.__aenter__.return_value = client
-        client.post.return_value = response
-        client_cls.return_value = client
-
-        result = await service.calculate_performance("P1", _request())
-
+    result = await service.calculate_performance("P1", _request())
     assert "YTD" in result.summary
-    assert result.summary["YTD"].cumulative_return == 5.5
-    assert result.summary["YTD"].annualized_return == 3.0
     assert result.summary["YTD"].attributes is not None
-    assert result.breakdowns is not None
-    assert len(result.breakdowns["YTD"].results) == 2
-    client.post.assert_awaited_once()
-
-
-async def test_calculate_performance_raises_on_remote_error(service: PerformanceService) -> None:
-    response = SimpleNamespace(status_code=502, text="upstream")
-
-    with patch(
-        "src.services.query_service.app.services.performance_service.httpx.AsyncClient"
-    ) as client_cls:
-        client = AsyncMock()
-        client.__aenter__.return_value = client
-        client.post.return_value = response
-        client_cls.return_value = client
-
-        with pytest.raises(RuntimeError, match="lotus-performance request failed"):
-            await service.calculate_performance("P1", _request())
-
-
-def test_period_to_pa_type_rejects_unsupported_value() -> None:
-    with pytest.raises(ValueError, match="Unsupported period type"):
-        PerformanceService._period_to_pa_type("BAD")
-
-
-def test_breakdown_to_pa_frequencies_defaults_and_fallback() -> None:
-    assert PerformanceService._breakdown_to_pa_frequencies(None) == ["monthly"]
-    assert PerformanceService._breakdown_to_pa_frequencies("UNKNOWN") == ["monthly"]
-
-
-def test_extract_breakdown_results_returns_empty_for_unknown_breakdown() -> None:
-    results = PerformanceService._extract_breakdown_results(
-        period_payload={},
-        breakdown="BAD",
-        default_start=date(2025, 1, 1),
-        default_end=date(2025, 1, 2),
-    )
-    assert results == []
-
-
-def test_extract_breakdown_results_handles_invalid_period_date() -> None:
-    results = PerformanceService._extract_breakdown_results(
-        period_payload={
-            "breakdowns": {"daily": [{"period": "bad", "summary": {"period_return_pct": 1.2}}]}
-        },
-        breakdown="DAILY",
-        default_start=date(2025, 1, 1),
-        default_end=date(2025, 1, 2),
-    )
-    assert len(results) == 1
-    assert results[0].start_date == date(2025, 1, 2)
-
-
-async def test_calculate_performance_returns_empty_when_no_periods(
-    service: PerformanceService,
-) -> None:
-    request = PerformanceRequest.model_validate(
-        {
-            "scope": {"as_of_date": "2025-03-31", "net_or_gross": "NET"},
-            "periods": [],
-            "options": {
-                "include_cumulative": True,
-                "include_annualized": True,
-                "include_attributes": True,
-            },
-        }
-    )
-    result = await service.calculate_performance("P1", request)
-    assert result.summary == {}
-    assert result.breakdowns is None
-
-
-async def test_calculate_performance_handles_missing_remote_period_payload(
-    service: PerformanceService,
-) -> None:
-    response = SimpleNamespace()
-    response.status_code = 200
-    response.json = lambda: {"results_by_period": {}}
-
-    with patch(
-        "src.services.query_service.app.services.performance_service.httpx.AsyncClient"
-    ) as client_cls:
-        client = AsyncMock()
-        client.__aenter__.return_value = client
-        client.post.return_value = response
-        client_cls.return_value = client
-
-        result = await service.calculate_performance("P1", _request())
-
     assert result.summary["YTD"].cumulative_return is None


### PR DESCRIPTION
## Summary
- remove lotus-core query performance service outbound dependency on lotus-performance
- keep query-service behavior core-data-only with local summary placeholders
- simplify performance service unit tests to match new core-local behavior

## Validation
- python -m pytest tests/unit/services/query_service/services/test_performance_service.py -q