### PR TITLE
Harden unit-db docker stack startup resilience

### DIFF
--- a/tests/unit/test_support/test_docker_stack.py
+++ b/tests/unit/test_support/test_docker_stack.py
@@ -38,7 +38,13 @@ def test_compose_up_retries_on_existing_image_conflict() -> None:
             )
         return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
 
-    compose_up("docker-compose.yml", build=False, retries=1, runner=runner)
+    compose_up(
+        "docker-compose.yml",
+        build=False,
+        retries=1,
+        retry_wait_seconds=0,
+        runner=runner,
+    )
 
     assert calls[0][-2:] == ["up", "-d"]
     assert calls[1][-2:] == ["down", "--remove-orphans"]


### PR DESCRIPTION
## Summary\n- make docker compose bring-up retries robust for transient pull/build/network errors\n- add configurable test harness timeouts/retries via env vars in 	ests/conftest.py\n- avoid retry sleep in unit harness test to keep tests fast\n\n## Validation\n- python -m pytest tests/unit/test_support/test_docker_stack.py -q\n- make lint\n- make test-unit-db (blocked locally by Docker BuildKit snapshot error; expected to validate in CI)\n