### PR TITLE
feat(buy): slice 6 conformance gate and regression suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
           - suite: unit
           - suite: unit-db
           - suite: integration-lite
+          - suite: buy-rfc
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint typecheck architecture-guard monetary-float-guard no-alias-gate openapi-gate api-vocabulary-gate warning-gate migration-smoke migration-apply test test-unit test-unit-db test-integration-lite test-e2e-smoke security-audit check coverage-gate ci ci-local docker-build clean
+.PHONY: install lint typecheck architecture-guard monetary-float-guard no-alias-gate openapi-gate api-vocabulary-gate warning-gate migration-smoke migration-apply test test-unit test-unit-db test-integration-lite test-buy-rfc test-e2e-smoke security-audit check coverage-gate ci ci-local docker-build clean
 
 install:
 	python scripts/bootstrap_dev.py
@@ -46,6 +46,9 @@ test-unit-db:
 
 test-integration-lite:
 	python scripts/test_manifest.py --suite integration-lite --quiet
+
+test-buy-rfc:
+	python scripts/test_manifest.py --suite buy-rfc --quiet
 
 test-e2e-smoke:
 	python scripts/test_manifest.py --suite e2e-smoke --quiet

--- a/docs/RFCs/RFC 059 - BUY Transaction RFC Implementation Plan.md
+++ b/docs/RFCs/RFC 059 - BUY Transaction RFC Implementation Plan.md
@@ -377,13 +377,13 @@ Use the following board in PR descriptions and weekly status updates:
 
 | Slice | Name | Status | Owner | PRs | Test Gate | Evidence | Notes |
 |---|---|---|---|---|---|---|---|
-| 0 | Baseline characterization | DONE | lotus-core engineering | pending | local green | gap matrix + characterization tests | Baseline lock established; canonical lock migration required in later slices |
-| 1 | Canonical contract + validation | TODO | TBD |  |  |  |  |
-| 2 | Persistence + linkage + policy metadata | TODO | TBD |  |  |  |  |
-| 3 | Calculations + invariants | TODO | TBD |  |  |  |  |
-| 4 | Position/lot/cash/offset | TODO | TBD |  |  |  |  |
-| 5 | Query + observability | TODO | TBD |  |  |  |  |
-| 6 | Final conformance gate | TODO | TBD |  |  |  |  |
+| 0 | Baseline characterization | DONE | lotus-core engineering | merged | local + CI green | `BUY-SLICE-0-GAP-ASSESSMENT.md` + characterization tests | Baseline lock established and used as migration guardrail. |
+| 1 | Canonical contract + validation | DONE | lotus-core engineering | merged | local + CI green | `BUY-SLICE-1-VALIDATION-REASON-CODES.md` + validator tests | Deterministic BUY reason-code foundation implemented. |
+| 2 | Persistence + linkage + policy metadata | DONE | lotus-core engineering | merged | local + CI green | `BUY-SLICE-2-PERSISTENCE-METADATA.md` + repository tests | Transaction linkage/policy metadata persisted with idempotent updates. |
+| 3 | Calculations + invariants | DONE | lotus-core engineering | merged | local + CI green | `BUY-SLICE-3-CALCULATION-INVARIANTS.md` + financial engine tests | Canonical BUY invariants and explicit realized P&L zero behavior enforced. |
+| 4 | Position/lot/cash/offset | DONE | lotus-core engineering | merged | local + CI green | `BUY-SLICE-4-LOT-CASH-OFFSET.md` + integration tests | Durable lot and accrued-offset state added with linkage propagation. |
+| 5 | Query + observability | DONE | lotus-core engineering | merged | local + CI green | `BUY-SLICE-5-QUERY-OBSERVABILITY.md` + query tests | BUY lot/offset/cash-linkage endpoints and lifecycle telemetry implemented. |
+| 6 | Final conformance gate | DONE | lotus-core engineering | pending | local green | `BUY-SLICE-6-CONFORMANCE-REPORT.md` + `buy-rfc` suite | Final section-level conformance map and dedicated CI regression suite added. |
 
 Status values:
 

--- a/docs/rfc-transaction-specs/transactions/BUY/BUY-SLICE-6-CONFORMANCE-REPORT.md
+++ b/docs/rfc-transaction-specs/transactions/BUY/BUY-SLICE-6-CONFORMANCE-REPORT.md
@@ -1,0 +1,63 @@
+# BUY Slice 6 - RFC Conformance Gate Report
+
+## Scope
+
+This report closes RFC-059 Slice 6 by mapping `RFC-BUY-01` requirements to implementation evidence and the dedicated BUY regression suite (`buy-rfc`).
+
+Status labels:
+
+- `COVERED`
+- `PARTIALLY_COVERED`
+- `NOT_COVERED`
+
+Behavior labels:
+
+- `MATCHES`
+- `PARTIALLY_MATCHES`
+- `DOES_NOT_MATCH`
+
+## Section-Level Conformance Matrix
+
+| RFC-BUY-01 Section | Status | Behavior | Evidence | Notes |
+|---|---|---|---|---|
+| 4. BUY Semantic Invariants | COVERED | MATCHES | `tests/unit/libs/financial-calculator-engine/unit/test_cost_calculator.py`, `tests/unit/transaction_specs/test_buy_slice0_characterization.py` | BUY quantity/cost progression and explicit zero realized P&L locked in tests. |
+| 5. BUY Processing Flow | PARTIALLY_COVERED | PARTIALLY_MATCHES | `src/services/calculators/cost_calculator_service/app/consumer.py`, `tests/unit/services/calculators/cashflow_calculator_service/unit/core/test_cashflow_logic.py` | Lifecycle is implemented across ingestion/persistence/calculation/query with stage telemetry; a single persisted lifecycle-stage state machine is not yet implemented. |
+| 6. BUY Canonical Data Model | COVERED | MATCHES | `tests/unit/services/ingestion_service/test_transaction_model.py`, `tests/unit/libs/portfolio_common/test_transaction_metadata_contract.py` | Canonical BUY metadata, linkage fields, and policy metadata are preserved end-to-end. |
+| 7. BUY Validation Rules | COVERED | MATCHES | `tests/unit/libs/portfolio_common/test_buy_validation.py`, `docs/rfc-transaction-specs/transactions/BUY/BUY-SLICE-1-VALIDATION-REASON-CODES.md` | Deterministic reason codes and strict metadata validation are implemented. |
+| 8. BUY Calculation Rules and Formulas | COVERED | MATCHES | `tests/unit/libs/financial-calculator-engine/unit/test_cost_calculator.py` | Calculation invariants and cross-currency rules are enforced. |
+| 9. BUY Position Rules | COVERED | MATCHES | `tests/unit/transaction_specs/test_buy_slice0_characterization.py` | BUY increases position quantity and cost basis as required. |
+| 10. BUY Lot Rules | COVERED | MATCHES | `tests/integration/services/calculators/cost_calculator_service/test_int_cost_repository_lot_offset.py` | Durable BUY lot-state creation/upsert behavior validated. |
+| 11. BUY Cash and Dual-Accounting Rules | COVERED | MATCHES | `tests/unit/services/calculators/cashflow_calculator_service/unit/core/test_cashflow_logic.py`, `tests/unit/libs/financial-calculator-engine/unit/test_cost_calculator.py` | BUY outflow sign, linkage propagation, and dual-currency handling validated. |
+| 12. BUY Accrued-Interest Offset Rules | COVERED | MATCHES | `tests/integration/services/calculators/cost_calculator_service/test_int_cost_repository_lot_offset.py` | Accrued-interest offset initialization and persistence are validated. |
+| 13. BUY Timing Rules | PARTIALLY_COVERED | PARTIALLY_MATCHES | `tests/unit/libs/portfolio_common/test_buy_validation.py` | Date ordering and settlement-date requirements are enforced; broader policy-level timing modes remain to be added with later transaction RFC rollout. |
+| 14. BUY Query / Output Contract | COVERED | MATCHES | `tests/unit/services/query_service/repositories/test_buy_state_repository.py`, `tests/unit/services/query_service/services/test_buy_state_service.py`, `tests/integration/services/query_service/test_buy_state_router.py` | BUY lot/offset/cash-linkage query surfaces are implemented and tested. |
+| 17. BUY Test Matrix | COVERED | MATCHES | `scripts/test_manifest.py` (`buy-rfc` suite) | Dedicated regression suite now aggregates BUY-critical tests across unit/integration layers. |
+| 19. BUY Configurable Policies | COVERED | MATCHES | `tests/unit/libs/financial-calculator-engine/unit/test_cost_calculator.py` | BUY policy hook coverage exists for accrued-interest exclusion policy. |
+| 20. BUY Gap Assessment Checklist | COVERED | MATCHES | `docs/rfc-transaction-specs/transactions/BUY/BUY-SLICE-0-GAP-ASSESSMENT.md`, this report | Gap tracking and final conformance evidence are now both in-repo artifacts. |
+
+## Dedicated Regression Suite
+
+- Suite name: `buy-rfc`
+- Source: `scripts/test_manifest.py`
+- Local command: `make test-buy-rfc`
+- CI command: `python scripts/test_manifest.py --suite buy-rfc --with-coverage --coverage-file .coverage.buy-rfc`
+- CI wiring: `.github/workflows/ci.yml` test matrix includes `buy-rfc`
+
+## Residual Accepted Gaps
+
+1. Lifecycle stage persistence model:
+   - Current state: stage-level metrics/logging exists, but no single persisted state-machine record per transaction.
+   - Impact: low for current BUY correctness; medium for support diagnostics depth.
+   - Disposition: accepted for BUY completion; can be elevated in a future observability-focused RFC.
+2. Extended timing-policy modes:
+   - Current state: mandatory date validation and ordering enforcement exists; advanced timing-mode expansion is not yet modeled as policy catalog.
+   - Impact: low for current BUY baseline; future enhancement for broader policy programmability.
+   - Disposition: accepted and explicitly tracked for follow-on transaction RFC work.
+
+## Exit Decision
+
+Slice 6 is complete for BUY under RFC-059:
+
+- blocking BUY behaviors are covered and test-backed
+- dedicated regression suite is wired into CI
+- residual non-blocking gaps are explicit and accepted

--- a/scripts/test_manifest.py
+++ b/scripts/test_manifest.py
@@ -28,6 +28,19 @@ SUITES: dict[str, list[str]] = {
         "tests/e2e/test_query_service_observability.py",
         "tests/e2e/test_complex_portfolio_lifecycle.py",
     ],
+    "buy-rfc": [
+        "tests/unit/transaction_specs/test_buy_slice0_characterization.py",
+        "tests/unit/libs/portfolio_common/test_buy_validation.py",
+        "tests/unit/libs/portfolio_common/test_transaction_metadata_contract.py",
+        "tests/unit/services/ingestion_service/test_transaction_model.py",
+        "tests/unit/libs/financial-calculator-engine/unit/test_cost_calculator.py",
+        "tests/unit/libs/financial-calculator-engine/unit/test_transaction_processor.py",
+        "tests/unit/services/calculators/cashflow_calculator_service/unit/core/test_cashflow_logic.py",
+        "tests/unit/services/query_service/repositories/test_buy_state_repository.py",
+        "tests/unit/services/query_service/services/test_buy_state_service.py",
+        "tests/integration/services/calculators/cost_calculator_service/test_int_cost_repository_lot_offset.py",
+        "tests/integration/services/query_service/test_buy_state_router.py",
+    ],
 }
 
 SOURCE = "src/services/query_service/app"


### PR DESCRIPTION
## Summary
- add BUY Slice 6 conformance report with section-level RFC-BUY-01 evidence map
- add dedicated buy-rfc regression suite to scripts/test_manifest.py and expose make test-buy-rfc
- wire buy-rfc into GitHub Actions CI test matrix
- update RFC-059 tracking board statuses through Slice 6

## Validation
- make test-buy-rfc
- python scripts/test_manifest.py --suite buy-rfc --validate-only
- python -m ruff check scripts/test_manifest.py
- python -m ruff format --check scripts/test_manifest.py
