### PR TITLE
feat(core): issuer enrichment contract for concentration consumers

### DIFF
--- a/alembic/versions/a7d3c9f1e4b2_feat_add_issuer_name_fields_to_instruments.py
+++ b/alembic/versions/a7d3c9f1e4b2_feat_add_issuer_name_fields_to_instruments.py
@@ -1,0 +1,32 @@
+"""feat: add issuer name fields to instruments
+
+Revision ID: a7d3c9f1e4b2
+Revises: 9c1e2d3f4a5b
+Create Date: 2026-02-27 11:30:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a7d3c9f1e4b2"
+down_revision: Union[str, None] = "9c1e2d3f4a5b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("instruments", sa.Column("issuer_name", sa.String(), nullable=True))
+    op.add_column(
+        "instruments",
+        sa.Column("ultimate_parent_issuer_name", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("instruments", "ultimate_parent_issuer_name")
+    op.drop_column("instruments", "issuer_name")
+

--- a/docs/standards/api-vocabulary/lotus-core-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-core-api-vocabulary.v1.json
@@ -13,7 +13,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-02-27T10:21:00.104621+00:00",
+  "generatedAt": "2026-02-27T12:11:33.165292+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.active_reprocessing_keys",
@@ -865,8 +865,24 @@
       "semanticId": "lotus.issuer_id",
       "canonicalTerm": "issuer_id",
       "preferredName": "issuer_id",
-      "description": "Identifier for the direct issuer of the security.",
+      "description": "Canonical direct issuer identifier, when available.",
       "example": "ISSUER_001",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.issuer_name",
+      "canonicalTerm": "issuer_name",
+      "preferredName": "issuer_name",
+      "description": "Display name for direct issuer, when available.",
+      "example": {
+        "id": "OBJ_001"
+      },
       "type": "object",
       "locations": [
         "body"
@@ -1434,7 +1450,7 @@
           "quantity": "100.0000000000"
         }
       ],
-      "type": "array",
+      "type": "object",
       "locations": [
         "body"
       ],
@@ -1453,7 +1469,7 @@
           "delta_quantity": "20.0000000000"
         }
       ],
-      "type": "array",
+      "type": "object",
       "locations": [
         "body"
       ],
@@ -1472,7 +1488,7 @@
           "quantity": "120.0000000000"
         }
       ],
-      "type": "array",
+      "type": "object",
       "locations": [
         "body"
       ],
@@ -1691,6 +1707,22 @@
       ]
     },
     {
+      "semanticId": "lotus.records",
+      "canonicalTerm": "records",
+      "preferredName": "records",
+      "description": "Deterministic enrichment records in the same order as request security_ids.",
+      "example": [
+        "RECORDS_ITEM_VALUE"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
       "semanticId": "lotus.reporting_currency",
       "canonicalTerm": "reporting_currency",
       "preferredName": "reporting_currency",
@@ -1789,11 +1821,7 @@
       "preferredName": "sections",
       "description": "Requested snapshot sections to include in the response payload.",
       "example": [
-        "positions_baseline",
-        "positions_projected",
-        "positions_delta",
-        "portfolio_totals",
-        "instrument_enrichment"
+        "SECTIONS_ITEM_VALUE"
       ],
       "type": "array",
       "locations": [
@@ -1833,6 +1861,22 @@
       "observedTypes": [
         "object",
         "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.security_ids",
+      "canonicalTerm": "security_ids",
+      "preferredName": "security_ids",
+      "description": "Canonical Lotus security identifiers to enrich.",
+      "example": [
+        "SECURITY_IDS_ITEM_VALUE"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
       ]
     },
     {
@@ -2303,8 +2347,24 @@
       "semanticId": "lotus.ultimate_parent_issuer_id",
       "canonicalTerm": "ultimate_parent_issuer_id",
       "preferredName": "ultimate_parent_issuer_id",
-      "description": "Identifier for the ultimate parent of the issuer.",
+      "description": "Canonical ultimate parent issuer identifier, when available.",
       "example": "ULTIMATE_PARENT_ISSUER_001",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.ultimate_parent_issuer_name",
+      "canonicalTerm": "ultimate_parent_issuer_name",
+      "preferredName": "ultimate_parent_issuer_name",
+      "description": "Display name for ultimate parent issuer, when available.",
+      "example": {
+        "id": "OBJ_001"
+      },
       "type": "object",
       "locations": [
         "body"
@@ -6078,6 +6138,96 @@
       }
     },
     {
+      "operationId": "get_instrument_enrichment_bulk_integration_instruments_enrichment_bulk_post",
+      "method": "POST",
+      "path": "/integration/instruments/enrichment-bulk",
+      "domain": "integration_contracts",
+      "serviceGroup": "query",
+      "tags": [
+        "Integration Contracts"
+      ],
+      "summary": "Resolve issuer enrichment for security identifiers",
+      "description": "Returns issuer enrichment for a caller-provided security_id list. Records are deterministic and preserve request order. Unknown securities are returned with null issuer fields.",
+      "naming": {
+        "boundedContext": "integration_contracts",
+        "canonicalTerms": [
+          "issuer_id",
+          "issuer_name",
+          "records",
+          "security_id",
+          "security_ids",
+          "ultimate_parent_issuer_id",
+          "ultimate_parent_issuer_name"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "security_ids",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.security_ids",
+            "attributeRef": "lotus.security_ids"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "InstrumentEnrichmentBulkResponse",
+        "fields": [
+          {
+            "name": "records",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.records",
+            "attributeRef": "lotus.records"
+          },
+          {
+            "name": "records[].security_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "records[].issuer_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.issuer_id",
+            "attributeRef": "lotus.issuer_id"
+          },
+          {
+            "name": "records[].issuer_name",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.issuer_name",
+            "attributeRef": "lotus.issuer_name"
+          },
+          {
+            "name": "records[].ultimate_parent_issuer_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.ultimate_parent_issuer_id",
+            "attributeRef": "lotus.ultimate_parent_issuer_id"
+          },
+          {
+            "name": "records[].ultimate_parent_issuer_name",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.ultimate_parent_issuer_name",
+            "attributeRef": "lotus.ultimate_parent_issuer_name"
+          }
+        ]
+      }
+    },
+    {
       "operationId": "get_integration_capabilities_integration_capabilities_get",
       "method": "GET",
       "path": "/integration/capabilities",
@@ -8078,13 +8228,15 @@
           "instruments",
           "isin",
           "issuer_id",
+          "issuer_name",
           "maturity_date",
           "name",
           "product_type",
           "rating",
           "sector",
           "security_id",
-          "ultimate_parent_issuer_id"
+          "ultimate_parent_issuer_id",
+          "ultimate_parent_issuer_name"
         ]
       },
       "request": {
@@ -8186,12 +8338,28 @@
             "attributeRef": "lotus.issuer_id"
           },
           {
+            "name": "instruments[].issuer_name",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.issuer_name",
+            "attributeRef": "lotus.issuer_name"
+          },
+          {
             "name": "instruments[].ultimate_parent_issuer_id",
             "location": "body",
             "required": false,
             "type": "object",
             "semanticId": "lotus.ultimate_parent_issuer_id",
             "attributeRef": "lotus.ultimate_parent_issuer_id"
+          },
+          {
+            "name": "instruments[].ultimate_parent_issuer_name",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.ultimate_parent_issuer_name",
+            "attributeRef": "lotus.ultimate_parent_issuer_name"
           }
         ]
       },
@@ -8457,6 +8625,7 @@
           "is_leverage_allowed",
           "isin",
           "issuer_id",
+          "issuer_name",
           "market_prices",
           "maturity_date",
           "mode",
@@ -8486,7 +8655,8 @@
           "transaction_id",
           "transaction_type",
           "transactions",
-          "ultimate_parent_issuer_id"
+          "ultimate_parent_issuer_id",
+          "ultimate_parent_issuer_name"
         ]
       },
       "request": {
@@ -8740,12 +8910,28 @@
             "attributeRef": "lotus.issuer_id"
           },
           {
+            "name": "instruments[].issuer_name",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.issuer_name",
+            "attributeRef": "lotus.issuer_name"
+          },
+          {
             "name": "instruments[].ultimate_parent_issuer_id",
             "location": "body",
             "required": false,
             "type": "object",
             "semanticId": "lotus.ultimate_parent_issuer_id",
             "attributeRef": "lotus.ultimate_parent_issuer_id"
+          },
+          {
+            "name": "instruments[].ultimate_parent_issuer_name",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.ultimate_parent_issuer_name",
+            "attributeRef": "lotus.ultimate_parent_issuer_name"
           },
           {
             "name": "transactions",

--- a/src/libs/portfolio-common/portfolio_common/database_models.py
+++ b/src/libs/portfolio-common/portfolio_common/database_models.py
@@ -157,7 +157,9 @@ class Instrument(Base):
     rating = Column(String, nullable=True)
     maturity_date = Column(Date, nullable=True)
     issuer_id = Column(String, nullable=True, index=True)
+    issuer_name = Column(String, nullable=True)
     ultimate_parent_issuer_id = Column(String, nullable=True, index=True)
+    ultimate_parent_issuer_name = Column(String, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
 

--- a/src/libs/portfolio-common/portfolio_common/events.py
+++ b/src/libs/portfolio-common/portfolio_common/events.py
@@ -71,7 +71,9 @@ class InstrumentEvent(BaseModel):
     rating: Optional[str] = None
     maturity_date: Optional[date] = Field(None)
     issuer_id: Optional[str] = Field(None)
+    issuer_name: Optional[str] = Field(None)
     ultimate_parent_issuer_id: Optional[str] = Field(None)
+    ultimate_parent_issuer_name: Optional[str] = Field(None)
 
 class TransactionEvent(BaseModel):
     model_config = ConfigDict(from_attributes=True)

--- a/src/services/ingestion_service/app/DTOs/instrument_dto.py
+++ b/src/services/ingestion_service/app/DTOs/instrument_dto.py
@@ -18,23 +18,27 @@ class Instrument(BaseModel):
     rating: Optional[str] = Field(None, description="Credit rating for fixed income instruments (e.g., 'AAA').")
     maturity_date: Optional[date] = Field(None, description="Maturity date for fixed income instruments.")
     issuer_id: Optional[str] = Field(None, description="Identifier for the direct issuer of the security.")
+    issuer_name: Optional[str] = Field(None, description="Display name for the direct issuer of the security.")
     ultimate_parent_issuer_id: Optional[str] = Field(None, description="Identifier for the ultimate parent of the issuer.")
+    ultimate_parent_issuer_name: Optional[str] = Field(None, description="Display name for the ultimate parent issuer.")
 
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
-                "securityId": "SEC_BARC_PERP",
+                "security_id": "SEC_BARC_PERP",
                 "name": "Barclays PLC 8% Perpetual",
                 "isin": "US06738E2046",
-                "instrumentCurrency": "USD",
-                "productType": "Bond",
-                "assetClass": "Fixed Income",
+                "currency": "USD",
+                "product_type": "Bond",
+                "asset_class": "Fixed Income",
                 "sector": "Financials",
-                "countryOfRisk": "GB",
+                "country_of_risk": "GB",
                 "rating": "BB+",
-                "maturityDate": None,
-                "issuerId": "ISSUER_BARC",
-                "ultimateParentIssuerId": "ULTIMATE_BARC"
+                "maturity_date": None,
+                "issuer_id": "ISSUER_BARC",
+                "issuer_name": "Barclays PLC",
+                "ultimate_parent_issuer_id": "ULTIMATE_BARC",
+                "ultimate_parent_issuer_name": "Barclays Group Holdings PLC"
             }
         }
     )

--- a/src/services/query_service/app/dtos/core_snapshot_dto.py
+++ b/src/services/query_service/app/dtos/core_snapshot_dto.py
@@ -252,6 +252,26 @@ class CoreSnapshotInstrumentEnrichmentRecord(BaseModel):
         description="Instrument display name.",
         examples=["Apple Inc."],
     )
+    issuer_id: Optional[str] = Field(
+        None,
+        description="Canonical direct issuer identifier.",
+        examples=["ISSUER_APPLE_INC"],
+    )
+    issuer_name: Optional[str] = Field(
+        None,
+        description="Display name for direct issuer.",
+        examples=["Apple Inc."],
+    )
+    ultimate_parent_issuer_id: Optional[str] = Field(
+        None,
+        description="Canonical ultimate parent issuer identifier.",
+        examples=["ISSUER_APPLE_HOLDING"],
+    )
+    ultimate_parent_issuer_name: Optional[str] = Field(
+        None,
+        description="Display name for ultimate parent issuer.",
+        examples=["Apple Holdings PLC"],
+    )
 
 
 class CoreSnapshotPortfolioTotals(BaseModel):

--- a/src/services/query_service/app/dtos/integration_dto.py
+++ b/src/services/query_service/app/dtos/integration_dto.py
@@ -23,3 +23,64 @@ class EffectiveIntegrationPolicyResponse(BaseModel):
     warnings: list[str] = Field(default_factory=list)
 
     model_config = ConfigDict()
+
+
+class InstrumentEnrichmentBulkRequest(BaseModel):
+    security_ids: list[str] = Field(
+        ...,
+        description="Canonical Lotus security identifiers to enrich.",
+        examples=[["SEC_AAPL_US", "SEC_MSFT_US"]],
+        min_length=1,
+    )
+
+    model_config = ConfigDict()
+
+
+class InstrumentEnrichmentRecord(BaseModel):
+    security_id: str = Field(
+        ...,
+        description="Canonical Lotus security identifier.",
+        examples=["SEC_AAPL_US"],
+    )
+    issuer_id: str | None = Field(
+        None,
+        description="Canonical direct issuer identifier, when available.",
+        examples=["ISSUER_APPLE_INC"],
+    )
+    issuer_name: str | None = Field(
+        None,
+        description="Display name for direct issuer, when available.",
+        examples=["Apple Inc."],
+    )
+    ultimate_parent_issuer_id: str | None = Field(
+        None,
+        description="Canonical ultimate parent issuer identifier, when available.",
+        examples=["ISSUER_APPLE_HOLDING"],
+    )
+    ultimate_parent_issuer_name: str | None = Field(
+        None,
+        description="Display name for ultimate parent issuer, when available.",
+        examples=["Apple Holdings PLC"],
+    )
+
+    model_config = ConfigDict()
+
+
+class InstrumentEnrichmentBulkResponse(BaseModel):
+    records: list[InstrumentEnrichmentRecord] = Field(
+        ...,
+        description="Deterministic enrichment records in the same order as request security_ids.",
+        examples=[
+            [
+                {
+                    "security_id": "SEC_AAPL_US",
+                    "issuer_id": "ISSUER_APPLE_INC",
+                    "issuer_name": "Apple Inc.",
+                    "ultimate_parent_issuer_id": "ISSUER_APPLE_HOLDING",
+                    "ultimate_parent_issuer_name": "Apple Holdings PLC",
+                }
+            ]
+        ],
+    )
+
+    model_config = ConfigDict()


### PR DESCRIPTION
## Summary
- add issuer_name and ultimate_parent_issuer_name into core instrument model and events
- extend core snapshot instrument enrichment with issuer identifiers and names
- add stateless bulk enrichment endpoint: POST /integration/instruments/enrichment-bulk
- regenerate lotus-core API vocabulary inventory per RFC-0067

## Validation
- python -m pytest tests/unit/services/query_service/dtos/test_core_snapshot_dto.py tests/unit/services/query_service/services/test_core_snapshot_service.py tests/unit/services/query_service/routers/test_integration_router.py -q
- python scripts/openapi_quality_gate.py
- python scripts/api_vocabulary_inventory.py --validate-only
