### PR TITLE
RFC-0067: lotus-core snapshot contract governance alignment

### DIFF
--- a/docs/standards/api-vocabulary/README.md
+++ b/docs/standards/api-vocabulary/README.md
@@ -1,0 +1,16 @@
+# lotus-core API Vocabulary Inventory
+
+This folder stores the generated RFC-0067 API vocabulary inventory for `lotus-core`.
+
+## Regenerate
+
+```powershell
+python scripts/api_vocabulary_inventory.py `
+  --output docs/standards/api-vocabulary/lotus-core-api-vocabulary.v1.json
+```
+
+## Validate
+
+```powershell
+python scripts/api_vocabulary_inventory.py --validate-only
+```

--- a/docs/standards/api-vocabulary/lotus-core-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-core-api-vocabulary.v1.json
@@ -1,0 +1,9164 @@
+{
+  "specVersion": "1.0.0",
+  "application": "lotus-core",
+  "sourceOpenApi": [
+    {
+      "service": "query_service",
+      "version": "0.2.0",
+      "openApiVersion": "3.1.0"
+    },
+    {
+      "service": "ingestion_service",
+      "version": "0.5.0",
+      "openApiVersion": "3.1.0"
+    }
+  ],
+  "generatedAt": "2026-02-27T10:21:00.104621+00:00",
+  "attributeCatalog": [
+    {
+      "semanticId": "lotus.active_reprocessing_keys",
+      "canonicalTerm": "active_reprocessing_keys",
+      "preferredName": "active_reprocessing_keys",
+      "description": "Number of portfolio-security keys currently marked REPROCESSING.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.advisor_id",
+      "canonicalTerm": "advisor_id",
+      "preferredName": "advisor_id",
+      "description": "Primary advisor identifier.",
+      "example": "ADVISOR_001",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.allowed_sections",
+      "canonicalTerm": "allowed_sections",
+      "preferredName": "allowed_sections",
+      "description": "effective integration policy response field: allowed sections.",
+      "example": [
+        "ALLOWED_SECTIONS_ITEM_VALUE"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.amount",
+      "canonicalTerm": "amount",
+      "preferredName": "amount",
+      "description": "Monetary value for amount.",
+      "example": 125000.5,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.as_of_date",
+      "canonicalTerm": "as_of_date",
+      "preferredName": "as_of_date",
+      "description": "Business date used to resolve baseline positions and valuation context.",
+      "example": "2026-02-27",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.asset_class",
+      "canonicalTerm": "asset_class",
+      "preferredName": "asset_class",
+      "description": "Asset class for grouping and reporting.",
+      "example": "EQUITY",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.attempt_count",
+      "canonicalTerm": "attempt_count",
+      "preferredName": "attempt_count",
+      "description": "Current retry attempt count for valuation jobs.",
+      "example": 1,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.base_currency",
+      "canonicalTerm": "base_currency",
+      "preferredName": "base_currency",
+      "description": "ISO base currency code.",
+      "example": "USD",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.baseline_as_of",
+      "canonicalTerm": "baseline_as_of",
+      "preferredName": "baseline_as_of",
+      "description": "projected positions response field: baseline as of.",
+      "example": "2026-02-27",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.baseline_quantity",
+      "canonicalTerm": "baseline_quantity",
+      "preferredName": "baseline_quantity",
+      "description": "Quantity value for baseline quantity.",
+      "example": 100.0,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.booking_center_code",
+      "canonicalTerm": "booking_center_code",
+      "preferredName": "booking_center_code",
+      "description": "Filter by booking center to get all portfolios for a business unit.",
+      "example": {
+        "id": "OBJ_001"
+      },
+      "type": "string",
+      "locations": [
+        "body",
+        "query"
+      ],
+      "observedTypes": [
+        "object",
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.business_date",
+      "canonicalTerm": "business_date",
+      "preferredName": "business_date",
+      "description": "Business date for the job (valuation_date or aggregation_date).",
+      "example": "2026-02-27",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.business_dates",
+      "canonicalTerm": "business_dates",
+      "preferredName": "business_dates",
+      "description": "business date ingestion request field: business dates.",
+      "example": [
+        "2026-02-27"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.cashflow",
+      "canonicalTerm": "cashflow",
+      "preferredName": "cashflow",
+      "description": "transaction record field: cashflow.",
+      "example": 3200.0,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.change_id",
+      "canonicalTerm": "change_id",
+      "preferredName": "change_id",
+      "description": "Unique change identifier.",
+      "example": "CHG_0001",
+      "type": "string",
+      "locations": [
+        "body",
+        "path"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.changes",
+      "canonicalTerm": "changes",
+      "preferredName": "changes",
+      "description": "simulation change upsert request field: changes.",
+      "example": [
+        "CHANGES_ITEM_VALUE"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.client_id",
+      "canonicalTerm": "client_id",
+      "preferredName": "client_id",
+      "description": "Filter by the client grouping ID (CIF) to get all portfolios for a client.",
+      "example": "CLIENT_001",
+      "type": "string",
+      "locations": [
+        "body",
+        "query"
+      ],
+      "observedTypes": [
+        "object",
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.close_date",
+      "canonicalTerm": "close_date",
+      "preferredName": "close_date",
+      "description": "Portfolio close date, if portfolio is closed.",
+      "example": "2026-02-27",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.consumer_system",
+      "canonicalTerm": "consumer_system",
+      "preferredName": "consumer_system",
+      "description": "Canonical consumer system value used in request parameter.",
+      "example": "STANDARD",
+      "type": "string",
+      "locations": [
+        "body",
+        "query"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.contract_version",
+      "canonicalTerm": "contract_version",
+      "preferredName": "contract_version",
+      "description": "effective integration policy response field: contract version.",
+      "example": "v1",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.cost_basis",
+      "canonicalTerm": "cost_basis",
+      "preferredName": "cost_basis",
+      "description": "The total cost basis of the holding as of this record.",
+      "example": {
+        "id": "OBJ_001"
+      },
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object",
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.cost_basis_local",
+      "canonicalTerm": "cost_basis_local",
+      "preferredName": "cost_basis_local",
+      "description": "The total cost basis in the instrument's local currency.",
+      "example": 95000.0,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.cost_basis_method",
+      "canonicalTerm": "cost_basis_method",
+      "preferredName": "cost_basis_method",
+      "description": "portfolio field: cost basis method.",
+      "example": "FIFO",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.country_of_risk",
+      "canonicalTerm": "country_of_risk",
+      "preferredName": "country_of_risk",
+      "description": "Instrument country of risk (ISO 3166-1 alpha-2).",
+      "example": "US",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.created_at",
+      "canonicalTerm": "created_at",
+      "preferredName": "created_at",
+      "description": "Timestamp for created at.",
+      "example": "2026-02-27T10:30:00Z",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.created_by",
+      "canonicalTerm": "created_by",
+      "preferredName": "created_by",
+      "description": "simulation session create request field: created by.",
+      "example": "lotus-manage",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.currency",
+      "canonicalTerm": "currency",
+      "preferredName": "currency",
+      "description": "Instrument trading currency (ISO 4217).",
+      "example": "USD",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object",
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.current_epoch",
+      "canonicalTerm": "current_epoch",
+      "preferredName": "current_epoch",
+      "description": "Current active epoch for the portfolio across position state keys.",
+      "example": 42,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.delta_quantity",
+      "canonicalTerm": "delta_quantity",
+      "preferredName": "delta_quantity",
+      "description": "Quantity value for delta quantity.",
+      "example": 100.0,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.description",
+      "canonicalTerm": "description",
+      "preferredName": "description",
+      "description": "Human-readable capability summary.",
+      "example": "Portfolio-level metric description.",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.effective_date",
+      "canonicalTerm": "effective_date",
+      "preferredName": "effective_date",
+      "description": "simulation change input field: effective date.",
+      "example": "2026-02-27",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.enabled",
+      "canonicalTerm": "enabled",
+      "preferredName": "enabled",
+      "description": "Whether this feature is enabled.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
+      "semanticId": "lotus.end_date",
+      "canonicalTerm": "end_date",
+      "preferredName": "end_date",
+      "description": "The end date for the date range filter (inclusive).",
+      "example": "2026-02-27",
+      "type": "object",
+      "locations": [
+        "query"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.entity_type",
+      "canonicalTerm": "entity_type",
+      "preferredName": "entity_type",
+      "description": "upload preview response field: entity type.",
+      "example": "portfolios",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.epoch",
+      "canonicalTerm": "epoch",
+      "preferredName": "epoch",
+      "description": "Epoch for valuation jobs.",
+      "example": 42,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer",
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.errors",
+      "canonicalTerm": "errors",
+      "preferredName": "errors",
+      "description": "Validation errors by row for correction before commit.",
+      "example": [
+        "ERRORS_ITEM_VALUE"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.expires_at",
+      "canonicalTerm": "expires_at",
+      "preferredName": "expires_at",
+      "description": "Timestamp for expires at.",
+      "example": "2026-02-27T10:30:00Z",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.failure_reason",
+      "canonicalTerm": "failure_reason",
+      "preferredName": "failure_reason",
+      "description": "Failure reason (when status=FAILED).",
+      "example": "missing_market_price",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.features",
+      "canonicalTerm": "features",
+      "preferredName": "features",
+      "description": "integration capabilities response field: features.",
+      "example": [
+        "FEATURES_ITEM_VALUE"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.file_format",
+      "canonicalTerm": "file_format",
+      "preferredName": "file_format",
+      "description": "upload preview response field: file format.",
+      "example": "csv",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.from_currency",
+      "canonicalTerm": "from_currency",
+      "preferredName": "from_currency",
+      "description": "The base currency (e.g., USD).",
+      "example": "USD",
+      "type": "string",
+      "locations": [
+        "body",
+        "query"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.fx_rates",
+      "canonicalTerm": "fx_rates",
+      "preferredName": "fx_rates",
+      "description": "Rate/price value for fx rates.",
+      "example": [
+        "FX_RATES_ITEM_VALUE"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.generated_at",
+      "canonicalTerm": "generated_at",
+      "preferredName": "generated_at",
+      "description": "Timestamp for generated at.",
+      "example": "2026-02-27T10:30:00Z",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.gross_transaction_amount",
+      "canonicalTerm": "gross_transaction_amount",
+      "preferredName": "gross_transaction_amount",
+      "description": "Monetary value for gross transaction amount.",
+      "example": 125000.5,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number",
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.held_since_date",
+      "canonicalTerm": "held_since_date",
+      "preferredName": "held_since_date",
+      "description": "Start date of the current continuous holding period in the active epoch.",
+      "example": "2026-02-27",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.id",
+      "canonicalTerm": "id",
+      "preferredName": "id",
+      "description": "Canonical identifier used by UI selectors.",
+      "example": "ITEM_001",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.include_cash_positions",
+      "canonicalTerm": "include_cash_positions",
+      "preferredName": "include_cash_positions",
+      "description": "Include cash-class positions in section responses.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
+      "semanticId": "lotus.include_sections",
+      "canonicalTerm": "include_sections",
+      "preferredName": "include_sections",
+      "description": "Canonical include sections value used in request parameter.",
+      "example": {
+        "id": "OBJ_001"
+      },
+      "type": "object",
+      "locations": [
+        "query"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.include_zero_quantity_positions",
+      "canonicalTerm": "include_zero_quantity_positions",
+      "preferredName": "include_zero_quantity_positions",
+      "description": "Include positions with zero quantity in section responses.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
+      "semanticId": "lotus.instrument_enrichment",
+      "canonicalTerm": "instrument_enrichment",
+      "preferredName": "instrument_enrichment",
+      "description": "Reference enrichment for securities included in snapshot sections.",
+      "example": {
+        "id": "OBJ_001"
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.instrument_id",
+      "canonicalTerm": "instrument_id",
+      "preferredName": "instrument_id",
+      "description": "Unique instrument identifier.",
+      "example": "EQ_US_AAPL",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.instrument_name",
+      "canonicalTerm": "instrument_name",
+      "preferredName": "instrument_name",
+      "description": "Instrument display name.",
+      "example": "Apple Inc.",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.instrument_page_limit",
+      "canonicalTerm": "instrument_page_limit",
+      "preferredName": "instrument_page_limit",
+      "description": "Canonical instrument page limit value used in request parameter.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "query"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.instruments",
+      "canonicalTerm": "instruments",
+      "preferredName": "instruments",
+      "description": "The list of instrument records for the current page.",
+      "example": [
+        "INSTRUMENTS_ITEM_VALUE"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.invalid_rows",
+      "canonicalTerm": "invalid_rows",
+      "preferredName": "invalid_rows",
+      "description": "upload preview response field: invalid rows.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.investment_time_horizon",
+      "canonicalTerm": "investment_time_horizon",
+      "preferredName": "investment_time_horizon",
+      "description": "Investment horizon category.",
+      "example": "2026-02-27T10:30:00Z",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.is_leverage_allowed",
+      "canonicalTerm": "is_leverage_allowed",
+      "preferredName": "is_leverage_allowed",
+      "description": "Whether leverage is allowed for this portfolio.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
+      "semanticId": "lotus.isin",
+      "canonicalTerm": "isin",
+      "preferredName": "isin",
+      "description": "ISIN instrument identifier.",
+      "example": "US0378331005",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object",
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.issuer_id",
+      "canonicalTerm": "issuer_id",
+      "preferredName": "issuer_id",
+      "description": "Identifier for the direct issuer of the security.",
+      "example": "ISSUER_001",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.items",
+      "canonicalTerm": "items",
+      "preferredName": "items",
+      "description": "Operational jobs for support workflows.",
+      "example": [
+        "ITEMS_ITEM_VALUE"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.job_type",
+      "canonicalTerm": "job_type",
+      "preferredName": "job_type",
+      "description": "Type of support job.",
+      "example": "VALUATION",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.key",
+      "canonicalTerm": "key",
+      "preferredName": "key",
+      "description": "Canonical feature key.",
+      "example": "portfolio_state",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.label",
+      "canonicalTerm": "label",
+      "preferredName": "label",
+      "description": "Display label for UI selector option.",
+      "example": "Global Equity Portfolio",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.latest_daily_snapshot_date",
+      "canonicalTerm": "latest_daily_snapshot_date",
+      "preferredName": "latest_daily_snapshot_date",
+      "description": "Latest date available in daily_position_snapshots for current epoch.",
+      "example": "2026-02-27",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.latest_position_history_date",
+      "canonicalTerm": "latest_position_history_date",
+      "preferredName": "latest_position_history_date",
+      "description": "Latest date available in position_history for current epoch.",
+      "example": "2026-02-27",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.latest_position_snapshot_date",
+      "canonicalTerm": "latest_position_snapshot_date",
+      "preferredName": "latest_position_snapshot_date",
+      "description": "Most recent daily position snapshot date in the current epoch.",
+      "example": "2026-02-27",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.latest_transaction_date",
+      "canonicalTerm": "latest_transaction_date",
+      "preferredName": "latest_transaction_date",
+      "description": "Most recent transaction business date observed for the portfolio.",
+      "example": "2026-02-27",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.latest_valuation_job_date",
+      "canonicalTerm": "latest_valuation_job_date",
+      "preferredName": "latest_valuation_job_date",
+      "description": "Latest valuation job business date for current epoch.",
+      "example": "2026-02-27",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.latest_valuation_job_status",
+      "canonicalTerm": "latest_valuation_job_status",
+      "preferredName": "latest_valuation_job_status",
+      "description": "Status of the latest valuation job for current epoch.",
+      "example": "ACTIVE",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.limit",
+      "canonicalTerm": "limit",
+      "preferredName": "limit",
+      "description": "Maximum number of records to return",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body",
+        "query"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.market_prices",
+      "canonicalTerm": "market_prices",
+      "preferredName": "market_prices",
+      "description": "Rate/price value for market prices.",
+      "example": [
+        "MARKET_PRICES_ITEM_VALUE"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.matched_rule_id",
+      "canonicalTerm": "matched_rule_id",
+      "preferredName": "matched_rule_id",
+      "description": "Unique matched rule identifier.",
+      "example": "MATCHED_RULE_001",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.maturity_date",
+      "canonicalTerm": "maturity_date",
+      "preferredName": "maturity_date",
+      "description": "Maturity date for fixed income instruments.",
+      "example": "2026-02-27",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.message",
+      "canonicalTerm": "message",
+      "preferredName": "message",
+      "description": "Validation error message for the row.",
+      "example": "Operation completed successfully.",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.metadata",
+      "canonicalTerm": "metadata",
+      "preferredName": "metadata",
+      "description": "simulation change input field: metadata.",
+      "example": {
+        "source": "lotus-core"
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.mode",
+      "canonicalTerm": "mode",
+      "preferredName": "mode",
+      "description": "Ingestion mode for bundle semantics; current behavior is UPSERT-style event publication.",
+      "example": "UPSERT",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.name",
+      "canonicalTerm": "name",
+      "preferredName": "name",
+      "description": "instrument record field: name.",
+      "example": "Global Balanced Portfolio",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.net_cost",
+      "canonicalTerm": "net_cost",
+      "preferredName": "net_cost",
+      "description": "transaction record field: net cost.",
+      "example": 98000.0,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.net_cost_local",
+      "canonicalTerm": "net_cost_local",
+      "preferredName": "net_cost_local",
+      "description": "transaction record field: net cost local.",
+      "example": 98000.0,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.net_delta_quantity",
+      "canonicalTerm": "net_delta_quantity",
+      "preferredName": "net_delta_quantity",
+      "description": "Quantity value for net delta quantity.",
+      "example": 100.0,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.objective",
+      "canonicalTerm": "objective",
+      "preferredName": "objective",
+      "description": "Primary client objective for this portfolio.",
+      "example": "CAPITAL_APPRECIATION",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.open_date",
+      "canonicalTerm": "open_date",
+      "preferredName": "open_date",
+      "description": "Portfolio inception/open date.",
+      "example": "2026-02-27",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.options",
+      "canonicalTerm": "options",
+      "preferredName": "options",
+      "description": "Section behavior options.",
+      "example": "STANDARD",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "CoreSnapshotRequestOptions"
+      ]
+    },
+    {
+      "semanticId": "lotus.owner_service",
+      "canonicalTerm": "owner_service",
+      "preferredName": "owner_service",
+      "description": "Owning service for the feature capability.",
+      "example": "lotus-core",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.pending_aggregation_jobs",
+      "canonicalTerm": "pending_aggregation_jobs",
+      "preferredName": "pending_aggregation_jobs",
+      "description": "Number of pending/processing portfolio aggregation jobs for the portfolio.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.pending_valuation_jobs",
+      "canonicalTerm": "pending_valuation_jobs",
+      "preferredName": "pending_valuation_jobs",
+      "description": "Number of pending/processing valuation jobs for the portfolio.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.policy_provenance",
+      "canonicalTerm": "policy_provenance",
+      "preferredName": "policy_provenance",
+      "description": "effective integration policy response field: policy provenance.",
+      "example": "STANDARD",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "PolicyProvenanceMetadata"
+      ]
+    },
+    {
+      "semanticId": "lotus.policy_source",
+      "canonicalTerm": "policy_source",
+      "preferredName": "policy_source",
+      "description": "policy provenance metadata field: policy source.",
+      "example": "tenant-default-policy",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.policy_version",
+      "canonicalTerm": "policy_version",
+      "preferredName": "policy_version",
+      "description": "policy provenance metadata field: policy version.",
+      "example": "tenant-default-v1",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.portfolio_currency",
+      "canonicalTerm": "portfolio_currency",
+      "preferredName": "portfolio_currency",
+      "description": "Portfolio base currency used by lotus-core for valuation storage.",
+      "example": "USD",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.portfolio_id",
+      "canonicalTerm": "portfolio_id",
+      "preferredName": "portfolio_id",
+      "description": "Filter by a single, specific portfolio ID.",
+      "example": "PORTFOLIO_001",
+      "type": "string",
+      "locations": [
+        "body",
+        "path",
+        "query"
+      ],
+      "observedTypes": [
+        "object",
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.portfolio_totals",
+      "canonicalTerm": "portfolio_totals",
+      "preferredName": "portfolio_totals",
+      "description": "Portfolio-level baseline/projected totals and delta.",
+      "example": {
+        "id": "OBJ_001"
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.portfolio_type",
+      "canonicalTerm": "portfolio_type",
+      "preferredName": "portfolio_type",
+      "description": "Portfolio product/type classification.",
+      "example": "DISCRETIONARY",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.portfolios",
+      "canonicalTerm": "portfolios",
+      "preferredName": "portfolios",
+      "description": "List of portfolios matching query filters.",
+      "example": [
+        "PORTFOLIOS_ITEM_VALUE"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.position_basis",
+      "canonicalTerm": "position_basis",
+      "preferredName": "position_basis",
+      "description": "Basis used for position valuation fields.",
+      "example": "STANDARD",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "CoreSnapshotPositionBasis"
+      ]
+    },
+    {
+      "semanticId": "lotus.position_date",
+      "canonicalTerm": "position_date",
+      "preferredName": "position_date",
+      "description": "The date of this position snapshot.",
+      "example": "2026-02-27",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.positions",
+      "canonicalTerm": "positions",
+      "preferredName": "positions",
+      "description": "A time-series list of position records.",
+      "example": [
+        "POSITIONS_ITEM_VALUE"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.positions_baseline",
+      "canonicalTerm": "positions_baseline",
+      "preferredName": "positions_baseline",
+      "description": "Baseline positions resolved for as_of_date.",
+      "example": [
+        {
+          "security_id": "SEC_AAPL_US",
+          "quantity": "100.0000000000"
+        }
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.positions_delta",
+      "canonicalTerm": "positions_delta",
+      "preferredName": "positions_delta",
+      "description": "Per-security baseline versus projected deltas.",
+      "example": [
+        {
+          "security_id": "SEC_AAPL_US",
+          "delta_quantity": "20.0000000000"
+        }
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.positions_projected",
+      "canonicalTerm": "positions_projected",
+      "preferredName": "positions_projected",
+      "description": "Projected positions after applying simulation changes.",
+      "example": [
+        {
+          "security_id": "SEC_AAPL_US",
+          "quantity": "120.0000000000"
+        }
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.price",
+      "canonicalTerm": "price",
+      "preferredName": "price",
+      "description": "Rate/price value for price.",
+      "example": 1.2345,
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number",
+        "object",
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.price_date",
+      "canonicalTerm": "price_date",
+      "preferredName": "price_date",
+      "description": "Business date for price date.",
+      "example": "2026-02-27",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.prices",
+      "canonicalTerm": "prices",
+      "preferredName": "prices",
+      "description": "A list of market price records.",
+      "example": [
+        "PRICES_ITEM_VALUE"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.product_type",
+      "canonicalTerm": "product_type",
+      "preferredName": "product_type",
+      "description": "Filter by a specific product type (e.g., Equity).",
+      "example": {
+        "id": "OBJ_001"
+      },
+      "type": "string",
+      "locations": [
+        "body",
+        "query"
+      ],
+      "observedTypes": [
+        "object",
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.proposed_quantity",
+      "canonicalTerm": "proposed_quantity",
+      "preferredName": "proposed_quantity",
+      "description": "Quantity value for proposed quantity.",
+      "example": 100.0,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.published_rows",
+      "canonicalTerm": "published_rows",
+      "preferredName": "published_rows",
+      "description": "upload commit response field: published rows.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.q",
+      "canonicalTerm": "q",
+      "preferredName": "q",
+      "description": "Optional case-insensitive search text applied to portfolio ID.",
+      "example": {
+        "id": "OBJ_001"
+      },
+      "type": "object",
+      "locations": [
+        "query"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.quantity",
+      "canonicalTerm": "quantity",
+      "preferredName": "quantity",
+      "description": "The number of shares held as of this record.",
+      "example": 100.0,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number",
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.rate",
+      "canonicalTerm": "rate",
+      "preferredName": "rate",
+      "description": "Rate/price value for rate.",
+      "example": 1.2345,
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object",
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.rate_date",
+      "canonicalTerm": "rate_date",
+      "preferredName": "rate_date",
+      "description": "Business date for rate date.",
+      "example": "2026-02-27",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.rates",
+      "canonicalTerm": "rates",
+      "preferredName": "rates",
+      "description": "A list of FX rate records.",
+      "example": [
+        "RATES_ITEM_VALUE"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.rating",
+      "canonicalTerm": "rating",
+      "preferredName": "rating",
+      "description": "Credit rating for fixed income instruments (e.g., 'AAA').",
+      "example": "A",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.realized_gain_loss",
+      "canonicalTerm": "realized_gain_loss",
+      "preferredName": "realized_gain_loss",
+      "description": "transaction record field: realized gain loss.",
+      "example": 525.75,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.realized_gain_loss_local",
+      "canonicalTerm": "realized_gain_loss_local",
+      "preferredName": "realized_gain_loss_local",
+      "description": "transaction record field: realized gain loss local.",
+      "example": 525.75,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.reporting_currency",
+      "canonicalTerm": "reporting_currency",
+      "preferredName": "reporting_currency",
+      "description": "ISO currency code for reporting conversion. Defaults to portfolio base currency.",
+      "example": "USD",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object",
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.reprocessing_status",
+      "canonicalTerm": "reprocessing_status",
+      "preferredName": "reprocessing_status",
+      "description": "Reprocessing status for this portfolio-security key.",
+      "example": "ACTIVE",
+      "type": "string",
+      "locations": [
+        "body",
+        "query"
+      ],
+      "observedTypes": [
+        "object",
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.required_features",
+      "canonicalTerm": "required_features",
+      "preferredName": "required_features",
+      "description": "Feature keys required for workflow execution.",
+      "example": [
+        "REQUIRED_FEATURES_ITEM_VALUE"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.risk_exposure",
+      "canonicalTerm": "risk_exposure",
+      "preferredName": "risk_exposure",
+      "description": "Client risk exposure classification.",
+      "example": "MODERATE",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.row_number",
+      "canonicalTerm": "row_number",
+      "preferredName": "row_number",
+      "description": "1-based row number from the uploaded file.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.sample_rows",
+      "canonicalTerm": "sample_rows",
+      "preferredName": "sample_rows",
+      "description": "Normalized and validated sample rows for UI preview.",
+      "example": [
+        {
+          "key": "value"
+        }
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.sections",
+      "canonicalTerm": "sections",
+      "preferredName": "sections",
+      "description": "Requested snapshot sections to include in the response payload.",
+      "example": [
+        "positions_baseline",
+        "positions_projected",
+        "positions_delta",
+        "portfolio_totals",
+        "instrument_enrichment"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "CoreSnapshotSections",
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.sector",
+      "canonicalTerm": "sector",
+      "preferredName": "sector",
+      "description": "Instrument sector classification.",
+      "example": "TECHNOLOGY",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.security_id",
+      "canonicalTerm": "security_id",
+      "preferredName": "security_id",
+      "description": "The unique identifier for the security to query.",
+      "example": "SECURITY_001",
+      "type": "string",
+      "locations": [
+        "body",
+        "path",
+        "query"
+      ],
+      "observedTypes": [
+        "object",
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.session",
+      "canonicalTerm": "session",
+      "preferredName": "session",
+      "description": "simulation session response field: session.",
+      "example": "STANDARD",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "SimulationSessionRecord"
+      ]
+    },
+    {
+      "semanticId": "lotus.session_id",
+      "canonicalTerm": "session_id",
+      "preferredName": "session_id",
+      "description": "Unique session identifier.",
+      "example": "SIM_0001",
+      "type": "string",
+      "locations": [
+        "body",
+        "path"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.settlement_date",
+      "canonicalTerm": "settlement_date",
+      "preferredName": "settlement_date",
+      "description": "transaction field: settlement date.",
+      "example": "2026-02-27",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.simulation",
+      "canonicalTerm": "simulation",
+      "preferredName": "simulation",
+      "description": "Simulation options required for SIMULATION mode.",
+      "example": {
+        "id": "OBJ_001"
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.skip",
+      "canonicalTerm": "skip",
+      "preferredName": "skip",
+      "description": "Number of records to skip for pagination",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body",
+        "query"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.skipped_rows",
+      "canonicalTerm": "skipped_rows",
+      "preferredName": "skipped_rows",
+      "description": "upload commit response field: skipped rows.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.snapshot_mode",
+      "canonicalTerm": "snapshot_mode",
+      "preferredName": "snapshot_mode",
+      "description": "Snapshot mode: BASELINE for current state or SIMULATION for projected state.",
+      "example": "STANDARD",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "CoreSnapshotMode"
+      ]
+    },
+    {
+      "semanticId": "lotus.sort_by",
+      "canonicalTerm": "sort_by",
+      "preferredName": "sort_by",
+      "description": "Field to sort by (e.g., 'transaction_date').",
+      "example": {
+        "id": "OBJ_001"
+      },
+      "type": "object",
+      "locations": [
+        "query"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.sort_order",
+      "canonicalTerm": "sort_order",
+      "preferredName": "sort_order",
+      "description": "Sort order: 'asc' or 'desc'.",
+      "example": {
+        "id": "OBJ_001"
+      },
+      "type": "object",
+      "locations": [
+        "query"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.source",
+      "canonicalTerm": "source",
+      "preferredName": "source",
+      "description": "Currency source scope. Use ALL, PORTFOLIOS, or INSTRUMENTS.",
+      "example": "STANDARD",
+      "type": "string",
+      "locations": [
+        "query"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.source_service",
+      "canonicalTerm": "source_service",
+      "preferredName": "source_service",
+      "description": "effective integration policy response field: source service.",
+      "example": "lotus-core",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.source_system",
+      "canonicalTerm": "source_system",
+      "preferredName": "source_system",
+      "description": "Upstream source system identifier for audit and lineage.",
+      "example": "UI_UPLOAD",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.start_date",
+      "canonicalTerm": "start_date",
+      "preferredName": "start_date",
+      "description": "The start date for the date range filter (inclusive).",
+      "example": "2026-02-27",
+      "type": "object",
+      "locations": [
+        "query"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.status",
+      "canonicalTerm": "status",
+      "preferredName": "status",
+      "description": "Portfolio lifecycle status.",
+      "example": "ACTIVE",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.status_filter",
+      "canonicalTerm": "status_filter",
+      "preferredName": "status_filter",
+      "description": "Optional job status filter (e.g., PENDING, PROCESSING).",
+      "example": "ACTIVE",
+      "type": "object",
+      "locations": [
+        "query"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.strict_mode",
+      "canonicalTerm": "strict_mode",
+      "preferredName": "strict_mode",
+      "description": "policy provenance metadata field: strict mode.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
+      "semanticId": "lotus.supported_input_modes",
+      "canonicalTerm": "supported_input_modes",
+      "preferredName": "supported_input_modes",
+      "description": "integration capabilities response field: supported input modes.",
+      "example": [
+        "SUPPORTED_INPUT_MODES_ITEM_VALUE"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.tenant_id",
+      "canonicalTerm": "tenant_id",
+      "preferredName": "tenant_id",
+      "description": "Unique tenant identifier.",
+      "example": "TENANT_001",
+      "type": "string",
+      "locations": [
+        "body",
+        "query"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.to_currency",
+      "canonicalTerm": "to_currency",
+      "preferredName": "to_currency",
+      "description": "The quote currency (e.g., SGD).",
+      "example": "USD",
+      "type": "string",
+      "locations": [
+        "body",
+        "query"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.total",
+      "canonicalTerm": "total",
+      "preferredName": "total",
+      "description": "The total number of transactions matching the query.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.total_baseline_positions",
+      "canonicalTerm": "total_baseline_positions",
+      "preferredName": "total_baseline_positions",
+      "description": "projected summary response field: total baseline positions.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.total_proposed_positions",
+      "canonicalTerm": "total_proposed_positions",
+      "preferredName": "total_proposed_positions",
+      "description": "projected summary response field: total proposed positions.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.total_rows",
+      "canonicalTerm": "total_rows",
+      "preferredName": "total_rows",
+      "description": "upload preview response field: total rows.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.trade_currency",
+      "canonicalTerm": "trade_currency",
+      "preferredName": "trade_currency",
+      "description": "ISO currency code for trade currency.",
+      "example": "USD",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.trade_fee",
+      "canonicalTerm": "trade_fee",
+      "preferredName": "trade_fee",
+      "description": "transaction field: trade fee.",
+      "example": "5.0",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.transaction_date",
+      "canonicalTerm": "transaction_date",
+      "preferredName": "transaction_date",
+      "description": "Timestamp for transaction date.",
+      "example": "2026-02-27T10:30:00Z",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.transaction_fx_rate",
+      "canonicalTerm": "transaction_fx_rate",
+      "preferredName": "transaction_fx_rate",
+      "description": "Rate/price value for transaction fx rate.",
+      "example": 1.1032,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.transaction_id",
+      "canonicalTerm": "transaction_id",
+      "preferredName": "transaction_id",
+      "description": "The ID of the transaction that created this position state.",
+      "example": "TXN_0001",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.transaction_ids",
+      "canonicalTerm": "transaction_ids",
+      "preferredName": "transaction_ids",
+      "description": "A non-empty list of transaction_id strings to be reprocessed.",
+      "example": [
+        "TRANSACTION_IDS_ITEM_VALUE"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.transaction_type",
+      "canonicalTerm": "transaction_type",
+      "preferredName": "transaction_type",
+      "description": "transaction record field: transaction type.",
+      "example": "BUY",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.transactions",
+      "canonicalTerm": "transactions",
+      "preferredName": "transactions",
+      "description": "The list of transaction records for the current page.",
+      "example": [
+        "TRANSACTIONS_ITEM_VALUE"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.ttl_hours",
+      "canonicalTerm": "ttl_hours",
+      "preferredName": "ttl_hours",
+      "description": "simulation session create request field: ttl hours.",
+      "example": 24,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.ultimate_parent_issuer_id",
+      "canonicalTerm": "ultimate_parent_issuer_id",
+      "preferredName": "ultimate_parent_issuer_id",
+      "description": "Identifier for the ultimate parent of the issuer.",
+      "example": "ULTIMATE_PARENT_ISSUER_001",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.valid_rows",
+      "canonicalTerm": "valid_rows",
+      "preferredName": "valid_rows",
+      "description": "upload preview response field: valid rows.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.valuation",
+      "canonicalTerm": "valuation",
+      "preferredName": "valuation",
+      "description": "Valuation details for this record.",
+      "example": 125000.5,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.valuation_context",
+      "canonicalTerm": "valuation_context",
+      "preferredName": "valuation_context",
+      "description": "Valuation and weight basis context applied to all sections.",
+      "example": {
+        "portfolio_currency": "EUR",
+        "reporting_currency": "USD",
+        "position_basis": "market_value_base",
+        "weight_basis": "total_market_value_base"
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "CoreSnapshotValuationContext"
+      ]
+    },
+    {
+      "semanticId": "lotus.version",
+      "canonicalTerm": "version",
+      "preferredName": "version",
+      "description": "simulation session record field: version.",
+      "example": 1,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.warnings",
+      "canonicalTerm": "warnings",
+      "preferredName": "warnings",
+      "description": "effective integration policy response field: warnings.",
+      "example": [
+        "WARNINGS_ITEM_VALUE"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.watermark_date",
+      "canonicalTerm": "watermark_date",
+      "preferredName": "watermark_date",
+      "description": "Watermark date from which replay/reprocessing is active.",
+      "example": "2026-02-27",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.weight",
+      "canonicalTerm": "weight",
+      "preferredName": "weight",
+      "description": "Position weight versus total portfolio market value (0.0 to 1.0).",
+      "example": {
+        "id": "OBJ_001"
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.weight_basis",
+      "canonicalTerm": "weight_basis",
+      "preferredName": "weight_basis",
+      "description": "Basis used to calculate weight fields.",
+      "example": "STANDARD",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "CoreSnapshotWeightBasis"
+      ]
+    },
+    {
+      "semanticId": "lotus.workflow_key",
+      "canonicalTerm": "workflow_key",
+      "preferredName": "workflow_key",
+      "description": "Workflow identifier.",
+      "example": "portfolio_bulk_onboarding",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.workflows",
+      "canonicalTerm": "workflows",
+      "preferredName": "workflows",
+      "description": "integration capabilities response field: workflows.",
+      "example": [
+        "WORKFLOWS_ITEM_VALUE"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    }
+  ],
+  "controlsCatalog": [
+    {
+      "name": "portfolio_id",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Filter by a single, specific portfolio ID.",
+      "example": "PORTFOLIO_001",
+      "behaviorImpact": "Affects get_portfolios_portfolios__get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "portfolio_id",
+      "semanticId": "lotus.portfolio_id"
+    },
+    {
+      "name": "client_id",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Filter by the client grouping ID (CIF) to get all portfolios for a client.",
+      "example": "CLIENT_001",
+      "behaviorImpact": "Affects get_portfolios_portfolios__get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "client_id",
+      "semanticId": "lotus.client_id"
+    },
+    {
+      "name": "booking_center_code",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Filter by booking center to get all portfolios for a business unit.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects get_portfolios_portfolios__get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "booking_center_code",
+      "semanticId": "lotus.booking_center_code"
+    },
+    {
+      "name": "portfolio_id",
+      "kind": "request_option",
+      "location": "path",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "Unique portfolio identifier.",
+      "example": "PORTFOLIO_001",
+      "behaviorImpact": "Affects get_portfolio_by_id_portfolios__portfolio_id__get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "portfolio_id",
+      "semanticId": "lotus.portfolio_id"
+    },
+    {
+      "name": "portfolio_id",
+      "kind": "request_option",
+      "location": "path",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "Unique portfolio identifier.",
+      "example": "PORTFOLIO_001",
+      "behaviorImpact": "Affects get_position_history_portfolios__portfolio_id__position_history_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "portfolio_id",
+      "semanticId": "lotus.portfolio_id"
+    },
+    {
+      "name": "security_id",
+      "kind": "request_option",
+      "location": "query",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "The unique identifier for the security to query.",
+      "example": "SECURITY_001",
+      "behaviorImpact": "Affects get_position_history_portfolios__portfolio_id__position_history_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "security_id",
+      "semanticId": "lotus.security_id"
+    },
+    {
+      "name": "start_date",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "The start date for the date range filter (inclusive).",
+      "example": "2026-02-27",
+      "behaviorImpact": "Affects get_position_history_portfolios__portfolio_id__position_history_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "start_date",
+      "semanticId": "lotus.start_date"
+    },
+    {
+      "name": "end_date",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "The end date for the date range filter (inclusive).",
+      "example": "2026-02-27",
+      "behaviorImpact": "Affects get_position_history_portfolios__portfolio_id__position_history_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "end_date",
+      "semanticId": "lotus.end_date"
+    },
+    {
+      "name": "portfolio_id",
+      "kind": "request_option",
+      "location": "path",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "Unique portfolio identifier.",
+      "example": "PORTFOLIO_001",
+      "behaviorImpact": "Affects get_latest_positions_portfolios__portfolio_id__positions_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "portfolio_id",
+      "semanticId": "lotus.portfolio_id"
+    },
+    {
+      "name": "portfolio_id",
+      "kind": "request_option",
+      "location": "path",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "Unique portfolio identifier.",
+      "example": "PORTFOLIO_001",
+      "behaviorImpact": "Affects get_transactions_portfolios__portfolio_id__transactions_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "portfolio_id",
+      "semanticId": "lotus.portfolio_id"
+    },
+    {
+      "name": "security_id",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Filter by a specific security ID.",
+      "example": "SECURITY_001",
+      "behaviorImpact": "Affects get_transactions_portfolios__portfolio_id__transactions_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "security_id",
+      "semanticId": "lotus.security_id"
+    },
+    {
+      "name": "start_date",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "The start date for the date range filter (inclusive).",
+      "example": "2026-02-27",
+      "behaviorImpact": "Affects get_transactions_portfolios__portfolio_id__transactions_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "start_date",
+      "semanticId": "lotus.start_date"
+    },
+    {
+      "name": "end_date",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "The end date for the date range filter (inclusive).",
+      "example": "2026-02-27",
+      "behaviorImpact": "Affects get_transactions_portfolios__portfolio_id__transactions_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "end_date",
+      "semanticId": "lotus.end_date"
+    },
+    {
+      "name": "skip",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 0,
+      "allowedValues": [],
+      "description": "Number of records to skip for pagination",
+      "example": 10,
+      "behaviorImpact": "Affects get_transactions_portfolios__portfolio_id__transactions_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "skip",
+      "semanticId": "lotus.skip"
+    },
+    {
+      "name": "limit",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 100,
+      "allowedValues": [],
+      "description": "Maximum number of records to return",
+      "example": 10,
+      "behaviorImpact": "Affects get_transactions_portfolios__portfolio_id__transactions_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "limit",
+      "semanticId": "lotus.limit"
+    },
+    {
+      "name": "sort_by",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Field to sort by (e.g., 'transaction_date').",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects get_transactions_portfolios__portfolio_id__transactions_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "sort_by",
+      "semanticId": "lotus.sort_by"
+    },
+    {
+      "name": "sort_order",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "desc",
+      "allowedValues": [],
+      "description": "Sort order: 'asc' or 'desc'.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects get_transactions_portfolios__portfolio_id__transactions_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "sort_order",
+      "semanticId": "lotus.sort_order"
+    },
+    {
+      "name": "security_id",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Filter by a specific security ID.",
+      "example": "SECURITY_001",
+      "behaviorImpact": "Affects get_instruments_instruments__get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "security_id",
+      "semanticId": "lotus.security_id"
+    },
+    {
+      "name": "product_type",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Filter by a specific product type (e.g., Equity).",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects get_instruments_instruments__get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "product_type",
+      "semanticId": "lotus.product_type"
+    },
+    {
+      "name": "skip",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 0,
+      "allowedValues": [],
+      "description": "Number of records to skip for pagination",
+      "example": 10,
+      "behaviorImpact": "Affects get_instruments_instruments__get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "skip",
+      "semanticId": "lotus.skip"
+    },
+    {
+      "name": "limit",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 100,
+      "allowedValues": [],
+      "description": "Maximum number of records to return",
+      "example": 10,
+      "behaviorImpact": "Affects get_instruments_instruments__get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "limit",
+      "semanticId": "lotus.limit"
+    },
+    {
+      "name": "security_id",
+      "kind": "request_option",
+      "location": "query",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "The unique identifier for the security to query.",
+      "example": "SECURITY_001",
+      "behaviorImpact": "Affects get_prices_prices__get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "security_id",
+      "semanticId": "lotus.security_id"
+    },
+    {
+      "name": "start_date",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "The start date for the date range filter (inclusive).",
+      "example": "2026-02-27",
+      "behaviorImpact": "Affects get_prices_prices__get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "start_date",
+      "semanticId": "lotus.start_date"
+    },
+    {
+      "name": "end_date",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "The end date for the date range filter (inclusive).",
+      "example": "2026-02-27",
+      "behaviorImpact": "Affects get_prices_prices__get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "end_date",
+      "semanticId": "lotus.end_date"
+    },
+    {
+      "name": "from_currency",
+      "kind": "request_option",
+      "location": "query",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "The base currency (e.g., USD).",
+      "example": "USD",
+      "behaviorImpact": "Affects get_fx_rates_fx_rates__get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "from_currency",
+      "semanticId": "lotus.from_currency"
+    },
+    {
+      "name": "to_currency",
+      "kind": "request_option",
+      "location": "query",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "The quote currency (e.g., SGD).",
+      "example": "USD",
+      "behaviorImpact": "Affects get_fx_rates_fx_rates__get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "to_currency",
+      "semanticId": "lotus.to_currency"
+    },
+    {
+      "name": "start_date",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "The start date for the date range filter (inclusive).",
+      "example": "2026-02-27",
+      "behaviorImpact": "Affects get_fx_rates_fx_rates__get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "start_date",
+      "semanticId": "lotus.start_date"
+    },
+    {
+      "name": "end_date",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "The end date for the date range filter (inclusive).",
+      "example": "2026-02-27",
+      "behaviorImpact": "Affects get_fx_rates_fx_rates__get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "end_date",
+      "semanticId": "lotus.end_date"
+    },
+    {
+      "name": "portfolio_id",
+      "kind": "request_option",
+      "location": "path",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "Unique portfolio identifier.",
+      "example": "PORTFOLIO_001",
+      "behaviorImpact": "Affects get_support_overview_support_portfolios__portfolio_id__overview_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "portfolio_id",
+      "semanticId": "lotus.portfolio_id"
+    },
+    {
+      "name": "portfolio_id",
+      "kind": "request_option",
+      "location": "path",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "Unique portfolio identifier.",
+      "example": "PORTFOLIO_001",
+      "behaviorImpact": "Affects get_valuation_jobs_support_portfolios__portfolio_id__valuation_jobs_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "portfolio_id",
+      "semanticId": "lotus.portfolio_id"
+    },
+    {
+      "name": "status_filter",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Optional job status filter (e.g., PENDING, PROCESSING).",
+      "example": "ACTIVE",
+      "behaviorImpact": "Affects get_valuation_jobs_support_portfolios__portfolio_id__valuation_jobs_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "status_filter",
+      "semanticId": "lotus.status_filter"
+    },
+    {
+      "name": "skip",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 0,
+      "allowedValues": [],
+      "description": "Pagination offset.",
+      "example": 10,
+      "behaviorImpact": "Affects get_valuation_jobs_support_portfolios__portfolio_id__valuation_jobs_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "skip",
+      "semanticId": "lotus.skip"
+    },
+    {
+      "name": "limit",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 100,
+      "allowedValues": [],
+      "description": "Pagination limit.",
+      "example": 10,
+      "behaviorImpact": "Affects get_valuation_jobs_support_portfolios__portfolio_id__valuation_jobs_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "limit",
+      "semanticId": "lotus.limit"
+    },
+    {
+      "name": "portfolio_id",
+      "kind": "request_option",
+      "location": "path",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "Unique portfolio identifier.",
+      "example": "PORTFOLIO_001",
+      "behaviorImpact": "Affects get_aggregation_jobs_support_portfolios__portfolio_id__aggregation_jobs_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "portfolio_id",
+      "semanticId": "lotus.portfolio_id"
+    },
+    {
+      "name": "status_filter",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Optional job status filter (e.g., PENDING, PROCESSING).",
+      "example": "ACTIVE",
+      "behaviorImpact": "Affects get_aggregation_jobs_support_portfolios__portfolio_id__aggregation_jobs_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "status_filter",
+      "semanticId": "lotus.status_filter"
+    },
+    {
+      "name": "skip",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 0,
+      "allowedValues": [],
+      "description": "Pagination offset.",
+      "example": 10,
+      "behaviorImpact": "Affects get_aggregation_jobs_support_portfolios__portfolio_id__aggregation_jobs_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "skip",
+      "semanticId": "lotus.skip"
+    },
+    {
+      "name": "limit",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 100,
+      "allowedValues": [],
+      "description": "Pagination limit.",
+      "example": 10,
+      "behaviorImpact": "Affects get_aggregation_jobs_support_portfolios__portfolio_id__aggregation_jobs_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "limit",
+      "semanticId": "lotus.limit"
+    },
+    {
+      "name": "portfolio_id",
+      "kind": "request_option",
+      "location": "path",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "Unique portfolio identifier.",
+      "example": "PORTFOLIO_001",
+      "behaviorImpact": "Affects get_lineage_lineage_portfolios__portfolio_id__securities__security_id__get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "portfolio_id",
+      "semanticId": "lotus.portfolio_id"
+    },
+    {
+      "name": "security_id",
+      "kind": "request_option",
+      "location": "path",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "Unique security identifier.",
+      "example": "SECURITY_001",
+      "behaviorImpact": "Affects get_lineage_lineage_portfolios__portfolio_id__securities__security_id__get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "security_id",
+      "semanticId": "lotus.security_id"
+    },
+    {
+      "name": "portfolio_id",
+      "kind": "request_option",
+      "location": "path",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "Unique portfolio identifier.",
+      "example": "PORTFOLIO_001",
+      "behaviorImpact": "Affects get_lineage_keys_lineage_portfolios__portfolio_id__keys_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "portfolio_id",
+      "semanticId": "lotus.portfolio_id"
+    },
+    {
+      "name": "reprocessing_status",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Optional status filter for lineage keys (e.g., CURRENT, REPROCESSING).",
+      "example": "ACTIVE",
+      "behaviorImpact": "Affects get_lineage_keys_lineage_portfolios__portfolio_id__keys_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "reprocessing_status",
+      "semanticId": "lotus.reprocessing_status"
+    },
+    {
+      "name": "security_id",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Optional security filter to narrow lineage key results.",
+      "example": "SECURITY_001",
+      "behaviorImpact": "Affects get_lineage_keys_lineage_portfolios__portfolio_id__keys_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "security_id",
+      "semanticId": "lotus.security_id"
+    },
+    {
+      "name": "skip",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 0,
+      "allowedValues": [],
+      "description": "Pagination offset.",
+      "example": 10,
+      "behaviorImpact": "Affects get_lineage_keys_lineage_portfolios__portfolio_id__keys_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "skip",
+      "semanticId": "lotus.skip"
+    },
+    {
+      "name": "limit",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 100,
+      "allowedValues": [],
+      "description": "Pagination limit.",
+      "example": 10,
+      "behaviorImpact": "Affects get_lineage_keys_lineage_portfolios__portfolio_id__keys_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "limit",
+      "semanticId": "lotus.limit"
+    },
+    {
+      "name": "consumer_system",
+      "kind": "request_option",
+      "location": "query",
+      "type": "string",
+      "required": false,
+      "default": "lotus-gateway",
+      "allowedValues": [],
+      "description": "Canonical consumer system value used in request parameter.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects get_effective_integration_policy_integration_policy_effective_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "consumer_system",
+      "semanticId": "lotus.consumer_system"
+    },
+    {
+      "name": "tenant_id",
+      "kind": "request_option",
+      "location": "query",
+      "type": "string",
+      "required": false,
+      "default": "default",
+      "allowedValues": [],
+      "description": "Unique tenant identifier.",
+      "example": "TENANT_001",
+      "behaviorImpact": "Affects get_effective_integration_policy_integration_policy_effective_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "tenant_id",
+      "semanticId": "lotus.tenant_id"
+    },
+    {
+      "name": "include_sections",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Canonical include sections value used in request parameter.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects get_effective_integration_policy_integration_policy_effective_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "include_sections",
+      "semanticId": "lotus.include_sections"
+    },
+    {
+      "name": "portfolio_id",
+      "kind": "request_option",
+      "location": "path",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "Unique portfolio identifier.",
+      "example": "PORTFOLIO_001",
+      "behaviorImpact": "Affects create_core_snapshot_integration_portfolios__portfolio_id__core_snapshot_post request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "portfolio_id",
+      "semanticId": "lotus.portfolio_id"
+    },
+    {
+      "name": "consumer_system",
+      "kind": "request_option",
+      "location": "query",
+      "type": "string",
+      "required": false,
+      "default": "lotus-gateway",
+      "allowedValues": [
+        "lotus-gateway",
+        "lotus-performance",
+        "lotus-manage",
+        "UI",
+        "UNKNOWN"
+      ],
+      "description": "Consumer requesting capability metadata (lotus-gateway, lotus-manage, UI, UNKNOWN).",
+      "example": "lotus-gateway",
+      "behaviorImpact": "Affects get_integration_capabilities_integration_capabilities_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "consumer_system",
+      "semanticId": "lotus.consumer_system"
+    },
+    {
+      "name": "tenant_id",
+      "kind": "request_option",
+      "location": "query",
+      "type": "string",
+      "required": false,
+      "default": "default",
+      "allowedValues": [],
+      "description": "Tenant or client identifier for policy resolution.",
+      "example": "TENANT_001",
+      "behaviorImpact": "Affects get_integration_capabilities_integration_capabilities_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "tenant_id",
+      "semanticId": "lotus.tenant_id"
+    },
+    {
+      "name": "client_id",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Optional CIF filter for tenant/client scoping.",
+      "example": "CLIENT_001",
+      "behaviorImpact": "Affects get_portfolio_lookups_lookups_portfolios_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "client_id",
+      "semanticId": "lotus.client_id"
+    },
+    {
+      "name": "booking_center_code",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Optional booking-center filter for business-unit specific catalogs.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects get_portfolio_lookups_lookups_portfolios_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "booking_center_code",
+      "semanticId": "lotus.booking_center_code"
+    },
+    {
+      "name": "q",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Optional case-insensitive search text applied to portfolio ID.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects get_portfolio_lookups_lookups_portfolios_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "q",
+      "semanticId": "lotus.q"
+    },
+    {
+      "name": "limit",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 500,
+      "allowedValues": [],
+      "description": "Canonical limit value used in request parameter.",
+      "example": 10,
+      "behaviorImpact": "Affects get_portfolio_lookups_lookups_portfolios_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "limit",
+      "semanticId": "lotus.limit"
+    },
+    {
+      "name": "limit",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 200,
+      "allowedValues": [],
+      "description": "Canonical limit value used in request parameter.",
+      "example": 10,
+      "behaviorImpact": "Affects get_instrument_lookups_lookups_instruments_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "limit",
+      "semanticId": "lotus.limit"
+    },
+    {
+      "name": "product_type",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Optional product type filter (for example: Equity, Bond).",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects get_instrument_lookups_lookups_instruments_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "product_type",
+      "semanticId": "lotus.product_type"
+    },
+    {
+      "name": "q",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Optional case-insensitive search text applied to security ID and instrument name.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects get_instrument_lookups_lookups_instruments_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "q",
+      "semanticId": "lotus.q"
+    },
+    {
+      "name": "instrument_page_limit",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 500,
+      "allowedValues": [],
+      "description": "Canonical instrument page limit value used in request parameter.",
+      "example": 10,
+      "behaviorImpact": "Affects get_currency_lookups_lookups_currencies_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "instrument_page_limit",
+      "semanticId": "lotus.instrument_page_limit"
+    },
+    {
+      "name": "source",
+      "kind": "request_option",
+      "location": "query",
+      "type": "string",
+      "required": false,
+      "default": "ALL",
+      "allowedValues": [],
+      "description": "Currency source scope. Use ALL, PORTFOLIOS, or INSTRUMENTS.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects get_currency_lookups_lookups_currencies_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "source",
+      "semanticId": "lotus.source"
+    },
+    {
+      "name": "q",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Optional case-insensitive search text applied to currency code.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects get_currency_lookups_lookups_currencies_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "q",
+      "semanticId": "lotus.q"
+    },
+    {
+      "name": "limit",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 500,
+      "allowedValues": [],
+      "description": "Canonical limit value used in request parameter.",
+      "example": 10,
+      "behaviorImpact": "Affects get_currency_lookups_lookups_currencies_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "limit",
+      "semanticId": "lotus.limit"
+    },
+    {
+      "name": "session_id",
+      "kind": "request_option",
+      "location": "path",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "Unique session identifier.",
+      "example": "SESSION_001",
+      "behaviorImpact": "Affects get_simulation_session_simulation_sessions__session_id__get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "session_id",
+      "semanticId": "lotus.session_id"
+    },
+    {
+      "name": "session_id",
+      "kind": "request_option",
+      "location": "path",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "Unique session identifier.",
+      "example": "SESSION_001",
+      "behaviorImpact": "Affects close_simulation_session_simulation_sessions__session_id__delete request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "session_id",
+      "semanticId": "lotus.session_id"
+    },
+    {
+      "name": "session_id",
+      "kind": "request_option",
+      "location": "path",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "Unique session identifier.",
+      "example": "SESSION_001",
+      "behaviorImpact": "Affects add_simulation_changes_simulation_sessions__session_id__changes_post request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "session_id",
+      "semanticId": "lotus.session_id"
+    },
+    {
+      "name": "session_id",
+      "kind": "request_option",
+      "location": "path",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "Unique session identifier.",
+      "example": "SESSION_001",
+      "behaviorImpact": "Affects delete_simulation_change_simulation_sessions__session_id__changes__change_id__delete request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "session_id",
+      "semanticId": "lotus.session_id"
+    },
+    {
+      "name": "change_id",
+      "kind": "request_option",
+      "location": "path",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "Unique change identifier.",
+      "example": "CHANGE_001",
+      "behaviorImpact": "Affects delete_simulation_change_simulation_sessions__session_id__changes__change_id__delete request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "change_id",
+      "semanticId": "lotus.change_id"
+    },
+    {
+      "name": "session_id",
+      "kind": "request_option",
+      "location": "path",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "Unique session identifier.",
+      "example": "SESSION_001",
+      "behaviorImpact": "Affects get_projected_positions_simulation_sessions__session_id__projected_positions_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "session_id",
+      "semanticId": "lotus.session_id"
+    },
+    {
+      "name": "session_id",
+      "kind": "request_option",
+      "location": "path",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "Unique session identifier.",
+      "example": "SESSION_001",
+      "behaviorImpact": "Affects get_projected_summary_simulation_sessions__session_id__projected_summary_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "session_id",
+      "semanticId": "lotus.session_id"
+    },
+    {
+      "name": "LOTUS_CORE_CAP_SUPPORT_APIS_ENABLED",
+      "kind": "feature_toggle",
+      "default": true,
+      "description": "Toggles support overview capability exposure.",
+      "affects": [
+        "lotus_core.support.overview_api"
+      ],
+      "exposure": "server_side",
+      "canonicalTerm": "lotus_core_cap_support_apis_enabled",
+      "semanticId": "lotus.lotus_core_cap_support_apis_enabled"
+    },
+    {
+      "name": "LOTUS_CORE_CAP_LINEAGE_APIS_ENABLED",
+      "kind": "feature_toggle",
+      "default": true,
+      "description": "Toggles lineage capability exposure.",
+      "affects": [
+        "lotus_core.support.lineage_api"
+      ],
+      "exposure": "server_side",
+      "canonicalTerm": "lotus_core_cap_lineage_apis_enabled",
+      "semanticId": "lotus.lotus_core_cap_lineage_apis_enabled"
+    },
+    {
+      "name": "LOTUS_CORE_CAP_UPLOAD_APIS_ENABLED",
+      "kind": "feature_toggle",
+      "default": true,
+      "description": "Toggles bulk upload capability exposure.",
+      "affects": [
+        "lotus_core.ingestion.bulk_upload"
+      ],
+      "exposure": "server_side",
+      "canonicalTerm": "lotus_core_cap_upload_apis_enabled",
+      "semanticId": "lotus.lotus_core_cap_upload_apis_enabled"
+    },
+    {
+      "name": "LOTUS_CORE_CAP_SIMULATION_ENABLED",
+      "kind": "feature_toggle",
+      "default": true,
+      "description": "Toggles simulation capability exposure.",
+      "affects": [
+        "lotus_core.simulation.what_if"
+      ],
+      "exposure": "server_side",
+      "canonicalTerm": "lotus_core_cap_simulation_enabled",
+      "semanticId": "lotus.lotus_core_cap_simulation_enabled"
+    },
+    {
+      "name": "LOTUS_CORE_CAPABILITY_TENANT_OVERRIDES_JSON",
+      "kind": "service_policy",
+      "default": "{}",
+      "description": "Tenant-level capability and workflow override policy.",
+      "affects": [
+        "/integration/capabilities"
+      ],
+      "exposure": "server_side",
+      "canonicalTerm": "lotus_core_capability_tenant_overrides_json",
+      "semanticId": "lotus.lotus_core_capability_tenant_overrides_json"
+    },
+    {
+      "name": "LOTUS_CORE_POLICY_VERSION",
+      "kind": "service_policy",
+      "default": "tenant-default-v1",
+      "description": "Policy version surfaced in capabilities and policy metadata.",
+      "affects": [
+        "policy_version",
+        "policy_provenance.policy_version"
+      ],
+      "exposure": "server_side",
+      "canonicalTerm": "lotus_core_policy_version",
+      "semanticId": "lotus.lotus_core_policy_version"
+    },
+    {
+      "name": "LOTUS_CORE_INTEGRATION_SNAPSHOT_POLICY_JSON",
+      "kind": "service_policy",
+      "default": "{}",
+      "description": "Integration policy controlling allowed sections and strict mode.",
+      "affects": [
+        "/integration/policy/effective",
+        "allowed_sections",
+        "warnings"
+      ],
+      "exposure": "server_side",
+      "canonicalTerm": "lotus_core_integration_snapshot_policy_json",
+      "semanticId": "lotus.lotus_core_integration_snapshot_policy_json"
+    }
+  ],
+  "endpoints": [
+    {
+      "operationId": "metrics_metrics_get",
+      "method": "GET",
+      "path": "/metrics",
+      "domain": "monitoring",
+      "serviceGroup": "query",
+      "tags": [
+        "Monitoring"
+      ],
+      "summary": "Metrics",
+      "description": "Endpoint that serves Prometheus metrics.",
+      "naming": {
+        "boundedContext": "monitoring",
+        "canonicalTerms": []
+      },
+      "request": {
+        "fields": []
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": null,
+        "fields": []
+      }
+    },
+    {
+      "operationId": "liveness_probe_health_live_get",
+      "method": "GET",
+      "path": "/health/live",
+      "domain": "health",
+      "serviceGroup": "query",
+      "tags": [
+        "Health"
+      ],
+      "summary": "Liveness Probe",
+      "description": "GET operation for /health/live in query_service.",
+      "naming": {
+        "boundedContext": "health",
+        "canonicalTerms": []
+      },
+      "request": {
+        "fields": []
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "object",
+        "fields": []
+      }
+    },
+    {
+      "operationId": "readiness_probe_health_ready_get",
+      "method": "GET",
+      "path": "/health/ready",
+      "domain": "health",
+      "serviceGroup": "query",
+      "tags": [
+        "Health"
+      ],
+      "summary": "Readiness Probe",
+      "description": "GET operation for /health/ready in query_service.",
+      "naming": {
+        "boundedContext": "health",
+        "canonicalTerms": []
+      },
+      "request": {
+        "fields": []
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "object",
+        "fields": []
+      }
+    },
+    {
+      "operationId": "get_portfolios_portfolios__get",
+      "method": "GET",
+      "path": "/portfolios/",
+      "domain": "portfolios",
+      "serviceGroup": "query",
+      "tags": [
+        "Portfolios"
+      ],
+      "summary": "Get Portfolio Details",
+      "description": "Returns portfolios with optional filtering by portfolio ID, CIF, and booking center. Used by UI/lotus-gateway for portfolio discovery and navigation.",
+      "naming": {
+        "boundedContext": "portfolios",
+        "canonicalTerms": [
+          "advisor_id",
+          "base_currency",
+          "booking_center_code",
+          "client_id",
+          "close_date",
+          "investment_time_horizon",
+          "is_leverage_allowed",
+          "objective",
+          "open_date",
+          "portfolio_id",
+          "portfolio_type",
+          "portfolios",
+          "risk_exposure",
+          "status"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "client_id",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.client_id",
+            "attributeRef": "lotus.client_id"
+          },
+          {
+            "name": "booking_center_code",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.booking_center_code",
+            "attributeRef": "lotus.booking_center_code"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "PortfolioQueryResponse",
+        "fields": [
+          {
+            "name": "portfolios",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.portfolios",
+            "attributeRef": "lotus.portfolios"
+          },
+          {
+            "name": "portfolios[].portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "portfolios[].base_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.base_currency",
+            "attributeRef": "lotus.base_currency"
+          },
+          {
+            "name": "portfolios[].open_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.open_date",
+            "attributeRef": "lotus.open_date"
+          },
+          {
+            "name": "portfolios[].close_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.close_date",
+            "attributeRef": "lotus.close_date"
+          },
+          {
+            "name": "portfolios[].risk_exposure",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.risk_exposure",
+            "attributeRef": "lotus.risk_exposure"
+          },
+          {
+            "name": "portfolios[].investment_time_horizon",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.investment_time_horizon",
+            "attributeRef": "lotus.investment_time_horizon"
+          },
+          {
+            "name": "portfolios[].portfolio_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_type",
+            "attributeRef": "lotus.portfolio_type"
+          },
+          {
+            "name": "portfolios[].objective",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.objective",
+            "attributeRef": "lotus.objective"
+          },
+          {
+            "name": "portfolios[].booking_center_code",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.booking_center_code",
+            "attributeRef": "lotus.booking_center_code"
+          },
+          {
+            "name": "portfolios[].client_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.client_id",
+            "attributeRef": "lotus.client_id"
+          },
+          {
+            "name": "portfolios[].is_leverage_allowed",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.is_leverage_allowed",
+            "attributeRef": "lotus.is_leverage_allowed"
+          },
+          {
+            "name": "portfolios[].advisor_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.advisor_id",
+            "attributeRef": "lotus.advisor_id"
+          },
+          {
+            "name": "portfolios[].status",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.status",
+            "attributeRef": "lotus.status"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_portfolio_by_id_portfolios__portfolio_id__get",
+      "method": "GET",
+      "path": "/portfolios/{portfolio_id}",
+      "domain": "portfolios",
+      "serviceGroup": "query",
+      "tags": [
+        "Portfolios"
+      ],
+      "summary": "Get a Single Portfolio by ID",
+      "description": "Retrieves a single portfolio by its unique ID.\nReturns a `404 Not Found` if the portfolio does not exist.",
+      "naming": {
+        "boundedContext": "portfolios",
+        "canonicalTerms": [
+          "advisor_id",
+          "base_currency",
+          "booking_center_code",
+          "client_id",
+          "close_date",
+          "investment_time_horizon",
+          "is_leverage_allowed",
+          "objective",
+          "open_date",
+          "portfolio_id",
+          "portfolio_type",
+          "risk_exposure",
+          "status"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "PortfolioRecord",
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "base_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.base_currency",
+            "attributeRef": "lotus.base_currency"
+          },
+          {
+            "name": "open_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.open_date",
+            "attributeRef": "lotus.open_date"
+          },
+          {
+            "name": "close_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.close_date",
+            "attributeRef": "lotus.close_date"
+          },
+          {
+            "name": "risk_exposure",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.risk_exposure",
+            "attributeRef": "lotus.risk_exposure"
+          },
+          {
+            "name": "investment_time_horizon",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.investment_time_horizon",
+            "attributeRef": "lotus.investment_time_horizon"
+          },
+          {
+            "name": "portfolio_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_type",
+            "attributeRef": "lotus.portfolio_type"
+          },
+          {
+            "name": "objective",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.objective",
+            "attributeRef": "lotus.objective"
+          },
+          {
+            "name": "booking_center_code",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.booking_center_code",
+            "attributeRef": "lotus.booking_center_code"
+          },
+          {
+            "name": "client_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.client_id",
+            "attributeRef": "lotus.client_id"
+          },
+          {
+            "name": "is_leverage_allowed",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.is_leverage_allowed",
+            "attributeRef": "lotus.is_leverage_allowed"
+          },
+          {
+            "name": "advisor_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.advisor_id",
+            "attributeRef": "lotus.advisor_id"
+          },
+          {
+            "name": "status",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.status",
+            "attributeRef": "lotus.status"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_position_history_portfolios__portfolio_id__position_history_get",
+      "method": "GET",
+      "path": "/portfolios/{portfolio_id}/position-history",
+      "domain": "positions",
+      "serviceGroup": "query",
+      "tags": [
+        "Positions"
+      ],
+      "summary": "Get Position History for a Security",
+      "description": "Returns epoch-aware position history for a portfolio-security key across a date range. Used for drill-down views and lineage-aware troubleshooting.",
+      "naming": {
+        "boundedContext": "positions",
+        "canonicalTerms": [
+          "cost_basis",
+          "cost_basis_local",
+          "end_date",
+          "portfolio_id",
+          "position_date",
+          "positions",
+          "quantity",
+          "reprocessing_status",
+          "security_id",
+          "start_date",
+          "transaction_id",
+          "valuation"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "security_id",
+            "location": "query",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "start_date",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.start_date",
+            "attributeRef": "lotus.start_date"
+          },
+          {
+            "name": "end_date",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.end_date",
+            "attributeRef": "lotus.end_date"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "PortfolioPositionHistoryResponse",
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "security_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "positions",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.positions",
+            "attributeRef": "lotus.positions"
+          },
+          {
+            "name": "positions[].position_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.position_date",
+            "attributeRef": "lotus.position_date"
+          },
+          {
+            "name": "positions[].transaction_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.transaction_id",
+            "attributeRef": "lotus.transaction_id"
+          },
+          {
+            "name": "positions[].quantity",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.quantity",
+            "attributeRef": "lotus.quantity"
+          },
+          {
+            "name": "positions[].cost_basis",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.cost_basis",
+            "attributeRef": "lotus.cost_basis"
+          },
+          {
+            "name": "positions[].cost_basis_local",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.cost_basis_local",
+            "attributeRef": "lotus.cost_basis_local"
+          },
+          {
+            "name": "positions[].valuation",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.valuation",
+            "attributeRef": "lotus.valuation"
+          },
+          {
+            "name": "positions[].reprocessing_status",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.reprocessing_status",
+            "attributeRef": "lotus.reprocessing_status"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_latest_positions_portfolios__portfolio_id__positions_get",
+      "method": "GET",
+      "path": "/portfolios/{portfolio_id}/positions",
+      "domain": "positions",
+      "serviceGroup": "query",
+      "tags": [
+        "Positions"
+      ],
+      "summary": "Get Latest Positions for a Portfolio",
+      "description": "Returns latest current-epoch positions for a portfolio. Used by holdings screens and downstream review/analytics flows.",
+      "naming": {
+        "boundedContext": "positions",
+        "canonicalTerms": [
+          "asset_class",
+          "cost_basis",
+          "cost_basis_local",
+          "country_of_risk",
+          "currency",
+          "held_since_date",
+          "instrument_name",
+          "isin",
+          "portfolio_id",
+          "position_date",
+          "positions",
+          "quantity",
+          "reprocessing_status",
+          "sector",
+          "security_id",
+          "valuation",
+          "weight"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "PortfolioPositionsResponse",
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "positions",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.positions",
+            "attributeRef": "lotus.positions"
+          },
+          {
+            "name": "positions[].security_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "positions[].quantity",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.quantity",
+            "attributeRef": "lotus.quantity"
+          },
+          {
+            "name": "positions[].instrument_name",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.instrument_name",
+            "attributeRef": "lotus.instrument_name"
+          },
+          {
+            "name": "positions[].position_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.position_date",
+            "attributeRef": "lotus.position_date"
+          },
+          {
+            "name": "positions[].asset_class",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.asset_class",
+            "attributeRef": "lotus.asset_class"
+          },
+          {
+            "name": "positions[].isin",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.isin",
+            "attributeRef": "lotus.isin"
+          },
+          {
+            "name": "positions[].currency",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.currency",
+            "attributeRef": "lotus.currency"
+          },
+          {
+            "name": "positions[].sector",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.sector",
+            "attributeRef": "lotus.sector"
+          },
+          {
+            "name": "positions[].country_of_risk",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.country_of_risk",
+            "attributeRef": "lotus.country_of_risk"
+          },
+          {
+            "name": "positions[].cost_basis",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.cost_basis",
+            "attributeRef": "lotus.cost_basis"
+          },
+          {
+            "name": "positions[].cost_basis_local",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.cost_basis_local",
+            "attributeRef": "lotus.cost_basis_local"
+          },
+          {
+            "name": "positions[].valuation",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.valuation",
+            "attributeRef": "lotus.valuation"
+          },
+          {
+            "name": "positions[].reprocessing_status",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.reprocessing_status",
+            "attributeRef": "lotus.reprocessing_status"
+          },
+          {
+            "name": "positions[].held_since_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.held_since_date",
+            "attributeRef": "lotus.held_since_date"
+          },
+          {
+            "name": "positions[].weight",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.weight",
+            "attributeRef": "lotus.weight"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_transactions_portfolios__portfolio_id__transactions_get",
+      "method": "GET",
+      "path": "/portfolios/{portfolio_id}/transactions",
+      "domain": "transactions",
+      "serviceGroup": "query",
+      "tags": [
+        "Transactions"
+      ],
+      "summary": "Get Transactions for a Portfolio",
+      "description": "Returns transactions for a portfolio with filters, pagination, and sorting. Designed for transaction ledgers, audit timelines, and investigative support.",
+      "naming": {
+        "boundedContext": "transactions",
+        "canonicalTerms": [
+          "cashflow",
+          "currency",
+          "end_date",
+          "gross_transaction_amount",
+          "instrument_id",
+          "limit",
+          "net_cost",
+          "net_cost_local",
+          "portfolio_id",
+          "price",
+          "quantity",
+          "realized_gain_loss",
+          "realized_gain_loss_local",
+          "security_id",
+          "skip",
+          "sort_by",
+          "sort_order",
+          "start_date",
+          "total",
+          "transaction_date",
+          "transaction_fx_rate",
+          "transaction_id",
+          "transaction_type",
+          "transactions"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "security_id",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "start_date",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.start_date",
+            "attributeRef": "lotus.start_date"
+          },
+          {
+            "name": "end_date",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.end_date",
+            "attributeRef": "lotus.end_date"
+          },
+          {
+            "name": "skip",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.skip",
+            "attributeRef": "lotus.skip"
+          },
+          {
+            "name": "limit",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.limit",
+            "attributeRef": "lotus.limit"
+          },
+          {
+            "name": "sort_by",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.sort_by",
+            "attributeRef": "lotus.sort_by"
+          },
+          {
+            "name": "sort_order",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.sort_order",
+            "attributeRef": "lotus.sort_order"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "PaginatedTransactionResponse",
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "total",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.total",
+            "attributeRef": "lotus.total"
+          },
+          {
+            "name": "skip",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.skip",
+            "attributeRef": "lotus.skip"
+          },
+          {
+            "name": "limit",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.limit",
+            "attributeRef": "lotus.limit"
+          },
+          {
+            "name": "transactions",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.transactions",
+            "attributeRef": "lotus.transactions"
+          },
+          {
+            "name": "transactions[].transaction_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.transaction_id",
+            "attributeRef": "lotus.transaction_id"
+          },
+          {
+            "name": "transactions[].transaction_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.transaction_date",
+            "attributeRef": "lotus.transaction_date"
+          },
+          {
+            "name": "transactions[].transaction_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.transaction_type",
+            "attributeRef": "lotus.transaction_type"
+          },
+          {
+            "name": "transactions[].instrument_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.instrument_id",
+            "attributeRef": "lotus.instrument_id"
+          },
+          {
+            "name": "transactions[].security_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "transactions[].quantity",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.quantity",
+            "attributeRef": "lotus.quantity"
+          },
+          {
+            "name": "transactions[].price",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.price",
+            "attributeRef": "lotus.price"
+          },
+          {
+            "name": "transactions[].gross_transaction_amount",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.gross_transaction_amount",
+            "attributeRef": "lotus.gross_transaction_amount"
+          },
+          {
+            "name": "transactions[].currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.currency",
+            "attributeRef": "lotus.currency"
+          },
+          {
+            "name": "transactions[].net_cost",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.net_cost",
+            "attributeRef": "lotus.net_cost"
+          },
+          {
+            "name": "transactions[].realized_gain_loss",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.realized_gain_loss",
+            "attributeRef": "lotus.realized_gain_loss"
+          },
+          {
+            "name": "transactions[].net_cost_local",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.net_cost_local",
+            "attributeRef": "lotus.net_cost_local"
+          },
+          {
+            "name": "transactions[].realized_gain_loss_local",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.realized_gain_loss_local",
+            "attributeRef": "lotus.realized_gain_loss_local"
+          },
+          {
+            "name": "transactions[].transaction_fx_rate",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.transaction_fx_rate",
+            "attributeRef": "lotus.transaction_fx_rate"
+          },
+          {
+            "name": "transactions[].cashflow",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.cashflow",
+            "attributeRef": "lotus.cashflow"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_instruments_instruments__get",
+      "method": "GET",
+      "path": "/instruments/",
+      "domain": "instruments",
+      "serviceGroup": "query",
+      "tags": [
+        "Instruments"
+      ],
+      "summary": "Get a List of Instruments",
+      "description": "Returns reference instrument records with optional filtering by security and product type. Used by lookup selectors and enrichment workflows.",
+      "naming": {
+        "boundedContext": "instruments",
+        "canonicalTerms": [
+          "asset_class",
+          "currency",
+          "instruments",
+          "isin",
+          "limit",
+          "name",
+          "product_type",
+          "security_id",
+          "skip",
+          "total"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "security_id",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "product_type",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.product_type",
+            "attributeRef": "lotus.product_type"
+          },
+          {
+            "name": "skip",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.skip",
+            "attributeRef": "lotus.skip"
+          },
+          {
+            "name": "limit",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.limit",
+            "attributeRef": "lotus.limit"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "PaginatedInstrumentResponse",
+        "fields": [
+          {
+            "name": "total",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.total",
+            "attributeRef": "lotus.total"
+          },
+          {
+            "name": "skip",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.skip",
+            "attributeRef": "lotus.skip"
+          },
+          {
+            "name": "limit",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.limit",
+            "attributeRef": "lotus.limit"
+          },
+          {
+            "name": "instruments",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.instruments",
+            "attributeRef": "lotus.instruments"
+          },
+          {
+            "name": "instruments[].security_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "instruments[].name",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.name",
+            "attributeRef": "lotus.name"
+          },
+          {
+            "name": "instruments[].isin",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.isin",
+            "attributeRef": "lotus.isin"
+          },
+          {
+            "name": "instruments[].currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.currency",
+            "attributeRef": "lotus.currency"
+          },
+          {
+            "name": "instruments[].product_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.product_type",
+            "attributeRef": "lotus.product_type"
+          },
+          {
+            "name": "instruments[].asset_class",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.asset_class",
+            "attributeRef": "lotus.asset_class"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_prices_prices__get",
+      "method": "GET",
+      "path": "/prices/",
+      "domain": "market_prices",
+      "serviceGroup": "query",
+      "tags": [
+        "Market Prices"
+      ],
+      "summary": "Get Market Prices for a Security",
+      "description": "Returns market price series for a security with optional date-range filtering. Used by valuation checks and market data diagnostics.",
+      "naming": {
+        "boundedContext": "market_prices",
+        "canonicalTerms": [
+          "currency",
+          "end_date",
+          "price",
+          "price_date",
+          "prices",
+          "security_id",
+          "start_date"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "security_id",
+            "location": "query",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "start_date",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.start_date",
+            "attributeRef": "lotus.start_date"
+          },
+          {
+            "name": "end_date",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.end_date",
+            "attributeRef": "lotus.end_date"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "MarketPriceResponse",
+        "fields": [
+          {
+            "name": "security_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "prices",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.prices",
+            "attributeRef": "lotus.prices"
+          },
+          {
+            "name": "prices[].price_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.price_date",
+            "attributeRef": "lotus.price_date"
+          },
+          {
+            "name": "prices[].price",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.price",
+            "attributeRef": "lotus.price"
+          },
+          {
+            "name": "prices[].currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.currency",
+            "attributeRef": "lotus.currency"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_fx_rates_fx_rates__get",
+      "method": "GET",
+      "path": "/fx-rates/",
+      "domain": "fx_rates",
+      "serviceGroup": "query",
+      "tags": [
+        "FX Rates"
+      ],
+      "summary": "Get FX Rates for a Currency Pair",
+      "description": "Returns FX rates for a currency pair over an optional date range. Used by valuation/performance conversion diagnostics and reconciliation.",
+      "naming": {
+        "boundedContext": "fx_rates",
+        "canonicalTerms": [
+          "end_date",
+          "from_currency",
+          "rate",
+          "rate_date",
+          "rates",
+          "start_date",
+          "to_currency"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "from_currency",
+            "location": "query",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.from_currency",
+            "attributeRef": "lotus.from_currency"
+          },
+          {
+            "name": "to_currency",
+            "location": "query",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.to_currency",
+            "attributeRef": "lotus.to_currency"
+          },
+          {
+            "name": "start_date",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.start_date",
+            "attributeRef": "lotus.start_date"
+          },
+          {
+            "name": "end_date",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.end_date",
+            "attributeRef": "lotus.end_date"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "FxRateResponse",
+        "fields": [
+          {
+            "name": "from_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.from_currency",
+            "attributeRef": "lotus.from_currency"
+          },
+          {
+            "name": "to_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.to_currency",
+            "attributeRef": "lotus.to_currency"
+          },
+          {
+            "name": "rates",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.rates",
+            "attributeRef": "lotus.rates"
+          },
+          {
+            "name": "rates[].rate_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.rate_date",
+            "attributeRef": "lotus.rate_date"
+          },
+          {
+            "name": "rates[].rate",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.rate",
+            "attributeRef": "lotus.rate"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_support_overview_support_portfolios__portfolio_id__overview_get",
+      "method": "GET",
+      "path": "/support/portfolios/{portfolio_id}/overview",
+      "domain": "operations_support",
+      "serviceGroup": "query",
+      "tags": [
+        "Operations Support"
+      ],
+      "summary": "Get operational support overview for a portfolio",
+      "description": "Returns support-oriented operational state for a portfolio, including reprocessing/valuation queue indicators and latest data availability markers.",
+      "naming": {
+        "boundedContext": "operations_support",
+        "canonicalTerms": [
+          "active_reprocessing_keys",
+          "current_epoch",
+          "latest_position_snapshot_date",
+          "latest_transaction_date",
+          "pending_aggregation_jobs",
+          "pending_valuation_jobs",
+          "portfolio_id"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "SupportOverviewResponse",
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "current_epoch",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.current_epoch",
+            "attributeRef": "lotus.current_epoch"
+          },
+          {
+            "name": "active_reprocessing_keys",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.active_reprocessing_keys",
+            "attributeRef": "lotus.active_reprocessing_keys"
+          },
+          {
+            "name": "pending_valuation_jobs",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.pending_valuation_jobs",
+            "attributeRef": "lotus.pending_valuation_jobs"
+          },
+          {
+            "name": "pending_aggregation_jobs",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.pending_aggregation_jobs",
+            "attributeRef": "lotus.pending_aggregation_jobs"
+          },
+          {
+            "name": "latest_transaction_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.latest_transaction_date",
+            "attributeRef": "lotus.latest_transaction_date"
+          },
+          {
+            "name": "latest_position_snapshot_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.latest_position_snapshot_date",
+            "attributeRef": "lotus.latest_position_snapshot_date"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_valuation_jobs_support_portfolios__portfolio_id__valuation_jobs_get",
+      "method": "GET",
+      "path": "/support/portfolios/{portfolio_id}/valuation-jobs",
+      "domain": "operations_support",
+      "serviceGroup": "query",
+      "tags": [
+        "Operations Support"
+      ],
+      "summary": "List valuation jobs for support workflows",
+      "description": "Returns valuation jobs for a portfolio with pagination and optional status filtering. Designed for operations/support dashboards.",
+      "naming": {
+        "boundedContext": "operations_support",
+        "canonicalTerms": [
+          "attempt_count",
+          "business_date",
+          "epoch",
+          "failure_reason",
+          "items",
+          "job_type",
+          "limit",
+          "portfolio_id",
+          "security_id",
+          "skip",
+          "status",
+          "status_filter",
+          "total"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "status_filter",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.status_filter",
+            "attributeRef": "lotus.status_filter"
+          },
+          {
+            "name": "skip",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.skip",
+            "attributeRef": "lotus.skip"
+          },
+          {
+            "name": "limit",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.limit",
+            "attributeRef": "lotus.limit"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "SupportJobListResponse",
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "total",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.total",
+            "attributeRef": "lotus.total"
+          },
+          {
+            "name": "skip",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.skip",
+            "attributeRef": "lotus.skip"
+          },
+          {
+            "name": "limit",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.limit",
+            "attributeRef": "lotus.limit"
+          },
+          {
+            "name": "items",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.items",
+            "attributeRef": "lotus.items"
+          },
+          {
+            "name": "items[].job_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.job_type",
+            "attributeRef": "lotus.job_type"
+          },
+          {
+            "name": "items[].business_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.business_date",
+            "attributeRef": "lotus.business_date"
+          },
+          {
+            "name": "items[].status",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.status",
+            "attributeRef": "lotus.status"
+          },
+          {
+            "name": "items[].security_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "items[].epoch",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.epoch",
+            "attributeRef": "lotus.epoch"
+          },
+          {
+            "name": "items[].attempt_count",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.attempt_count",
+            "attributeRef": "lotus.attempt_count"
+          },
+          {
+            "name": "items[].failure_reason",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.failure_reason",
+            "attributeRef": "lotus.failure_reason"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_aggregation_jobs_support_portfolios__portfolio_id__aggregation_jobs_get",
+      "method": "GET",
+      "path": "/support/portfolios/{portfolio_id}/aggregation-jobs",
+      "domain": "operations_support",
+      "serviceGroup": "query",
+      "tags": [
+        "Operations Support"
+      ],
+      "summary": "List aggregation jobs for support workflows",
+      "description": "Returns aggregation jobs for a portfolio with pagination and optional status filtering. Designed for operations/support dashboards.",
+      "naming": {
+        "boundedContext": "operations_support",
+        "canonicalTerms": [
+          "attempt_count",
+          "business_date",
+          "epoch",
+          "failure_reason",
+          "items",
+          "job_type",
+          "limit",
+          "portfolio_id",
+          "security_id",
+          "skip",
+          "status",
+          "status_filter",
+          "total"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "status_filter",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.status_filter",
+            "attributeRef": "lotus.status_filter"
+          },
+          {
+            "name": "skip",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.skip",
+            "attributeRef": "lotus.skip"
+          },
+          {
+            "name": "limit",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.limit",
+            "attributeRef": "lotus.limit"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "SupportJobListResponse",
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "total",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.total",
+            "attributeRef": "lotus.total"
+          },
+          {
+            "name": "skip",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.skip",
+            "attributeRef": "lotus.skip"
+          },
+          {
+            "name": "limit",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.limit",
+            "attributeRef": "lotus.limit"
+          },
+          {
+            "name": "items",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.items",
+            "attributeRef": "lotus.items"
+          },
+          {
+            "name": "items[].job_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.job_type",
+            "attributeRef": "lotus.job_type"
+          },
+          {
+            "name": "items[].business_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.business_date",
+            "attributeRef": "lotus.business_date"
+          },
+          {
+            "name": "items[].status",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.status",
+            "attributeRef": "lotus.status"
+          },
+          {
+            "name": "items[].security_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "items[].epoch",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.epoch",
+            "attributeRef": "lotus.epoch"
+          },
+          {
+            "name": "items[].attempt_count",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.attempt_count",
+            "attributeRef": "lotus.attempt_count"
+          },
+          {
+            "name": "items[].failure_reason",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.failure_reason",
+            "attributeRef": "lotus.failure_reason"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_lineage_lineage_portfolios__portfolio_id__securities__security_id__get",
+      "method": "GET",
+      "path": "/lineage/portfolios/{portfolio_id}/securities/{security_id}",
+      "domain": "operations_support",
+      "serviceGroup": "query",
+      "tags": [
+        "Operations Support"
+      ],
+      "summary": "Get lineage state for a portfolio-security key",
+      "description": "Returns lineage-relevant state (epoch, watermark, latest artifacts) for a specific portfolio-security key.",
+      "naming": {
+        "boundedContext": "operations_support",
+        "canonicalTerms": [
+          "epoch",
+          "latest_daily_snapshot_date",
+          "latest_position_history_date",
+          "latest_valuation_job_date",
+          "latest_valuation_job_status",
+          "portfolio_id",
+          "reprocessing_status",
+          "security_id",
+          "watermark_date"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "security_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "LineageResponse",
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "security_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "epoch",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.epoch",
+            "attributeRef": "lotus.epoch"
+          },
+          {
+            "name": "watermark_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.watermark_date",
+            "attributeRef": "lotus.watermark_date"
+          },
+          {
+            "name": "reprocessing_status",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.reprocessing_status",
+            "attributeRef": "lotus.reprocessing_status"
+          },
+          {
+            "name": "latest_position_history_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.latest_position_history_date",
+            "attributeRef": "lotus.latest_position_history_date"
+          },
+          {
+            "name": "latest_daily_snapshot_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.latest_daily_snapshot_date",
+            "attributeRef": "lotus.latest_daily_snapshot_date"
+          },
+          {
+            "name": "latest_valuation_job_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.latest_valuation_job_date",
+            "attributeRef": "lotus.latest_valuation_job_date"
+          },
+          {
+            "name": "latest_valuation_job_status",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.latest_valuation_job_status",
+            "attributeRef": "lotus.latest_valuation_job_status"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_lineage_keys_lineage_portfolios__portfolio_id__keys_get",
+      "method": "GET",
+      "path": "/lineage/portfolios/{portfolio_id}/keys",
+      "domain": "operations_support",
+      "serviceGroup": "query",
+      "tags": [
+        "Operations Support"
+      ],
+      "summary": "List lineage keys for a portfolio",
+      "description": "Returns current lineage keys (portfolio-security state rows) for a portfolio with pagination and optional status/security filtering.",
+      "naming": {
+        "boundedContext": "operations_support",
+        "canonicalTerms": [
+          "epoch",
+          "items",
+          "limit",
+          "portfolio_id",
+          "reprocessing_status",
+          "security_id",
+          "skip",
+          "total",
+          "watermark_date"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "reprocessing_status",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.reprocessing_status",
+            "attributeRef": "lotus.reprocessing_status"
+          },
+          {
+            "name": "security_id",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "skip",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.skip",
+            "attributeRef": "lotus.skip"
+          },
+          {
+            "name": "limit",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.limit",
+            "attributeRef": "lotus.limit"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "LineageKeyListResponse",
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "total",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.total",
+            "attributeRef": "lotus.total"
+          },
+          {
+            "name": "skip",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.skip",
+            "attributeRef": "lotus.skip"
+          },
+          {
+            "name": "limit",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.limit",
+            "attributeRef": "lotus.limit"
+          },
+          {
+            "name": "items",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.items",
+            "attributeRef": "lotus.items"
+          },
+          {
+            "name": "items[].security_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "items[].epoch",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.epoch",
+            "attributeRef": "lotus.epoch"
+          },
+          {
+            "name": "items[].watermark_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.watermark_date",
+            "attributeRef": "lotus.watermark_date"
+          },
+          {
+            "name": "items[].reprocessing_status",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.reprocessing_status",
+            "attributeRef": "lotus.reprocessing_status"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_effective_integration_policy_integration_policy_effective_get",
+      "method": "GET",
+      "path": "/integration/policy/effective",
+      "domain": "integration_contracts",
+      "serviceGroup": "query",
+      "tags": [
+        "Integration Contracts"
+      ],
+      "summary": "Get effective lotus-core integration policy",
+      "description": "Returns effective policy diagnostics and provenance for the given consumer and tenant context, including strict-mode behavior and allowed sections.",
+      "naming": {
+        "boundedContext": "integration_contracts",
+        "canonicalTerms": [
+          "allowed_sections",
+          "consumer_system",
+          "contract_version",
+          "generated_at",
+          "include_sections",
+          "matched_rule_id",
+          "policy_provenance",
+          "policy_source",
+          "policy_version",
+          "source_service",
+          "strict_mode",
+          "tenant_id",
+          "warnings"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "consumer_system",
+            "location": "query",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.consumer_system",
+            "attributeRef": "lotus.consumer_system"
+          },
+          {
+            "name": "tenant_id",
+            "location": "query",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.tenant_id",
+            "attributeRef": "lotus.tenant_id"
+          },
+          {
+            "name": "include_sections",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.include_sections",
+            "attributeRef": "lotus.include_sections"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "EffectiveIntegrationPolicyResponse",
+        "fields": [
+          {
+            "name": "contract_version",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.contract_version",
+            "attributeRef": "lotus.contract_version"
+          },
+          {
+            "name": "source_service",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.source_service",
+            "attributeRef": "lotus.source_service"
+          },
+          {
+            "name": "consumer_system",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.consumer_system",
+            "attributeRef": "lotus.consumer_system"
+          },
+          {
+            "name": "tenant_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.tenant_id",
+            "attributeRef": "lotus.tenant_id"
+          },
+          {
+            "name": "generated_at",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.generated_at",
+            "attributeRef": "lotus.generated_at"
+          },
+          {
+            "name": "policy_provenance",
+            "location": "body",
+            "required": true,
+            "type": "PolicyProvenanceMetadata",
+            "semanticId": "lotus.policy_provenance",
+            "attributeRef": "lotus.policy_provenance"
+          },
+          {
+            "name": "policy_provenance.policy_version",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.policy_version",
+            "attributeRef": "lotus.policy_version"
+          },
+          {
+            "name": "policy_provenance.policy_source",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.policy_source",
+            "attributeRef": "lotus.policy_source"
+          },
+          {
+            "name": "policy_provenance.matched_rule_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.matched_rule_id",
+            "attributeRef": "lotus.matched_rule_id"
+          },
+          {
+            "name": "policy_provenance.strict_mode",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.strict_mode",
+            "attributeRef": "lotus.strict_mode"
+          },
+          {
+            "name": "allowed_sections",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.allowed_sections",
+            "attributeRef": "lotus.allowed_sections"
+          },
+          {
+            "name": "warnings",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.warnings",
+            "attributeRef": "lotus.warnings"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "create_core_snapshot_integration_portfolios__portfolio_id__core_snapshot_post",
+      "method": "POST",
+      "path": "/integration/portfolios/{portfolio_id}/core-snapshot",
+      "domain": "integration_contracts",
+      "serviceGroup": "query",
+      "tags": [
+        "Integration Contracts"
+      ],
+      "summary": "Generate a generic core snapshot",
+      "description": "Returns baseline or simulation snapshot sections for an integration consumer. Supports positions baseline/projected/delta, portfolio totals, and instrument enrichment.",
+      "naming": {
+        "boundedContext": "integration_contracts",
+        "canonicalTerms": [
+          "as_of_date",
+          "generated_at",
+          "include_cash_positions",
+          "include_zero_quantity_positions",
+          "instrument_enrichment",
+          "options",
+          "portfolio_currency",
+          "portfolio_id",
+          "portfolio_totals",
+          "position_basis",
+          "positions_baseline",
+          "positions_delta",
+          "positions_projected",
+          "reporting_currency",
+          "sections",
+          "simulation",
+          "snapshot_mode",
+          "valuation_context",
+          "weight_basis"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "as_of_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.as_of_date",
+            "attributeRef": "lotus.as_of_date"
+          },
+          {
+            "name": "snapshot_mode",
+            "location": "body",
+            "required": false,
+            "type": "CoreSnapshotMode",
+            "semanticId": "lotus.snapshot_mode",
+            "attributeRef": "lotus.snapshot_mode"
+          },
+          {
+            "name": "reporting_currency",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.reporting_currency",
+            "attributeRef": "lotus.reporting_currency"
+          },
+          {
+            "name": "sections",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.sections",
+            "attributeRef": "lotus.sections"
+          },
+          {
+            "name": "simulation",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.simulation",
+            "attributeRef": "lotus.simulation"
+          },
+          {
+            "name": "options",
+            "location": "body",
+            "required": false,
+            "type": "CoreSnapshotRequestOptions",
+            "semanticId": "lotus.options",
+            "attributeRef": "lotus.options"
+          },
+          {
+            "name": "options.include_zero_quantity_positions",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.include_zero_quantity_positions",
+            "attributeRef": "lotus.include_zero_quantity_positions"
+          },
+          {
+            "name": "options.include_cash_positions",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.include_cash_positions",
+            "attributeRef": "lotus.include_cash_positions"
+          },
+          {
+            "name": "options.position_basis",
+            "location": "body",
+            "required": false,
+            "type": "CoreSnapshotPositionBasis",
+            "semanticId": "lotus.position_basis",
+            "attributeRef": "lotus.position_basis"
+          },
+          {
+            "name": "options.weight_basis",
+            "location": "body",
+            "required": false,
+            "type": "CoreSnapshotWeightBasis",
+            "semanticId": "lotus.weight_basis",
+            "attributeRef": "lotus.weight_basis"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "CoreSnapshotResponse",
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "as_of_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.as_of_date",
+            "attributeRef": "lotus.as_of_date"
+          },
+          {
+            "name": "snapshot_mode",
+            "location": "body",
+            "required": true,
+            "type": "CoreSnapshotMode",
+            "semanticId": "lotus.snapshot_mode",
+            "attributeRef": "lotus.snapshot_mode"
+          },
+          {
+            "name": "generated_at",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.generated_at",
+            "attributeRef": "lotus.generated_at"
+          },
+          {
+            "name": "valuation_context",
+            "location": "body",
+            "required": true,
+            "type": "CoreSnapshotValuationContext",
+            "semanticId": "lotus.valuation_context",
+            "attributeRef": "lotus.valuation_context"
+          },
+          {
+            "name": "valuation_context.portfolio_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_currency",
+            "attributeRef": "lotus.portfolio_currency"
+          },
+          {
+            "name": "valuation_context.reporting_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.reporting_currency",
+            "attributeRef": "lotus.reporting_currency"
+          },
+          {
+            "name": "valuation_context.position_basis",
+            "location": "body",
+            "required": true,
+            "type": "CoreSnapshotPositionBasis",
+            "semanticId": "lotus.position_basis",
+            "attributeRef": "lotus.position_basis"
+          },
+          {
+            "name": "valuation_context.weight_basis",
+            "location": "body",
+            "required": true,
+            "type": "CoreSnapshotWeightBasis",
+            "semanticId": "lotus.weight_basis",
+            "attributeRef": "lotus.weight_basis"
+          },
+          {
+            "name": "simulation",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.simulation",
+            "attributeRef": "lotus.simulation"
+          },
+          {
+            "name": "sections",
+            "location": "body",
+            "required": true,
+            "type": "CoreSnapshotSections",
+            "semanticId": "lotus.sections",
+            "attributeRef": "lotus.sections"
+          },
+          {
+            "name": "sections.positions_baseline",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.positions_baseline",
+            "attributeRef": "lotus.positions_baseline"
+          },
+          {
+            "name": "sections.positions_projected",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.positions_projected",
+            "attributeRef": "lotus.positions_projected"
+          },
+          {
+            "name": "sections.positions_delta",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.positions_delta",
+            "attributeRef": "lotus.positions_delta"
+          },
+          {
+            "name": "sections.portfolio_totals",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.portfolio_totals",
+            "attributeRef": "lotus.portfolio_totals"
+          },
+          {
+            "name": "sections.instrument_enrichment",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.instrument_enrichment",
+            "attributeRef": "lotus.instrument_enrichment"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_integration_capabilities_integration_capabilities_get",
+      "method": "GET",
+      "path": "/integration/capabilities",
+      "domain": "integration",
+      "serviceGroup": "query",
+      "tags": [
+        "Integration"
+      ],
+      "summary": "Get lotus-core Integration Capabilities",
+      "description": "Returns backend-governed lotus-core capability and workflow flags for a consumer system and tenant context. Intended for lotus-gateway/UI and lotus-manage feature control.",
+      "naming": {
+        "boundedContext": "integration",
+        "canonicalTerms": [
+          "as_of_date",
+          "consumer_system",
+          "contract_version",
+          "description",
+          "enabled",
+          "features",
+          "generated_at",
+          "key",
+          "owner_service",
+          "policy_version",
+          "required_features",
+          "source_service",
+          "supported_input_modes",
+          "tenant_id",
+          "workflow_key",
+          "workflows"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "consumer_system",
+            "location": "query",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.consumer_system",
+            "attributeRef": "lotus.consumer_system"
+          },
+          {
+            "name": "tenant_id",
+            "location": "query",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.tenant_id",
+            "attributeRef": "lotus.tenant_id"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "IntegrationCapabilitiesResponse",
+        "fields": [
+          {
+            "name": "contract_version",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.contract_version",
+            "attributeRef": "lotus.contract_version"
+          },
+          {
+            "name": "source_service",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.source_service",
+            "attributeRef": "lotus.source_service"
+          },
+          {
+            "name": "consumer_system",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.consumer_system",
+            "attributeRef": "lotus.consumer_system"
+          },
+          {
+            "name": "tenant_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.tenant_id",
+            "attributeRef": "lotus.tenant_id"
+          },
+          {
+            "name": "generated_at",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.generated_at",
+            "attributeRef": "lotus.generated_at"
+          },
+          {
+            "name": "as_of_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.as_of_date",
+            "attributeRef": "lotus.as_of_date"
+          },
+          {
+            "name": "policy_version",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.policy_version",
+            "attributeRef": "lotus.policy_version"
+          },
+          {
+            "name": "supported_input_modes",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.supported_input_modes",
+            "attributeRef": "lotus.supported_input_modes"
+          },
+          {
+            "name": "features",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.features",
+            "attributeRef": "lotus.features"
+          },
+          {
+            "name": "features[].key",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.key",
+            "attributeRef": "lotus.key"
+          },
+          {
+            "name": "features[].enabled",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.enabled",
+            "attributeRef": "lotus.enabled"
+          },
+          {
+            "name": "features[].owner_service",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.owner_service",
+            "attributeRef": "lotus.owner_service"
+          },
+          {
+            "name": "features[].description",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.description",
+            "attributeRef": "lotus.description"
+          },
+          {
+            "name": "workflows",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.workflows",
+            "attributeRef": "lotus.workflows"
+          },
+          {
+            "name": "workflows[].workflow_key",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.workflow_key",
+            "attributeRef": "lotus.workflow_key"
+          },
+          {
+            "name": "workflows[].enabled",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.enabled",
+            "attributeRef": "lotus.enabled"
+          },
+          {
+            "name": "workflows[].required_features",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.required_features",
+            "attributeRef": "lotus.required_features"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_portfolio_lookups_lookups_portfolios_get",
+      "method": "GET",
+      "path": "/lookups/portfolios",
+      "domain": "lookup_catalogs",
+      "serviceGroup": "query",
+      "tags": [
+        "Lookup Catalogs"
+      ],
+      "summary": "Portfolio Lookup Catalog",
+      "description": "Returns portfolio selector options for lotus-gateway/UI portfolio selection workflows.",
+      "naming": {
+        "boundedContext": "lookup_catalogs",
+        "canonicalTerms": [
+          "booking_center_code",
+          "client_id",
+          "id",
+          "items",
+          "label",
+          "limit",
+          "q"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "client_id",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.client_id",
+            "attributeRef": "lotus.client_id"
+          },
+          {
+            "name": "booking_center_code",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.booking_center_code",
+            "attributeRef": "lotus.booking_center_code"
+          },
+          {
+            "name": "q",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.q",
+            "attributeRef": "lotus.q"
+          },
+          {
+            "name": "limit",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.limit",
+            "attributeRef": "lotus.limit"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "LookupResponse",
+        "fields": [
+          {
+            "name": "items",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.items",
+            "attributeRef": "lotus.items"
+          },
+          {
+            "name": "items[].id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.id",
+            "attributeRef": "lotus.id"
+          },
+          {
+            "name": "items[].label",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.label",
+            "attributeRef": "lotus.label"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_instrument_lookups_lookups_instruments_get",
+      "method": "GET",
+      "path": "/lookups/instruments",
+      "domain": "lookup_catalogs",
+      "serviceGroup": "query",
+      "tags": [
+        "Lookup Catalogs"
+      ],
+      "summary": "Instrument Lookup Catalog",
+      "description": "Returns instrument selector options for lotus-gateway/UI trade and intake workflows.",
+      "naming": {
+        "boundedContext": "lookup_catalogs",
+        "canonicalTerms": [
+          "id",
+          "items",
+          "label",
+          "limit",
+          "product_type",
+          "q"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "limit",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.limit",
+            "attributeRef": "lotus.limit"
+          },
+          {
+            "name": "product_type",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.product_type",
+            "attributeRef": "lotus.product_type"
+          },
+          {
+            "name": "q",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.q",
+            "attributeRef": "lotus.q"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "LookupResponse",
+        "fields": [
+          {
+            "name": "items",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.items",
+            "attributeRef": "lotus.items"
+          },
+          {
+            "name": "items[].id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.id",
+            "attributeRef": "lotus.id"
+          },
+          {
+            "name": "items[].label",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.label",
+            "attributeRef": "lotus.label"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_currency_lookups_lookups_currencies_get",
+      "method": "GET",
+      "path": "/lookups/currencies",
+      "domain": "lookup_catalogs",
+      "serviceGroup": "query",
+      "tags": [
+        "Lookup Catalogs"
+      ],
+      "summary": "Currency Lookup Catalog",
+      "description": "Returns distinct currency selector options derived from portfolio base currencies and instrument currencies.",
+      "naming": {
+        "boundedContext": "lookup_catalogs",
+        "canonicalTerms": [
+          "id",
+          "instrument_page_limit",
+          "items",
+          "label",
+          "limit",
+          "q",
+          "source"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "instrument_page_limit",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.instrument_page_limit",
+            "attributeRef": "lotus.instrument_page_limit"
+          },
+          {
+            "name": "source",
+            "location": "query",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.source",
+            "attributeRef": "lotus.source"
+          },
+          {
+            "name": "q",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.q",
+            "attributeRef": "lotus.q"
+          },
+          {
+            "name": "limit",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.limit",
+            "attributeRef": "lotus.limit"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "LookupResponse",
+        "fields": [
+          {
+            "name": "items",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.items",
+            "attributeRef": "lotus.items"
+          },
+          {
+            "name": "items[].id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.id",
+            "attributeRef": "lotus.id"
+          },
+          {
+            "name": "items[].label",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.label",
+            "attributeRef": "lotus.label"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "create_simulation_session_simulation_sessions_post",
+      "method": "POST",
+      "path": "/simulation-sessions",
+      "domain": "simulation",
+      "serviceGroup": "query",
+      "tags": [
+        "Simulation"
+      ],
+      "summary": "Create Simulation Session",
+      "description": "Create a simulation session for a portfolio.",
+      "naming": {
+        "boundedContext": "simulation",
+        "canonicalTerms": [
+          "created_at",
+          "created_by",
+          "expires_at",
+          "portfolio_id",
+          "session",
+          "session_id",
+          "status",
+          "ttl_hours",
+          "version"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "created_by",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.created_by",
+            "attributeRef": "lotus.created_by"
+          },
+          {
+            "name": "ttl_hours",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.ttl_hours",
+            "attributeRef": "lotus.ttl_hours"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 201,
+        "model": "SimulationSessionResponse",
+        "fields": [
+          {
+            "name": "session",
+            "location": "body",
+            "required": true,
+            "type": "SimulationSessionRecord",
+            "semanticId": "lotus.session",
+            "attributeRef": "lotus.session"
+          },
+          {
+            "name": "session.session_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.session_id",
+            "attributeRef": "lotus.session_id"
+          },
+          {
+            "name": "session.portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "session.status",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.status",
+            "attributeRef": "lotus.status"
+          },
+          {
+            "name": "session.version",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.version",
+            "attributeRef": "lotus.version"
+          },
+          {
+            "name": "session.created_by",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.created_by",
+            "attributeRef": "lotus.created_by"
+          },
+          {
+            "name": "session.created_at",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.created_at",
+            "attributeRef": "lotus.created_at"
+          },
+          {
+            "name": "session.expires_at",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.expires_at",
+            "attributeRef": "lotus.expires_at"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_simulation_session_simulation_sessions__session_id__get",
+      "method": "GET",
+      "path": "/simulation-sessions/{session_id}",
+      "domain": "simulation",
+      "serviceGroup": "query",
+      "tags": [
+        "Simulation"
+      ],
+      "summary": "Get Simulation Session",
+      "description": "Get simulation session metadata by session identifier.",
+      "naming": {
+        "boundedContext": "simulation",
+        "canonicalTerms": [
+          "created_at",
+          "created_by",
+          "expires_at",
+          "portfolio_id",
+          "session",
+          "session_id",
+          "status",
+          "version"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "session_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.session_id",
+            "attributeRef": "lotus.session_id"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "SimulationSessionResponse",
+        "fields": [
+          {
+            "name": "session",
+            "location": "body",
+            "required": true,
+            "type": "SimulationSessionRecord",
+            "semanticId": "lotus.session",
+            "attributeRef": "lotus.session"
+          },
+          {
+            "name": "session.session_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.session_id",
+            "attributeRef": "lotus.session_id"
+          },
+          {
+            "name": "session.portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "session.status",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.status",
+            "attributeRef": "lotus.status"
+          },
+          {
+            "name": "session.version",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.version",
+            "attributeRef": "lotus.version"
+          },
+          {
+            "name": "session.created_by",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.created_by",
+            "attributeRef": "lotus.created_by"
+          },
+          {
+            "name": "session.created_at",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.created_at",
+            "attributeRef": "lotus.created_at"
+          },
+          {
+            "name": "session.expires_at",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.expires_at",
+            "attributeRef": "lotus.expires_at"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "close_simulation_session_simulation_sessions__session_id__delete",
+      "method": "DELETE",
+      "path": "/simulation-sessions/{session_id}",
+      "domain": "simulation",
+      "serviceGroup": "query",
+      "tags": [
+        "Simulation"
+      ],
+      "summary": "Close Simulation Session",
+      "description": "Close an active simulation session.",
+      "naming": {
+        "boundedContext": "simulation",
+        "canonicalTerms": [
+          "created_at",
+          "created_by",
+          "expires_at",
+          "portfolio_id",
+          "session",
+          "session_id",
+          "status",
+          "version"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "session_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.session_id",
+            "attributeRef": "lotus.session_id"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "SimulationSessionResponse",
+        "fields": [
+          {
+            "name": "session",
+            "location": "body",
+            "required": true,
+            "type": "SimulationSessionRecord",
+            "semanticId": "lotus.session",
+            "attributeRef": "lotus.session"
+          },
+          {
+            "name": "session.session_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.session_id",
+            "attributeRef": "lotus.session_id"
+          },
+          {
+            "name": "session.portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "session.status",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.status",
+            "attributeRef": "lotus.status"
+          },
+          {
+            "name": "session.version",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.version",
+            "attributeRef": "lotus.version"
+          },
+          {
+            "name": "session.created_by",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.created_by",
+            "attributeRef": "lotus.created_by"
+          },
+          {
+            "name": "session.created_at",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.created_at",
+            "attributeRef": "lotus.created_at"
+          },
+          {
+            "name": "session.expires_at",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.expires_at",
+            "attributeRef": "lotus.expires_at"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "add_simulation_changes_simulation_sessions__session_id__changes_post",
+      "method": "POST",
+      "path": "/simulation-sessions/{session_id}/changes",
+      "domain": "simulation",
+      "serviceGroup": "query",
+      "tags": [
+        "Simulation"
+      ],
+      "summary": "Add Simulation Changes",
+      "description": "Add or update simulation changes for a session.",
+      "naming": {
+        "boundedContext": "simulation",
+        "canonicalTerms": [
+          "amount",
+          "change_id",
+          "changes",
+          "created_at",
+          "currency",
+          "effective_date",
+          "metadata",
+          "portfolio_id",
+          "price",
+          "quantity",
+          "security_id",
+          "session_id",
+          "transaction_type",
+          "version"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "session_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.session_id",
+            "attributeRef": "lotus.session_id"
+          },
+          {
+            "name": "changes",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.changes",
+            "attributeRef": "lotus.changes"
+          },
+          {
+            "name": "changes[].security_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "changes[].transaction_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.transaction_type",
+            "attributeRef": "lotus.transaction_type"
+          },
+          {
+            "name": "changes[].quantity",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.quantity",
+            "attributeRef": "lotus.quantity"
+          },
+          {
+            "name": "changes[].price",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.price",
+            "attributeRef": "lotus.price"
+          },
+          {
+            "name": "changes[].amount",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.amount",
+            "attributeRef": "lotus.amount"
+          },
+          {
+            "name": "changes[].currency",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.currency",
+            "attributeRef": "lotus.currency"
+          },
+          {
+            "name": "changes[].effective_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.effective_date",
+            "attributeRef": "lotus.effective_date"
+          },
+          {
+            "name": "changes[].metadata",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.metadata",
+            "attributeRef": "lotus.metadata"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "SimulationChangesResponse",
+        "fields": [
+          {
+            "name": "session_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.session_id",
+            "attributeRef": "lotus.session_id"
+          },
+          {
+            "name": "version",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.version",
+            "attributeRef": "lotus.version"
+          },
+          {
+            "name": "changes",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.changes",
+            "attributeRef": "lotus.changes"
+          },
+          {
+            "name": "changes[].change_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.change_id",
+            "attributeRef": "lotus.change_id"
+          },
+          {
+            "name": "changes[].session_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.session_id",
+            "attributeRef": "lotus.session_id"
+          },
+          {
+            "name": "changes[].portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "changes[].security_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "changes[].transaction_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.transaction_type",
+            "attributeRef": "lotus.transaction_type"
+          },
+          {
+            "name": "changes[].quantity",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.quantity",
+            "attributeRef": "lotus.quantity"
+          },
+          {
+            "name": "changes[].price",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.price",
+            "attributeRef": "lotus.price"
+          },
+          {
+            "name": "changes[].amount",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.amount",
+            "attributeRef": "lotus.amount"
+          },
+          {
+            "name": "changes[].currency",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.currency",
+            "attributeRef": "lotus.currency"
+          },
+          {
+            "name": "changes[].effective_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.effective_date",
+            "attributeRef": "lotus.effective_date"
+          },
+          {
+            "name": "changes[].metadata",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.metadata",
+            "attributeRef": "lotus.metadata"
+          },
+          {
+            "name": "changes[].created_at",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.created_at",
+            "attributeRef": "lotus.created_at"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "delete_simulation_change_simulation_sessions__session_id__changes__change_id__delete",
+      "method": "DELETE",
+      "path": "/simulation-sessions/{session_id}/changes/{change_id}",
+      "domain": "simulation",
+      "serviceGroup": "query",
+      "tags": [
+        "Simulation"
+      ],
+      "summary": "Delete Simulation Change",
+      "description": "Delete a simulation change from a session.",
+      "naming": {
+        "boundedContext": "simulation",
+        "canonicalTerms": [
+          "amount",
+          "change_id",
+          "changes",
+          "created_at",
+          "currency",
+          "effective_date",
+          "metadata",
+          "portfolio_id",
+          "price",
+          "quantity",
+          "security_id",
+          "session_id",
+          "transaction_type",
+          "version"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "session_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.session_id",
+            "attributeRef": "lotus.session_id"
+          },
+          {
+            "name": "change_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.change_id",
+            "attributeRef": "lotus.change_id"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "SimulationChangesResponse",
+        "fields": [
+          {
+            "name": "session_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.session_id",
+            "attributeRef": "lotus.session_id"
+          },
+          {
+            "name": "version",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.version",
+            "attributeRef": "lotus.version"
+          },
+          {
+            "name": "changes",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.changes",
+            "attributeRef": "lotus.changes"
+          },
+          {
+            "name": "changes[].change_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.change_id",
+            "attributeRef": "lotus.change_id"
+          },
+          {
+            "name": "changes[].session_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.session_id",
+            "attributeRef": "lotus.session_id"
+          },
+          {
+            "name": "changes[].portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "changes[].security_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "changes[].transaction_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.transaction_type",
+            "attributeRef": "lotus.transaction_type"
+          },
+          {
+            "name": "changes[].quantity",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.quantity",
+            "attributeRef": "lotus.quantity"
+          },
+          {
+            "name": "changes[].price",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.price",
+            "attributeRef": "lotus.price"
+          },
+          {
+            "name": "changes[].amount",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.amount",
+            "attributeRef": "lotus.amount"
+          },
+          {
+            "name": "changes[].currency",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.currency",
+            "attributeRef": "lotus.currency"
+          },
+          {
+            "name": "changes[].effective_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.effective_date",
+            "attributeRef": "lotus.effective_date"
+          },
+          {
+            "name": "changes[].metadata",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.metadata",
+            "attributeRef": "lotus.metadata"
+          },
+          {
+            "name": "changes[].created_at",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.created_at",
+            "attributeRef": "lotus.created_at"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_projected_positions_simulation_sessions__session_id__projected_positions_get",
+      "method": "GET",
+      "path": "/simulation-sessions/{session_id}/projected-positions",
+      "domain": "simulation",
+      "serviceGroup": "query",
+      "tags": [
+        "Simulation"
+      ],
+      "summary": "Get Projected Positions",
+      "description": "Return projected positions after applying session changes.",
+      "naming": {
+        "boundedContext": "simulation",
+        "canonicalTerms": [
+          "asset_class",
+          "baseline_as_of",
+          "baseline_quantity",
+          "cost_basis",
+          "cost_basis_local",
+          "delta_quantity",
+          "instrument_name",
+          "portfolio_id",
+          "positions",
+          "proposed_quantity",
+          "security_id",
+          "session_id"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "session_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.session_id",
+            "attributeRef": "lotus.session_id"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "ProjectedPositionsResponse",
+        "fields": [
+          {
+            "name": "session_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.session_id",
+            "attributeRef": "lotus.session_id"
+          },
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "baseline_as_of",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.baseline_as_of",
+            "attributeRef": "lotus.baseline_as_of"
+          },
+          {
+            "name": "positions",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.positions",
+            "attributeRef": "lotus.positions"
+          },
+          {
+            "name": "positions[].security_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "positions[].instrument_name",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.instrument_name",
+            "attributeRef": "lotus.instrument_name"
+          },
+          {
+            "name": "positions[].asset_class",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.asset_class",
+            "attributeRef": "lotus.asset_class"
+          },
+          {
+            "name": "positions[].baseline_quantity",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.baseline_quantity",
+            "attributeRef": "lotus.baseline_quantity"
+          },
+          {
+            "name": "positions[].proposed_quantity",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.proposed_quantity",
+            "attributeRef": "lotus.proposed_quantity"
+          },
+          {
+            "name": "positions[].delta_quantity",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.delta_quantity",
+            "attributeRef": "lotus.delta_quantity"
+          },
+          {
+            "name": "positions[].cost_basis",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.cost_basis",
+            "attributeRef": "lotus.cost_basis"
+          },
+          {
+            "name": "positions[].cost_basis_local",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.cost_basis_local",
+            "attributeRef": "lotus.cost_basis_local"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_projected_summary_simulation_sessions__session_id__projected_summary_get",
+      "method": "GET",
+      "path": "/simulation-sessions/{session_id}/projected-summary",
+      "domain": "simulation",
+      "serviceGroup": "query",
+      "tags": [
+        "Simulation"
+      ],
+      "summary": "Get Projected Summary",
+      "description": "Return projected summary metrics for a simulation session.",
+      "naming": {
+        "boundedContext": "simulation",
+        "canonicalTerms": [
+          "net_delta_quantity",
+          "portfolio_id",
+          "session_id",
+          "total_baseline_positions",
+          "total_proposed_positions"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "session_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.session_id",
+            "attributeRef": "lotus.session_id"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "ProjectedSummaryResponse",
+        "fields": [
+          {
+            "name": "session_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.session_id",
+            "attributeRef": "lotus.session_id"
+          },
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "total_baseline_positions",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.total_baseline_positions",
+            "attributeRef": "lotus.total_baseline_positions"
+          },
+          {
+            "name": "total_proposed_positions",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.total_proposed_positions",
+            "attributeRef": "lotus.total_proposed_positions"
+          },
+          {
+            "name": "net_delta_quantity",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.net_delta_quantity",
+            "attributeRef": "lotus.net_delta_quantity"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "metrics_metrics_get",
+      "method": "GET",
+      "path": "/metrics",
+      "domain": "monitoring",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Monitoring"
+      ],
+      "summary": "Metrics",
+      "description": "Endpoint that serves Prometheus metrics.",
+      "naming": {
+        "boundedContext": "monitoring",
+        "canonicalTerms": []
+      },
+      "request": {
+        "fields": []
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": null,
+        "fields": []
+      }
+    },
+    {
+      "operationId": "liveness_probe_health_live_get",
+      "method": "GET",
+      "path": "/health/live",
+      "domain": "health",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Health"
+      ],
+      "summary": "Liveness Probe",
+      "description": "GET operation for /health/live in ingestion_service.",
+      "naming": {
+        "boundedContext": "health",
+        "canonicalTerms": []
+      },
+      "request": {
+        "fields": []
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "object",
+        "fields": []
+      }
+    },
+    {
+      "operationId": "readiness_probe_health_ready_get",
+      "method": "GET",
+      "path": "/health/ready",
+      "domain": "health",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Health"
+      ],
+      "summary": "Readiness Probe",
+      "description": "GET operation for /health/ready in ingestion_service.",
+      "naming": {
+        "boundedContext": "health",
+        "canonicalTerms": []
+      },
+      "request": {
+        "fields": []
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "object",
+        "fields": []
+      }
+    },
+    {
+      "operationId": "ingest_portfolios_ingest_portfolios_post",
+      "method": "POST",
+      "path": "/ingest/portfolios",
+      "domain": "portfolios",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Portfolios"
+      ],
+      "summary": "Ingest Portfolios",
+      "description": "Ingests a list of portfolios and publishes each to a Kafka topic.",
+      "naming": {
+        "boundedContext": "portfolios",
+        "canonicalTerms": [
+          "advisor_id",
+          "base_currency",
+          "booking_center_code",
+          "client_id",
+          "close_date",
+          "cost_basis_method",
+          "investment_time_horizon",
+          "is_leverage_allowed",
+          "objective",
+          "open_date",
+          "portfolio_id",
+          "portfolio_type",
+          "portfolios",
+          "risk_exposure",
+          "status"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "portfolios",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.portfolios",
+            "attributeRef": "lotus.portfolios"
+          },
+          {
+            "name": "portfolios[].portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "portfolios[].base_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.base_currency",
+            "attributeRef": "lotus.base_currency"
+          },
+          {
+            "name": "portfolios[].open_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.open_date",
+            "attributeRef": "lotus.open_date"
+          },
+          {
+            "name": "portfolios[].close_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.close_date",
+            "attributeRef": "lotus.close_date"
+          },
+          {
+            "name": "portfolios[].risk_exposure",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.risk_exposure",
+            "attributeRef": "lotus.risk_exposure"
+          },
+          {
+            "name": "portfolios[].investment_time_horizon",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.investment_time_horizon",
+            "attributeRef": "lotus.investment_time_horizon"
+          },
+          {
+            "name": "portfolios[].portfolio_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_type",
+            "attributeRef": "lotus.portfolio_type"
+          },
+          {
+            "name": "portfolios[].objective",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.objective",
+            "attributeRef": "lotus.objective"
+          },
+          {
+            "name": "portfolios[].booking_center_code",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.booking_center_code",
+            "attributeRef": "lotus.booking_center_code"
+          },
+          {
+            "name": "portfolios[].client_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.client_id",
+            "attributeRef": "lotus.client_id"
+          },
+          {
+            "name": "portfolios[].is_leverage_allowed",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.is_leverage_allowed",
+            "attributeRef": "lotus.is_leverage_allowed"
+          },
+          {
+            "name": "portfolios[].advisor_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.advisor_id",
+            "attributeRef": "lotus.advisor_id"
+          },
+          {
+            "name": "portfolios[].status",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.status",
+            "attributeRef": "lotus.status"
+          },
+          {
+            "name": "portfolios[].cost_basis_method",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.cost_basis_method",
+            "attributeRef": "lotus.cost_basis_method"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 202,
+        "model": "object",
+        "fields": []
+      }
+    },
+    {
+      "operationId": "ingest_transaction_ingest_transaction_post",
+      "method": "POST",
+      "path": "/ingest/transaction",
+      "domain": "transactions",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Transactions"
+      ],
+      "summary": "Ingest Transaction",
+      "description": "Ingests a single financial transaction and publishes it to a Kafka topic.",
+      "naming": {
+        "boundedContext": "transactions",
+        "canonicalTerms": [
+          "created_at",
+          "currency",
+          "gross_transaction_amount",
+          "instrument_id",
+          "portfolio_id",
+          "price",
+          "quantity",
+          "security_id",
+          "settlement_date",
+          "trade_currency",
+          "trade_fee",
+          "transaction_date",
+          "transaction_id",
+          "transaction_type"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "transaction_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.transaction_id",
+            "attributeRef": "lotus.transaction_id"
+          },
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "instrument_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.instrument_id",
+            "attributeRef": "lotus.instrument_id"
+          },
+          {
+            "name": "security_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "transaction_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.transaction_date",
+            "attributeRef": "lotus.transaction_date"
+          },
+          {
+            "name": "transaction_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.transaction_type",
+            "attributeRef": "lotus.transaction_type"
+          },
+          {
+            "name": "quantity",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.quantity",
+            "attributeRef": "lotus.quantity"
+          },
+          {
+            "name": "price",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.price",
+            "attributeRef": "lotus.price"
+          },
+          {
+            "name": "gross_transaction_amount",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.gross_transaction_amount",
+            "attributeRef": "lotus.gross_transaction_amount"
+          },
+          {
+            "name": "trade_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.trade_currency",
+            "attributeRef": "lotus.trade_currency"
+          },
+          {
+            "name": "currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.currency",
+            "attributeRef": "lotus.currency"
+          },
+          {
+            "name": "trade_fee",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.trade_fee",
+            "attributeRef": "lotus.trade_fee"
+          },
+          {
+            "name": "settlement_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.settlement_date",
+            "attributeRef": "lotus.settlement_date"
+          },
+          {
+            "name": "created_at",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.created_at",
+            "attributeRef": "lotus.created_at"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 202,
+        "model": "object",
+        "fields": []
+      }
+    },
+    {
+      "operationId": "ingest_transactions_ingest_transactions_post",
+      "method": "POST",
+      "path": "/ingest/transactions",
+      "domain": "transactions",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Transactions"
+      ],
+      "summary": "Ingest Transactions",
+      "description": "Ingests a list of financial transactions and publishes each to a Kafka topic.",
+      "naming": {
+        "boundedContext": "transactions",
+        "canonicalTerms": [
+          "created_at",
+          "currency",
+          "gross_transaction_amount",
+          "instrument_id",
+          "portfolio_id",
+          "price",
+          "quantity",
+          "security_id",
+          "settlement_date",
+          "trade_currency",
+          "trade_fee",
+          "transaction_date",
+          "transaction_id",
+          "transaction_type",
+          "transactions"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "transactions",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.transactions",
+            "attributeRef": "lotus.transactions"
+          },
+          {
+            "name": "transactions[].transaction_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.transaction_id",
+            "attributeRef": "lotus.transaction_id"
+          },
+          {
+            "name": "transactions[].portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "transactions[].instrument_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.instrument_id",
+            "attributeRef": "lotus.instrument_id"
+          },
+          {
+            "name": "transactions[].security_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "transactions[].transaction_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.transaction_date",
+            "attributeRef": "lotus.transaction_date"
+          },
+          {
+            "name": "transactions[].transaction_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.transaction_type",
+            "attributeRef": "lotus.transaction_type"
+          },
+          {
+            "name": "transactions[].quantity",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.quantity",
+            "attributeRef": "lotus.quantity"
+          },
+          {
+            "name": "transactions[].price",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.price",
+            "attributeRef": "lotus.price"
+          },
+          {
+            "name": "transactions[].gross_transaction_amount",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.gross_transaction_amount",
+            "attributeRef": "lotus.gross_transaction_amount"
+          },
+          {
+            "name": "transactions[].trade_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.trade_currency",
+            "attributeRef": "lotus.trade_currency"
+          },
+          {
+            "name": "transactions[].currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.currency",
+            "attributeRef": "lotus.currency"
+          },
+          {
+            "name": "transactions[].trade_fee",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.trade_fee",
+            "attributeRef": "lotus.trade_fee"
+          },
+          {
+            "name": "transactions[].settlement_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.settlement_date",
+            "attributeRef": "lotus.settlement_date"
+          },
+          {
+            "name": "transactions[].created_at",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.created_at",
+            "attributeRef": "lotus.created_at"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 202,
+        "model": "object",
+        "fields": []
+      }
+    },
+    {
+      "operationId": "ingest_instruments_ingest_instruments_post",
+      "method": "POST",
+      "path": "/ingest/instruments",
+      "domain": "instruments",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Instruments"
+      ],
+      "summary": "Ingest Instruments",
+      "description": "Ingests a list of financial instruments and publishes each to a Kafka topic.",
+      "naming": {
+        "boundedContext": "instruments",
+        "canonicalTerms": [
+          "asset_class",
+          "country_of_risk",
+          "currency",
+          "instruments",
+          "isin",
+          "issuer_id",
+          "maturity_date",
+          "name",
+          "product_type",
+          "rating",
+          "sector",
+          "security_id",
+          "ultimate_parent_issuer_id"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "instruments",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.instruments",
+            "attributeRef": "lotus.instruments"
+          },
+          {
+            "name": "instruments[].security_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "instruments[].name",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.name",
+            "attributeRef": "lotus.name"
+          },
+          {
+            "name": "instruments[].isin",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.isin",
+            "attributeRef": "lotus.isin"
+          },
+          {
+            "name": "instruments[].currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.currency",
+            "attributeRef": "lotus.currency"
+          },
+          {
+            "name": "instruments[].product_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.product_type",
+            "attributeRef": "lotus.product_type"
+          },
+          {
+            "name": "instruments[].asset_class",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.asset_class",
+            "attributeRef": "lotus.asset_class"
+          },
+          {
+            "name": "instruments[].sector",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.sector",
+            "attributeRef": "lotus.sector"
+          },
+          {
+            "name": "instruments[].country_of_risk",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.country_of_risk",
+            "attributeRef": "lotus.country_of_risk"
+          },
+          {
+            "name": "instruments[].rating",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.rating",
+            "attributeRef": "lotus.rating"
+          },
+          {
+            "name": "instruments[].maturity_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.maturity_date",
+            "attributeRef": "lotus.maturity_date"
+          },
+          {
+            "name": "instruments[].issuer_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.issuer_id",
+            "attributeRef": "lotus.issuer_id"
+          },
+          {
+            "name": "instruments[].ultimate_parent_issuer_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.ultimate_parent_issuer_id",
+            "attributeRef": "lotus.ultimate_parent_issuer_id"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 202,
+        "model": "object",
+        "fields": []
+      }
+    },
+    {
+      "operationId": "ingest_market_prices_ingest_market_prices_post",
+      "method": "POST",
+      "path": "/ingest/market-prices",
+      "domain": "market_prices",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Market Prices"
+      ],
+      "summary": "Ingest Market Prices",
+      "description": "Ingests a list of market prices and publishes each to a Kafka topic.",
+      "naming": {
+        "boundedContext": "market_prices",
+        "canonicalTerms": [
+          "currency",
+          "market_prices",
+          "price",
+          "price_date",
+          "security_id"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "market_prices",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.market_prices",
+            "attributeRef": "lotus.market_prices"
+          },
+          {
+            "name": "market_prices[].security_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "market_prices[].price_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.price_date",
+            "attributeRef": "lotus.price_date"
+          },
+          {
+            "name": "market_prices[].price",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.price",
+            "attributeRef": "lotus.price"
+          },
+          {
+            "name": "market_prices[].currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.currency",
+            "attributeRef": "lotus.currency"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 202,
+        "model": "object",
+        "fields": []
+      }
+    },
+    {
+      "operationId": "ingest_fx_rates_ingest_fx_rates_post",
+      "method": "POST",
+      "path": "/ingest/fx-rates",
+      "domain": "fx_rates",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "FX Rates"
+      ],
+      "summary": "Ingest Fx Rates",
+      "description": "Ingests a list of FX rates and publishes each to a Kafka topic.",
+      "naming": {
+        "boundedContext": "fx_rates",
+        "canonicalTerms": [
+          "from_currency",
+          "fx_rates",
+          "rate",
+          "rate_date",
+          "to_currency"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "fx_rates",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.fx_rates",
+            "attributeRef": "lotus.fx_rates"
+          },
+          {
+            "name": "fx_rates[].from_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.from_currency",
+            "attributeRef": "lotus.from_currency"
+          },
+          {
+            "name": "fx_rates[].to_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.to_currency",
+            "attributeRef": "lotus.to_currency"
+          },
+          {
+            "name": "fx_rates[].rate_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.rate_date",
+            "attributeRef": "lotus.rate_date"
+          },
+          {
+            "name": "fx_rates[].rate",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.rate",
+            "attributeRef": "lotus.rate"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 202,
+        "model": "object",
+        "fields": []
+      }
+    },
+    {
+      "operationId": "ingest_business_dates_ingest_business_dates_post",
+      "method": "POST",
+      "path": "/ingest/business-dates",
+      "domain": "business_dates",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Business Dates"
+      ],
+      "summary": "Ingest Business Dates",
+      "description": "Ingests a list of business dates and publishes each to a Kafka topic.",
+      "naming": {
+        "boundedContext": "business_dates",
+        "canonicalTerms": [
+          "business_date",
+          "business_dates"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "business_dates",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.business_dates",
+            "attributeRef": "lotus.business_dates"
+          },
+          {
+            "name": "business_dates[].business_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.business_date",
+            "attributeRef": "lotus.business_date"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 202,
+        "model": "object",
+        "fields": []
+      }
+    },
+    {
+      "operationId": "reprocess_transactions_reprocess_transactions_post",
+      "method": "POST",
+      "path": "/reprocess/transactions",
+      "domain": "reprocessing",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Reprocessing"
+      ],
+      "summary": "Reprocess Transactions",
+      "description": "Accepts a list of transaction IDs and publishes a reprocessing request\nevent for each to a Kafka topic.",
+      "naming": {
+        "boundedContext": "reprocessing",
+        "canonicalTerms": [
+          "transaction_ids"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "transaction_ids",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.transaction_ids",
+            "attributeRef": "lotus.transaction_ids"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 202,
+        "model": "object",
+        "fields": []
+      }
+    },
+    {
+      "operationId": "ingest_portfolio_bundle_ingest_portfolio_bundle_post",
+      "method": "POST",
+      "path": "/ingest/portfolio-bundle",
+      "domain": "portfolio_bundle",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Portfolio Bundle"
+      ],
+      "summary": "Ingest a complete portfolio bundle",
+      "description": "Accepts a mixed payload (portfolio, instruments, transactions, market prices, FX rates, business dates) for UI/manual/file-based onboarding and publishes to existing lotus-core topics.",
+      "naming": {
+        "boundedContext": "portfolio_bundle",
+        "canonicalTerms": [
+          "advisor_id",
+          "asset_class",
+          "base_currency",
+          "booking_center_code",
+          "business_date",
+          "business_dates",
+          "client_id",
+          "close_date",
+          "cost_basis_method",
+          "country_of_risk",
+          "created_at",
+          "currency",
+          "from_currency",
+          "fx_rates",
+          "gross_transaction_amount",
+          "instrument_id",
+          "instruments",
+          "investment_time_horizon",
+          "is_leverage_allowed",
+          "isin",
+          "issuer_id",
+          "market_prices",
+          "maturity_date",
+          "mode",
+          "name",
+          "objective",
+          "open_date",
+          "portfolio_id",
+          "portfolio_type",
+          "portfolios",
+          "price",
+          "price_date",
+          "product_type",
+          "quantity",
+          "rate",
+          "rate_date",
+          "rating",
+          "risk_exposure",
+          "sector",
+          "security_id",
+          "settlement_date",
+          "source_system",
+          "status",
+          "to_currency",
+          "trade_currency",
+          "trade_fee",
+          "transaction_date",
+          "transaction_id",
+          "transaction_type",
+          "transactions",
+          "ultimate_parent_issuer_id"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "source_system",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_system",
+            "attributeRef": "lotus.source_system"
+          },
+          {
+            "name": "mode",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.mode",
+            "attributeRef": "lotus.mode"
+          },
+          {
+            "name": "business_dates",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.business_dates",
+            "attributeRef": "lotus.business_dates"
+          },
+          {
+            "name": "business_dates[].business_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.business_date",
+            "attributeRef": "lotus.business_date"
+          },
+          {
+            "name": "portfolios",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.portfolios",
+            "attributeRef": "lotus.portfolios"
+          },
+          {
+            "name": "portfolios[].portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "portfolios[].base_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.base_currency",
+            "attributeRef": "lotus.base_currency"
+          },
+          {
+            "name": "portfolios[].open_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.open_date",
+            "attributeRef": "lotus.open_date"
+          },
+          {
+            "name": "portfolios[].close_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.close_date",
+            "attributeRef": "lotus.close_date"
+          },
+          {
+            "name": "portfolios[].risk_exposure",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.risk_exposure",
+            "attributeRef": "lotus.risk_exposure"
+          },
+          {
+            "name": "portfolios[].investment_time_horizon",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.investment_time_horizon",
+            "attributeRef": "lotus.investment_time_horizon"
+          },
+          {
+            "name": "portfolios[].portfolio_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_type",
+            "attributeRef": "lotus.portfolio_type"
+          },
+          {
+            "name": "portfolios[].objective",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.objective",
+            "attributeRef": "lotus.objective"
+          },
+          {
+            "name": "portfolios[].booking_center_code",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.booking_center_code",
+            "attributeRef": "lotus.booking_center_code"
+          },
+          {
+            "name": "portfolios[].client_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.client_id",
+            "attributeRef": "lotus.client_id"
+          },
+          {
+            "name": "portfolios[].is_leverage_allowed",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.is_leverage_allowed",
+            "attributeRef": "lotus.is_leverage_allowed"
+          },
+          {
+            "name": "portfolios[].advisor_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.advisor_id",
+            "attributeRef": "lotus.advisor_id"
+          },
+          {
+            "name": "portfolios[].status",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.status",
+            "attributeRef": "lotus.status"
+          },
+          {
+            "name": "portfolios[].cost_basis_method",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.cost_basis_method",
+            "attributeRef": "lotus.cost_basis_method"
+          },
+          {
+            "name": "instruments",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.instruments",
+            "attributeRef": "lotus.instruments"
+          },
+          {
+            "name": "instruments[].security_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "instruments[].name",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.name",
+            "attributeRef": "lotus.name"
+          },
+          {
+            "name": "instruments[].isin",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.isin",
+            "attributeRef": "lotus.isin"
+          },
+          {
+            "name": "instruments[].currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.currency",
+            "attributeRef": "lotus.currency"
+          },
+          {
+            "name": "instruments[].product_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.product_type",
+            "attributeRef": "lotus.product_type"
+          },
+          {
+            "name": "instruments[].asset_class",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.asset_class",
+            "attributeRef": "lotus.asset_class"
+          },
+          {
+            "name": "instruments[].sector",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.sector",
+            "attributeRef": "lotus.sector"
+          },
+          {
+            "name": "instruments[].country_of_risk",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.country_of_risk",
+            "attributeRef": "lotus.country_of_risk"
+          },
+          {
+            "name": "instruments[].rating",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.rating",
+            "attributeRef": "lotus.rating"
+          },
+          {
+            "name": "instruments[].maturity_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.maturity_date",
+            "attributeRef": "lotus.maturity_date"
+          },
+          {
+            "name": "instruments[].issuer_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.issuer_id",
+            "attributeRef": "lotus.issuer_id"
+          },
+          {
+            "name": "instruments[].ultimate_parent_issuer_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.ultimate_parent_issuer_id",
+            "attributeRef": "lotus.ultimate_parent_issuer_id"
+          },
+          {
+            "name": "transactions",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.transactions",
+            "attributeRef": "lotus.transactions"
+          },
+          {
+            "name": "transactions[].transaction_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.transaction_id",
+            "attributeRef": "lotus.transaction_id"
+          },
+          {
+            "name": "transactions[].portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "transactions[].instrument_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.instrument_id",
+            "attributeRef": "lotus.instrument_id"
+          },
+          {
+            "name": "transactions[].security_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "transactions[].transaction_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.transaction_date",
+            "attributeRef": "lotus.transaction_date"
+          },
+          {
+            "name": "transactions[].transaction_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.transaction_type",
+            "attributeRef": "lotus.transaction_type"
+          },
+          {
+            "name": "transactions[].quantity",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.quantity",
+            "attributeRef": "lotus.quantity"
+          },
+          {
+            "name": "transactions[].price",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.price",
+            "attributeRef": "lotus.price"
+          },
+          {
+            "name": "transactions[].gross_transaction_amount",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.gross_transaction_amount",
+            "attributeRef": "lotus.gross_transaction_amount"
+          },
+          {
+            "name": "transactions[].trade_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.trade_currency",
+            "attributeRef": "lotus.trade_currency"
+          },
+          {
+            "name": "transactions[].currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.currency",
+            "attributeRef": "lotus.currency"
+          },
+          {
+            "name": "transactions[].trade_fee",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.trade_fee",
+            "attributeRef": "lotus.trade_fee"
+          },
+          {
+            "name": "transactions[].settlement_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.settlement_date",
+            "attributeRef": "lotus.settlement_date"
+          },
+          {
+            "name": "transactions[].created_at",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.created_at",
+            "attributeRef": "lotus.created_at"
+          },
+          {
+            "name": "market_prices",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.market_prices",
+            "attributeRef": "lotus.market_prices"
+          },
+          {
+            "name": "market_prices[].security_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "market_prices[].price_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.price_date",
+            "attributeRef": "lotus.price_date"
+          },
+          {
+            "name": "market_prices[].price",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.price",
+            "attributeRef": "lotus.price"
+          },
+          {
+            "name": "market_prices[].currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.currency",
+            "attributeRef": "lotus.currency"
+          },
+          {
+            "name": "fx_rates",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.fx_rates",
+            "attributeRef": "lotus.fx_rates"
+          },
+          {
+            "name": "fx_rates[].from_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.from_currency",
+            "attributeRef": "lotus.from_currency"
+          },
+          {
+            "name": "fx_rates[].to_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.to_currency",
+            "attributeRef": "lotus.to_currency"
+          },
+          {
+            "name": "fx_rates[].rate_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.rate_date",
+            "attributeRef": "lotus.rate_date"
+          },
+          {
+            "name": "fx_rates[].rate",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.rate",
+            "attributeRef": "lotus.rate"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 202,
+        "model": "object",
+        "fields": []
+      }
+    },
+    {
+      "operationId": "preview_upload_ingest_uploads_preview_post",
+      "method": "POST",
+      "path": "/ingest/uploads/preview",
+      "domain": "bulk_uploads",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Bulk Uploads"
+      ],
+      "summary": "Preview and validate bulk upload data",
+      "description": "Validates CSV/XLSX rows against lotus-core ingestion contracts without publishing events. Returns row-level errors and normalized sample rows for UI correction workflows.",
+      "naming": {
+        "boundedContext": "bulk_uploads",
+        "canonicalTerms": [
+          "entity_type",
+          "errors",
+          "file_format",
+          "invalid_rows",
+          "message",
+          "row_number",
+          "sample_rows",
+          "total_rows",
+          "valid_rows"
+        ]
+      },
+      "request": {
+        "fields": []
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "UploadPreviewResponse",
+        "fields": [
+          {
+            "name": "entity_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.entity_type",
+            "attributeRef": "lotus.entity_type"
+          },
+          {
+            "name": "file_format",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.file_format",
+            "attributeRef": "lotus.file_format"
+          },
+          {
+            "name": "total_rows",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.total_rows",
+            "attributeRef": "lotus.total_rows"
+          },
+          {
+            "name": "valid_rows",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.valid_rows",
+            "attributeRef": "lotus.valid_rows"
+          },
+          {
+            "name": "invalid_rows",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.invalid_rows",
+            "attributeRef": "lotus.invalid_rows"
+          },
+          {
+            "name": "sample_rows",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.sample_rows",
+            "attributeRef": "lotus.sample_rows"
+          },
+          {
+            "name": "errors",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.errors",
+            "attributeRef": "lotus.errors"
+          },
+          {
+            "name": "errors[].row_number",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.row_number",
+            "attributeRef": "lotus.row_number"
+          },
+          {
+            "name": "errors[].message",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.message",
+            "attributeRef": "lotus.message"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "commit_upload_ingest_uploads_commit_post",
+      "method": "POST",
+      "path": "/ingest/uploads/commit",
+      "domain": "bulk_uploads",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Bulk Uploads"
+      ],
+      "summary": "Commit validated bulk upload data",
+      "description": "Validates CSV/XLSX rows and publishes valid records to existing lotus-core ingestion topics. By default rejects partial uploads; set allowPartial=true to publish valid rows only.",
+      "naming": {
+        "boundedContext": "bulk_uploads",
+        "canonicalTerms": [
+          "entity_type",
+          "file_format",
+          "invalid_rows",
+          "message",
+          "published_rows",
+          "skipped_rows",
+          "total_rows",
+          "valid_rows"
+        ]
+      },
+      "request": {
+        "fields": []
+      },
+      "response": {
+        "httpStatus": 202,
+        "model": "UploadCommitResponse",
+        "fields": [
+          {
+            "name": "entity_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.entity_type",
+            "attributeRef": "lotus.entity_type"
+          },
+          {
+            "name": "file_format",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.file_format",
+            "attributeRef": "lotus.file_format"
+          },
+          {
+            "name": "total_rows",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.total_rows",
+            "attributeRef": "lotus.total_rows"
+          },
+          {
+            "name": "valid_rows",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.valid_rows",
+            "attributeRef": "lotus.valid_rows"
+          },
+          {
+            "name": "invalid_rows",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.invalid_rows",
+            "attributeRef": "lotus.invalid_rows"
+          },
+          {
+            "name": "published_rows",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.published_rows",
+            "attributeRef": "lotus.published_rows"
+          },
+          {
+            "name": "skipped_rows",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.skipped_rows",
+            "attributeRef": "lotus.skipped_rows"
+          },
+          {
+            "name": "message",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.message",
+            "attributeRef": "lotus.message"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/services/query_service/app/dtos/core_snapshot_dto.py
+++ b/src/services/query_service/app/dtos/core_snapshot_dto.py
@@ -28,10 +28,14 @@ class CoreSnapshotWeightBasis(str, Enum):
 
 
 class CoreSnapshotSimulationOptions(BaseModel):
-    session_id: str = Field(..., description="Simulation session identifier.", examples=["SIM_0001"])
+    session_id: str = Field(
+        ...,
+        description="Simulation session identifier created by /simulation-sessions.",
+        examples=["SIM_0001"],
+    )
     expected_version: Optional[int] = Field(
         None,
-        description="Optional optimistic lock for simulation version.",
+        description="Optional optimistic lock for simulation session version.",
         examples=[3],
     )
 
@@ -40,26 +44,35 @@ class CoreSnapshotRequestOptions(BaseModel):
     include_zero_quantity_positions: bool = Field(
         False,
         description="Include positions with zero quantity in section responses.",
+        examples=[False],
     )
     include_cash_positions: bool = Field(
         True,
         description="Include cash-class positions in section responses.",
+        examples=[True],
     )
     position_basis: CoreSnapshotPositionBasis = Field(
         CoreSnapshotPositionBasis.MARKET_VALUE_BASE,
         description="Basis used for position valuation fields.",
+        examples=["market_value_base"],
     )
     weight_basis: CoreSnapshotWeightBasis = Field(
         CoreSnapshotWeightBasis.TOTAL_MARKET_VALUE_BASE,
         description="Basis used to calculate weight fields.",
+        examples=["total_market_value_base"],
     )
 
 
 class CoreSnapshotRequest(BaseModel):
-    as_of_date: date = Field(..., description="Business date for snapshot resolution.")
+    as_of_date: date = Field(
+        ...,
+        description="Business date used to resolve baseline positions and valuation context.",
+        examples=["2026-02-27"],
+    )
     snapshot_mode: CoreSnapshotMode = Field(
         CoreSnapshotMode.BASELINE,
-        description="Snapshot mode: BASELINE or SIMULATION.",
+        description="Snapshot mode: BASELINE for current state or SIMULATION for projected state.",
+        examples=["SIMULATION"],
     )
     reporting_currency: Optional[str] = Field(
         None,
@@ -68,7 +81,8 @@ class CoreSnapshotRequest(BaseModel):
     )
     sections: list[CoreSnapshotSection] = Field(
         ...,
-        description="Requested snapshot sections.",
+        description="Requested snapshot sections to include in the response payload.",
+        examples=[["positions_baseline", "positions_projected", "positions_delta"]],
     )
     simulation: Optional[CoreSnapshotSimulationOptions] = Field(
         None,
@@ -91,68 +105,259 @@ class CoreSnapshotRequest(BaseModel):
 
 
 class CoreSnapshotValuationContext(BaseModel):
-    portfolio_currency: str = Field(..., description="Portfolio base currency.")
-    reporting_currency: str = Field(..., description="Reporting currency for value fields.")
-    position_basis: CoreSnapshotPositionBasis = Field(...)
-    weight_basis: CoreSnapshotWeightBasis = Field(...)
+    portfolio_currency: str = Field(
+        ...,
+        description="Portfolio base currency used by lotus-core for valuation storage.",
+        examples=["EUR"],
+    )
+    reporting_currency: str = Field(
+        ...,
+        description="Reporting currency used in response monetary fields.",
+        examples=["USD"],
+    )
+    position_basis: CoreSnapshotPositionBasis = Field(
+        ...,
+        description="Position valuation basis applied to position and delta sections.",
+        examples=["market_value_base"],
+    )
+    weight_basis: CoreSnapshotWeightBasis = Field(
+        ...,
+        description="Weight calculation basis applied to baseline and projected sections.",
+        examples=["total_market_value_base"],
+    )
 
 
 class CoreSnapshotSimulationMetadata(BaseModel):
-    session_id: str = Field(...)
-    version: int = Field(...)
-    baseline_as_of_date: date = Field(...)
+    session_id: str = Field(
+        ...,
+        description="Simulation session identifier used to produce projected and delta sections.",
+        examples=["SIM_0001"],
+    )
+    version: int = Field(
+        ...,
+        description="Simulation session version resolved by lotus-core for deterministic replay.",
+        examples=[3],
+    )
+    baseline_as_of_date: date = Field(
+        ...,
+        description="Baseline business date used to resolve the simulation comparison state.",
+        examples=["2026-02-27"],
+    )
 
 
 class CoreSnapshotPositionRecord(BaseModel):
-    security_id: str = Field(..., examples=["AAPL.OQ"])
-    quantity: Decimal = Field(..., examples=["100.0000000000"])
-    market_value_base: Optional[Decimal] = Field(None, examples=["19500.25"])
-    market_value_local: Optional[Decimal] = Field(None, examples=["18000.00"])
-    weight: Optional[Decimal] = Field(None, examples=["0.1245"])
-    currency: Optional[str] = Field(None, examples=["USD"])
+    security_id: str = Field(
+        ...,
+        description="Canonical Lotus security identifier.",
+        examples=["SEC_AAPL_US"],
+    )
+    quantity: Decimal = Field(
+        ...,
+        description="Position quantity at the requested snapshot state.",
+        examples=["100.0000000000"],
+    )
+    market_value_base: Optional[Decimal] = Field(
+        None,
+        description="Position market value in reporting currency.",
+        examples=["19500.25"],
+    )
+    market_value_local: Optional[Decimal] = Field(
+        None,
+        description="Position market value in instrument local currency.",
+        examples=["18000.00"],
+    )
+    weight: Optional[Decimal] = Field(
+        None,
+        description="Position weight versus portfolio total market value.",
+        examples=["0.1245"],
+    )
+    currency: Optional[str] = Field(
+        None,
+        description="Instrument local currency for market_value_local.",
+        examples=["USD"],
+    )
 
 
 class CoreSnapshotDeltaRecord(BaseModel):
-    security_id: str = Field(..., examples=["AAPL.OQ"])
-    baseline_quantity: Decimal = Field(..., examples=["100.0000000000"])
-    projected_quantity: Decimal = Field(..., examples=["120.0000000000"])
-    delta_quantity: Decimal = Field(..., examples=["20.0000000000"])
-    baseline_market_value_base: Optional[Decimal] = Field(None, examples=["19500.25"])
-    projected_market_value_base: Optional[Decimal] = Field(None, examples=["23400.30"])
-    delta_market_value_base: Optional[Decimal] = Field(None, examples=["3900.05"])
-    delta_weight: Optional[Decimal] = Field(None, examples=["0.0175"])
+    security_id: str = Field(
+        ...,
+        description="Canonical Lotus security identifier.",
+        examples=["SEC_AAPL_US"],
+    )
+    baseline_quantity: Decimal = Field(
+        ...,
+        description="Baseline quantity before applying simulation changes.",
+        examples=["100.0000000000"],
+    )
+    projected_quantity: Decimal = Field(
+        ...,
+        description="Projected quantity after applying simulation changes.",
+        examples=["120.0000000000"],
+    )
+    delta_quantity: Decimal = Field(
+        ...,
+        description="Projected quantity minus baseline quantity.",
+        examples=["20.0000000000"],
+    )
+    baseline_market_value_base: Optional[Decimal] = Field(
+        None,
+        description="Baseline market value in reporting currency.",
+        examples=["19500.25"],
+    )
+    projected_market_value_base: Optional[Decimal] = Field(
+        None,
+        description="Projected market value in reporting currency.",
+        examples=["23400.30"],
+    )
+    delta_market_value_base: Optional[Decimal] = Field(
+        None,
+        description="Projected market value minus baseline market value in reporting currency.",
+        examples=["3900.05"],
+    )
+    delta_weight: Optional[Decimal] = Field(
+        None,
+        description="Projected weight minus baseline weight.",
+        examples=["0.0175"],
+    )
 
 
 class CoreSnapshotInstrumentEnrichmentRecord(BaseModel):
-    security_id: str = Field(...)
-    isin: Optional[str] = Field(None)
-    asset_class: Optional[str] = Field(None)
-    sector: Optional[str] = Field(None)
-    country_of_risk: Optional[str] = Field(None)
-    instrument_name: Optional[str] = Field(None)
+    security_id: str = Field(
+        ...,
+        description="Canonical Lotus security identifier.",
+        examples=["SEC_AAPL_US"],
+    )
+    isin: Optional[str] = Field(
+        None,
+        description="ISIN associated with the security.",
+        examples=["US0378331005"],
+    )
+    asset_class: Optional[str] = Field(
+        None,
+        description="Instrument asset class used for portfolio grouping.",
+        examples=["EQUITY"],
+    )
+    sector: Optional[str] = Field(
+        None,
+        description="Instrument sector classification.",
+        examples=["TECHNOLOGY"],
+    )
+    country_of_risk: Optional[str] = Field(
+        None,
+        description="Primary country of risk exposure.",
+        examples=["US"],
+    )
+    instrument_name: Optional[str] = Field(
+        None,
+        description="Instrument display name.",
+        examples=["Apple Inc."],
+    )
 
 
 class CoreSnapshotPortfolioTotals(BaseModel):
-    baseline_total_market_value_base: Optional[Decimal] = Field(None)
-    projected_total_market_value_base: Optional[Decimal] = Field(None)
-    delta_total_market_value_base: Optional[Decimal] = Field(None)
+    baseline_total_market_value_base: Optional[Decimal] = Field(
+        None,
+        description="Portfolio baseline total market value in reporting currency.",
+        examples=["156600.40"],
+    )
+    projected_total_market_value_base: Optional[Decimal] = Field(
+        None,
+        description="Portfolio projected total market value in reporting currency.",
+        examples=["160500.45"],
+    )
+    delta_total_market_value_base: Optional[Decimal] = Field(
+        None,
+        description="Projected total minus baseline total in reporting currency.",
+        examples=["3900.05"],
+    )
 
 
 class CoreSnapshotSections(BaseModel):
-    positions_baseline: Optional[list[CoreSnapshotPositionRecord]] = None
-    positions_projected: Optional[list[CoreSnapshotPositionRecord]] = None
-    positions_delta: Optional[list[CoreSnapshotDeltaRecord]] = None
-    portfolio_totals: Optional[CoreSnapshotPortfolioTotals] = None
-    instrument_enrichment: Optional[list[CoreSnapshotInstrumentEnrichmentRecord]] = None
+    positions_baseline: Optional[list[CoreSnapshotPositionRecord]] = Field(
+        None,
+        description="Baseline positions resolved for as_of_date.",
+        examples=[[{"security_id": "SEC_AAPL_US", "quantity": "100.0000000000"}]],
+    )
+    positions_projected: Optional[list[CoreSnapshotPositionRecord]] = Field(
+        None,
+        description="Projected positions after applying simulation changes.",
+        examples=[[{"security_id": "SEC_AAPL_US", "quantity": "120.0000000000"}]],
+    )
+    positions_delta: Optional[list[CoreSnapshotDeltaRecord]] = Field(
+        None,
+        description="Per-security baseline versus projected deltas.",
+        examples=[[{"security_id": "SEC_AAPL_US", "delta_quantity": "20.0000000000"}]],
+    )
+    portfolio_totals: Optional[CoreSnapshotPortfolioTotals] = Field(
+        None,
+        description="Portfolio-level baseline/projected totals and delta.",
+        examples=[
+            {
+                "baseline_total_market_value_base": "156600.40",
+                "projected_total_market_value_base": "160500.45",
+                "delta_total_market_value_base": "3900.05",
+            }
+        ],
+    )
+    instrument_enrichment: Optional[list[CoreSnapshotInstrumentEnrichmentRecord]] = Field(
+        None,
+        description="Reference enrichment for securities included in snapshot sections.",
+        examples=[[{"security_id": "SEC_AAPL_US", "isin": "US0378331005"}]],
+    )
 
 
 class CoreSnapshotResponse(BaseModel):
-    portfolio_id: str = Field(...)
-    as_of_date: date = Field(...)
-    snapshot_mode: CoreSnapshotMode = Field(...)
-    generated_at: datetime = Field(...)
-    valuation_context: CoreSnapshotValuationContext = Field(...)
-    simulation: Optional[CoreSnapshotSimulationMetadata] = Field(None)
-    sections: CoreSnapshotSections = Field(...)
+    portfolio_id: str = Field(
+        ...,
+        description="Portfolio identifier for the generated snapshot.",
+        examples=["DEMO_DPM_EUR_001"],
+    )
+    as_of_date: date = Field(
+        ...,
+        description="Business date used to resolve baseline state.",
+        examples=["2026-02-27"],
+    )
+    snapshot_mode: CoreSnapshotMode = Field(
+        ...,
+        description="Snapshot mode used for this response.",
+        examples=["SIMULATION"],
+    )
+    generated_at: datetime = Field(
+        ...,
+        description="UTC timestamp when lotus-core generated the snapshot response.",
+        examples=["2026-02-27T10:30:00Z"],
+    )
+    valuation_context: CoreSnapshotValuationContext = Field(
+        ...,
+        description="Valuation and weight basis context applied to all sections.",
+        examples=[
+            {
+                "portfolio_currency": "EUR",
+                "reporting_currency": "USD",
+                "position_basis": "market_value_base",
+                "weight_basis": "total_market_value_base",
+            }
+        ],
+    )
+    simulation: Optional[CoreSnapshotSimulationMetadata] = Field(
+        None,
+        description="Simulation metadata present only when snapshot_mode=SIMULATION.",
+        examples=[{"session_id": "SIM_0001", "version": 3, "baseline_as_of_date": "2026-02-27"}],
+    )
+    sections: CoreSnapshotSections = Field(
+        ...,
+        description="Requested snapshot sections payload.",
+        examples=[
+            {
+                "positions_baseline": [{"security_id": "SEC_AAPL_US", "quantity": "100.0000000000"}],
+                "positions_projected": [
+                    {"security_id": "SEC_AAPL_US", "quantity": "120.0000000000"}
+                ],
+                "positions_delta": [
+                    {"security_id": "SEC_AAPL_US", "delta_quantity": "20.0000000000"}
+                ],
+            }
+        ],
+    )
 
     model_config = ConfigDict()


### PR DESCRIPTION
## Summary
- applied RFC-0067 governance updates for the new lotus-core core snapshot contract
- improved OpenAPI schema metadata for core snapshot request/response models (descriptions + realistic examples)
- updated inventory generator handling for wrapper schema metadata during extraction
- regenerated app inventory at `docs/standards/api-vocabulary/lotus-core-api-vocabulary.v1.json`

## Validation
- `python scripts/openapi_quality_gate.py`
- `python scripts/no_alias_contract_guard.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`