### PR TITLE
Harden lotus-core CI test scope with manifest-driven suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,7 @@ jobs:
       matrix:
         include:
           - suite: unit
-            args: tests/unit/services/query_service
           - suite: integration-lite
-            args: tests/integration/services/query_service/test_capabilities_router_dependency.py tests/integration/services/query_service/test_concentration_router.py tests/integration/services/query_service/test_integration_router_dependency.py tests/integration/services/query_service/test_main_app.py tests/integration/services/query_service/test_performance_router.py tests/integration/services/query_service/test_portfolios_router_dependency.py tests/integration/services/query_service/test_position_analytics_router.py tests/integration/services/query_service/test_positions_router_dependency.py tests/integration/services/query_service/test_operations_router_dependency.py tests/integration/services/query_service/test_reference_data_routers.py tests/integration/services/query_service/test_lookup_contract_router.py tests/integration/services/query_service/test_review_router.py tests/integration/services/query_service/test_risk_router_dependency.py tests/integration/services/query_service/test_simulation_router_dependency.py tests/integration/services/query_service/test_summary_router.py tests/integration/services/query_service/test_transactions_router.py
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -99,10 +97,8 @@ jobs:
           make install
 
       - name: Run ${{ matrix.suite }} tests with coverage data
-        env:
-          COVERAGE_FILE: .coverage.${{ matrix.suite }}
         run: |
-          python -m pytest ${{ matrix.args }} --cov=src/services/query_service/app --cov-report=
+          python scripts/test_manifest.py --suite ${{ matrix.suite }} --with-coverage --coverage-file .coverage.${{ matrix.suite }}
 
       - name: Upload coverage data (${{ matrix.suite }})
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,13 @@ test:
 	$(MAKE) test-unit
 
 test-unit:
-	python -m pytest tests/unit/services/query_service -q
+	python scripts/test_manifest.py --suite unit --quiet
 
 test-integration-lite:
-	python -m pytest tests/integration/services/query_service/test_capabilities_router_dependency.py tests/integration/services/query_service/test_concentration_router.py tests/integration/services/query_service/test_integration_router_dependency.py tests/integration/services/query_service/test_main_app.py tests/integration/services/query_service/test_performance_router.py tests/integration/services/query_service/test_portfolios_router_dependency.py tests/integration/services/query_service/test_position_analytics_router.py tests/integration/services/query_service/test_positions_router_dependency.py tests/integration/services/query_service/test_operations_router_dependency.py tests/integration/services/query_service/test_reference_data_routers.py tests/integration/services/query_service/test_lookup_contract_router.py tests/integration/services/query_service/test_review_router.py tests/integration/services/query_service/test_risk_router_dependency.py tests/integration/services/query_service/test_simulation_router_dependency.py tests/integration/services/query_service/test_summary_router.py tests/integration/services/query_service/test_transactions_router.py -q
+	python scripts/test_manifest.py --suite integration-lite --quiet
 
 test-e2e-smoke:
-	python -m pytest tests/e2e/test_query_service_observability.py tests/e2e/test_complex_portfolio_lifecycle.py -q
+	python scripts/test_manifest.py --suite e2e-smoke --quiet
 
 security-audit:
 	python -m pip_audit -r tests/requirements.txt

--- a/README.md
+++ b/README.md
@@ -142,6 +142,14 @@ To run the integration-lite suite used in CI coverage:
 make test-integration-lite
 ```
 
+Test suite composition is centrally managed in `scripts/test_manifest.py`.
+Use this to inspect or validate exact CI test scope:
+
+```bash
+python scripts/test_manifest.py --suite integration-lite --print-args
+python scripts/test_manifest.py --suite integration-lite --validate-only
+```
+
 To run the query-service unit suite directly:
 
 ```bash

--- a/scripts/test_manifest.py
+++ b/scripts/test_manifest.py
@@ -1,0 +1,132 @@
+"""Single source of truth for CI/local test suite composition."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SUITES: dict[str, list[str]] = {
+    "unit": ["tests/unit/services/query_service"],
+    "integration-lite": [
+        "tests/integration/services/query_service/test_capabilities_router_dependency.py",
+        "tests/integration/services/query_service/test_concentration_router.py",
+        "tests/integration/services/query_service/test_integration_router_dependency.py",
+        "tests/integration/services/query_service/test_main_app.py",
+        "tests/integration/services/query_service/test_performance_router.py",
+        "tests/integration/services/query_service/test_portfolios_router_dependency.py",
+        "tests/integration/services/query_service/test_position_analytics_router.py",
+        "tests/integration/services/query_service/test_positions_router_dependency.py",
+        "tests/integration/services/query_service/test_operations_router_dependency.py",
+        "tests/integration/services/query_service/test_reference_data_routers.py",
+        "tests/integration/services/query_service/test_lookup_contract_router.py",
+        "tests/integration/services/query_service/test_review_router.py",
+        "tests/integration/services/query_service/test_risk_router_dependency.py",
+        "tests/integration/services/query_service/test_simulation_router_dependency.py",
+        "tests/integration/services/query_service/test_summary_router.py",
+        "tests/integration/services/query_service/test_transactions_router.py",
+    ],
+    "e2e-smoke": [
+        "tests/e2e/test_query_service_observability.py",
+        "tests/e2e/test_complex_portfolio_lifecycle.py",
+    ],
+}
+
+SOURCE = "src/services/query_service/app"
+
+
+def get_suite(name: str) -> list[str]:
+    try:
+        return SUITES[name]
+    except KeyError as exc:
+        raise ValueError(f"Unknown suite: {name}") from exc
+
+
+def validate_suite_paths(name: str) -> None:
+    missing = [path for path in get_suite(name) if not Path(path).exists()]
+    if missing:
+        raise FileNotFoundError(
+            f"Suite '{name}' has missing test paths:\n"
+            + "\n".join(f" - {path}" for path in missing)
+        )
+
+
+def run_suite(
+    name: str,
+    *,
+    quiet: bool = False,
+    with_coverage: bool = False,
+    coverage_file: str | None = None,
+) -> int:
+    validate_suite_paths(name)
+
+    cmd = [sys.executable, "-m", "pytest", *get_suite(name)]
+    if quiet:
+        cmd.append("-q")
+    if with_coverage:
+        cmd.extend([f"--cov={SOURCE}", "--cov-report="])
+
+    env = os.environ.copy()
+    if coverage_file:
+        env["COVERAGE_FILE"] = coverage_file
+
+    return subprocess.run(cmd, check=False, env=env).returncode
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run or inspect CI test suite definitions.")
+    parser.add_argument(
+        "--suite",
+        choices=sorted(SUITES.keys()),
+        required=True,
+        help="Suite name to run or inspect.",
+    )
+    parser.add_argument(
+        "--print-args",
+        action="store_true",
+        help="Print pytest args for the suite and exit.",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Run pytest with -q.",
+    )
+    parser.add_argument(
+        "--with-coverage",
+        action="store_true",
+        help="Add --cov and --cov-report= to pytest invocation.",
+    )
+    parser.add_argument(
+        "--coverage-file",
+        default=None,
+        help="Set COVERAGE_FILE while running the suite.",
+    )
+    parser.add_argument(
+        "--validate-only",
+        action="store_true",
+        help="Validate suite paths and exit.",
+    )
+    args = parser.parse_args()
+
+    validate_suite_paths(args.suite)
+
+    if args.print_args:
+        print(" ".join(get_suite(args.suite)))
+        return 0
+
+    if args.validate_only:
+        print(f"Suite '{args.suite}' is valid ({len(get_suite(args.suite))} entries).")
+        return 0
+
+    return run_suite(
+        args.suite,
+        quiet=args.quiet,
+        with_coverage=args.with_coverage,
+        coverage_file=args.coverage_file,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/services/query_service/test_test_manifest.py
+++ b/tests/unit/services/query_service/test_test_manifest.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.test_manifest import SUITES, get_suite, validate_suite_paths
+
+
+def test_integration_lite_suite_includes_lookup_contract_router() -> None:
+    integration_suite = get_suite("integration-lite")
+    assert (
+        "tests/integration/services/query_service/test_lookup_contract_router.py"
+        in integration_suite
+    )
+
+
+def test_manifest_paths_exist_for_all_suites() -> None:
+    for suite_name in SUITES:
+        validate_suite_paths(suite_name)
+        for path in get_suite(suite_name):
+            assert Path(path).exists()


### PR DESCRIPTION
## Summary
- introduce scripts/test_manifest.py as the single source of truth for unit, integration-lite, and e2e-smoke suite composition
- wire Makefile, scripts/coverage_gate.py, and CI workflow to use manifest-driven execution
- remove suite drift risk in coverage gate and include test_lookup_contract_router.py in integration-lite scope
- add regression test to assert manifest correctness and path validity

## Why
- aligns lotus-core with lotus-platform standards around predictable test scope and local/CI parity
- eliminates hidden scope reduction that can cause PR surprises and late failures

## Validation
- python -m ruff check scripts/test_manifest.py scripts/coverage_gate.py tests/unit/services/query_service/test_test_manifest.py
- python -m pytest tests/unit/services/query_service/test_test_manifest.py tests/unit/services/query_service/services/test_period_resolution.py tests/unit/services/query_service/services/test_performance_service.py tests/unit/services/query_service/services/test_risk_service.py tests/unit/services/query_service/test_enterprise_readiness.py -q
- python scripts/coverage_gate.py
