### PR TITLE
RFC-057 PR-5: harden ingestion adapter-mode boundaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,7 @@ HOST_DATABASE_URL=postgresql://user:password@localhost:5432/portfolio_db
 
 # Demo data pack bootstrap (set false to skip auto ingest/verify at compose startup)
 DEMO_DATA_PACK_ENABLED=true
+
+# Adapter-mode ingestion endpoints (non-canonical; recommended true only for UI/demo/manual onboarding)
+LOTUS_CORE_INGEST_PORTFOLIO_BUNDLE_ENABLED=true
+LOTUS_CORE_INGEST_UPLOAD_APIS_ENABLED=true

--- a/docs/RFCs/RFC 057 - Lotus Core Directory Reorganization and Legacy Module Retirement.md
+++ b/docs/RFCs/RFC 057 - Lotus Core Directory Reorganization and Legacy Module Retirement.md
@@ -376,7 +376,15 @@ Compatibility strategy:
  - removed position-analytics DTO/service/router/test/docs stack
  - enriched canonical `GET /portfolios/{portfolio_id}/positions` response with instrument metadata (`isin`, `currency`, `sector`, `country_of_risk`) and core position context (`weight`, `held_since_date`)
 
-4. In progress: remaining PR slices (ingestion mode hardening, API-first ops hardening, downstream drift hard-cut)
+4. Completed: PR-5 ingestion mode hardening
+ - `/ingest/portfolio-bundle` and `/ingest/uploads/*` are explicitly adapter-mode endpoints
+ - feature flags added:
+   - `LOTUS_CORE_INGEST_PORTFOLIO_BUNDLE_ENABLED`
+   - `LOTUS_CORE_INGEST_UPLOAD_APIS_ENABLED`
+ - adapter-disabled requests return explicit `410 Gone` with capability metadata
+ - integration capability metadata now reflects adapter-mode flags and supported input modes
+
+5. In progress: remaining PR slices (API-first ops hardening, downstream drift hard-cut)
 
 ## Definition of Done
 

--- a/docs/architecture/lotus-core-target-architecture.md
+++ b/docs/architecture/lotus-core-target-architecture.md
@@ -57,6 +57,9 @@ Mode policy:
 
 1. Canonical enterprise flow: external upstream -> ingestion contracts -> Kafka -> persistence.
 2. Upload/bundle flows are adapter paths and must be feature-flagged as non-canonical.
+3. Adapter flags:
+ - `LOTUS_CORE_INGEST_PORTFOLIO_BUNDLE_ENABLED`
+ - `LOTUS_CORE_INGEST_UPLOAD_APIS_ENABLED`
 
 ## Position Contract Direction
 

--- a/src/services/ingestion_service/app/adapter_mode.py
+++ b/src/services/ingestion_service/app/adapter_mode.py
@@ -1,0 +1,48 @@
+import os
+
+from fastapi import HTTPException, status
+
+
+def _env_enabled(name: str, default: str = "true") -> bool:
+    return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def portfolio_bundle_adapter_enabled() -> bool:
+    return _env_enabled("LOTUS_CORE_INGEST_PORTFOLIO_BUNDLE_ENABLED", "true")
+
+
+def upload_adapter_enabled() -> bool:
+    return _env_enabled("LOTUS_CORE_INGEST_UPLOAD_APIS_ENABLED", "true")
+
+
+def require_portfolio_bundle_adapter_enabled() -> None:
+    if portfolio_bundle_adapter_enabled():
+        return
+    raise HTTPException(
+        status_code=status.HTTP_410_GONE,
+        detail={
+            "code": "LOTUS_CORE_ADAPTER_MODE_DISABLED",
+            "capability": "lotus_core.ingestion.portfolio_bundle_adapter",
+            "message": (
+                "Portfolio bundle adapter mode is disabled. "
+                "Use canonical ingestion endpoints (/ingest/portfolios, /ingest/transactions, "
+                "/ingest/instruments, /ingest/market-prices, /ingest/fx-rates, /ingest/business-dates)."
+            ),
+        },
+    )
+
+
+def require_upload_adapter_enabled() -> None:
+    if upload_adapter_enabled():
+        return
+    raise HTTPException(
+        status_code=status.HTTP_410_GONE,
+        detail={
+            "code": "LOTUS_CORE_ADAPTER_MODE_DISABLED",
+            "capability": "lotus_core.ingestion.bulk_upload_adapter",
+            "message": (
+                "Bulk upload adapter mode is disabled. "
+                "Use canonical ingestion endpoints for production upstream integration."
+            ),
+        },
+    )

--- a/src/services/ingestion_service/app/routers/portfolio_bundle.py
+++ b/src/services/ingestion_service/app/routers/portfolio_bundle.py
@@ -2,6 +2,7 @@ import logging
 
 from fastapi import APIRouter, Depends, status
 
+from app.adapter_mode import require_portfolio_bundle_adapter_enabled
 from app.DTOs.portfolio_bundle_dto import PortfolioBundleIngestionRequest
 from app.services.ingestion_service import IngestionService, get_ingestion_service
 
@@ -12,6 +13,11 @@ router = APIRouter()
 @router.post(
     "/ingest/portfolio-bundle",
     status_code=status.HTTP_202_ACCEPTED,
+    responses={
+        status.HTTP_410_GONE: {
+            "description": "Portfolio bundle adapter mode disabled for this environment."
+        }
+    },
     tags=["Portfolio Bundle"],
     summary="Ingest a complete portfolio bundle",
     description=(
@@ -21,6 +27,7 @@ router = APIRouter()
 )
 async def ingest_portfolio_bundle(
     request: PortfolioBundleIngestionRequest,
+    _: None = Depends(require_portfolio_bundle_adapter_enabled),
     ingestion_service: IngestionService = Depends(get_ingestion_service),
 ):
     published_counts = await ingestion_service.publish_portfolio_bundle(request)

--- a/src/services/ingestion_service/app/routers/uploads.py
+++ b/src/services/ingestion_service/app/routers/uploads.py
@@ -1,6 +1,7 @@
 import logging
 
 from app.DTOs.upload_dto import UploadCommitResponse, UploadEntityType, UploadPreviewResponse
+from app.adapter_mode import require_upload_adapter_enabled
 from app.services.upload_ingestion_service import (
     UploadIngestionService,
     get_upload_ingestion_service,
@@ -18,7 +19,10 @@ router = APIRouter()
     responses={
         status.HTTP_400_BAD_REQUEST: {
             "description": "Invalid upload file format or content.",
-        }
+        },
+        status.HTTP_410_GONE: {
+            "description": "Bulk upload adapter mode disabled for this environment.",
+        },
     },
     tags=["Bulk Uploads"],
     summary="Preview and validate bulk upload data",
@@ -31,6 +35,7 @@ async def preview_upload(
     entity_type: UploadEntityType = Form(...),
     file: UploadFile = File(...),
     sample_size: int = Form(20, ge=1, le=100),
+    _: None = Depends(require_upload_adapter_enabled),
     upload_service: UploadIngestionService = Depends(get_upload_ingestion_service),
 ):
     content = await file.read()
@@ -60,7 +65,10 @@ async def preview_upload(
     responses={
         status.HTTP_400_BAD_REQUEST: {
             "description": "Invalid upload file format or content.",
-        }
+        },
+        status.HTTP_410_GONE: {
+            "description": "Bulk upload adapter mode disabled for this environment.",
+        },
     },
     tags=["Bulk Uploads"],
     summary="Commit validated bulk upload data",
@@ -73,6 +81,7 @@ async def commit_upload(
     entity_type: UploadEntityType = Form(...),
     file: UploadFile = File(...),
     allow_partial: bool = Form(False),
+    _: None = Depends(require_upload_adapter_enabled),
     upload_service: UploadIngestionService = Depends(get_upload_ingestion_service),
 ):
     content = await file.read()

--- a/src/services/query_service/app/dtos/capabilities_dto.py
+++ b/src/services/query_service/app/dtos/capabilities_dto.py
@@ -47,19 +47,19 @@ class IntegrationCapabilitiesResponse(BaseModel):
                 "supported_input_modes": ["lotus_core_ref", "inline_bundle"],
                 "features": [
                     {
-                        "key": "lotus_core.support.overview_api",
+                        "key": "lotus_core.ingestion.bulk_upload_adapter",
                         "enabled": True,
                         "owner_service": "lotus-core",
-                        "description": "Support diagnostics and operational support APIs.",
+                        "description": "CSV/XLSX preview+commit adapter endpoints for onboarding workflows.",
                     }
                 ],
                 "workflows": [
                     {
-                        "workflow_key": "advisor_workbench_overview",
+                        "workflow_key": "portfolio_bulk_onboarding",
                         "enabled": True,
                         "required_features": [
-                            "lotus_core.integration.core_snapshot",
-                            "lotus_core.support.overview_api",
+                            "lotus_core.ingestion.bulk_upload_adapter",
+                            "lotus_core.ingestion.portfolio_bundle_adapter",
                         ],
                     }
                 ],

--- a/tests/integration/services/ingestion_service/test_ingestion_main_app_contract.py
+++ b/tests/integration/services/ingestion_service/test_ingestion_main_app_contract.py
@@ -42,3 +42,6 @@ async def test_openapi_declares_upload_400_contracts(async_test_client):
     paths = response.json()["paths"]
     assert "400" in paths["/ingest/uploads/preview"]["post"]["responses"]
     assert "400" in paths["/ingest/uploads/commit"]["post"]["responses"]
+    assert "410" in paths["/ingest/uploads/preview"]["post"]["responses"]
+    assert "410" in paths["/ingest/uploads/commit"]["post"]["responses"]
+    assert "410" in paths["/ingest/portfolio-bundle"]["post"]["responses"]


### PR DESCRIPTION
## Summary
- add explicit adapter-mode guards for non-canonical ingestion endpoints:
  - `POST /ingest/portfolio-bundle`
  - `POST /ingest/uploads/preview`
  - `POST /ingest/uploads/commit`
- introduce environment flags:
  - `LOTUS_CORE_INGEST_PORTFOLIO_BUNDLE_ENABLED`
  - `LOTUS_CORE_INGEST_UPLOAD_APIS_ENABLED`
- return `410 Gone` with explicit capability metadata when adapter endpoints are disabled
- update integration capabilities output to reflect adapter-mode feature flags and input modes
- update RFC-057 execution progress for PR-5 and document flags in architecture/.env example

## Validation
- `python -m pytest -q tests/unit/services/query_service/services/test_capabilities_service.py tests/integration/services/query_service/test_capabilities_router_dependency.py`
- `python -m pytest -q tests/integration/services/ingestion_service/test_ingestion_routers.py -k "disabled_by_feature_flag"`
- `python -m pytest -q tests/integration/services/ingestion_service/test_ingestion_main_app_contract.py`
- `python scripts/openapi_quality_gate.py`
- `python scripts/no_alias_contract_guard.py`
