### PR TITLE
feat(buy-slice3): harden BUY calculations and invariants

### DIFF
--- a/docs/rfc-transaction-specs/transactions/BUY/BUY-SLICE-3-CALCULATION-INVARIANTS.md
+++ b/docs/rfc-transaction-specs/transactions/BUY/BUY-SLICE-3-CALCULATION-INVARIANTS.md
@@ -1,0 +1,37 @@
+# BUY Slice 3 - Calculation and Invariant Hardening
+
+## Scope Implemented
+
+- Canonical BUY calculation hardening in the financial calculation engine.
+- Deterministic BUY invariant checks.
+- Explicit realized P&L zero emission for BUY events.
+- Policy hook for accrued-interest exclusion from BUY book cost.
+
+## Behavior Changes
+
+- BUY now emits:
+  - `realized_gain_loss = 0`
+  - `realized_gain_loss_local = 0`
+- BUY principal `gross_cost` now follows base-currency semantics:
+  - `gross_cost = gross_transaction_amount * transaction_fx_rate`
+- Invariant failures are captured with deterministic reason text:
+  - quantity must be positive
+  - gross/base/book costs must be non-negative
+  - realized P&L for BUY must remain explicit zero
+
+## Policy Hook Added
+
+- `calculation_policy_id = BUY_EXCLUDE_ACCRUED_INTEREST_FROM_BOOK_COST`
+  - excludes accrued interest from BUY book cost while keeping principal and fees in cost basis.
+
+## Tests Added/Updated
+
+- Financial engine unit tests:
+  - BUY explicit zero realized P&L
+  - cross-currency BUY gross/base cost consistency
+  - accrued-interest exclusion policy behavior
+  - quantity invariant violation behavior
+- Cost calculator consumer unit test:
+  - verifies BUY emits explicit zero realized P&L values
+- Transaction processor unit test:
+  - verifies BUY transactions in recalculation timeline carry zero realized P&L

--- a/tests/unit/libs/financial-calculator-engine/unit/test_transaction_processor.py
+++ b/tests/unit/libs/financial-calculator-engine/unit/test_transaction_processor.py
@@ -92,6 +92,8 @@ def test_transaction_processor_handles_backdated_insert(transaction_processor: T
     # Check that the costs for the buy transactions are correct
     assert results["BUY_1"].net_cost == Decimal("1000")
     assert results["BUY_2_BACKDATED"].net_cost == Decimal("800")
+    assert results["BUY_1"].realized_gain_loss == Decimal("0")
+    assert results["BUY_2_BACKDATED"].realized_gain_loss == Decimal("0")
 
 @patch('engine.transaction_processor.RECALCULATION_DURATION_SECONDS')
 @patch('engine.transaction_processor.RECALCULATION_DEPTH')

--- a/tests/unit/services/calculators/cost_calculator_service/consumer/test_cost_calculator_consumer.py
+++ b/tests/unit/services/calculators/cost_calculator_service/consumer/test_cost_calculator_consumer.py
@@ -164,6 +164,8 @@ async def test_consumer_uses_trade_fee_in_calculation(
     updated_transaction_arg = mock_repo.update_transaction_costs.call_args[0][0]
     
     assert updated_transaction_arg.net_cost == Decimal("1507.50")
+    assert updated_transaction_arg.realized_gain_loss == Decimal("0")
+    assert updated_transaction_arg.realized_gain_loss_local == Decimal("0")
 
 async def test_consumer_propagates_epoch_field(
     cost_calculator_consumer: CostCalculatorConsumer, mock_buy_kafka_message: MagicMock, mock_dependencies


### PR DESCRIPTION
## Summary\n- enforce BUY invariants in financial calculation engine (positive quantity, non-negative cost fields)\n- emit explicit zero BUY realized P&L fields (base + local)\n- align BUY gross_cost to base-currency principal semantics\n- add policy hook: BUY_EXCLUDE_ACCRUED_INTEREST_FROM_BOOK_COST\n- add Slice 3 delivery doc under docs/rfc-transaction-specs/transactions/BUY\n\n## Validation\n- python -m pytest tests/unit/libs/financial-calculator-engine/unit/test_cost_calculator.py tests/unit/libs/financial-calculator-engine/unit/test_transaction_processor.py tests/unit/services/calculators/cost_calculator_service/consumer/test_cost_calculator_consumer.py -q\n- python -m pytest tests/unit/libs/portfolio_common/test_buy_validation.py tests/unit/transaction_specs/test_buy_slice0_characterization.py -q\n- python scripts/openapi_quality_gate.py\n- python scripts/api_vocabulary_inventory.py --validate-only\n\n## RFC Alignment\n- RFC-059 Slice 3 (BUY calculations and invariants hardening)\n- RFC-BUY-01 numeric invariant requirements for BUY realized P&L zero semantics