### PR TITLE
Refactor ingestion routers to share idempotency header definition

### DIFF
--- a/src/services/ingestion_service/app/request_metadata.py
+++ b/src/services/ingestion_service/app/request_metadata.py
@@ -1,11 +1,21 @@
+from typing import Annotated
 from uuid import uuid4
 
-from fastapi import Request
+from fastapi import Header, Request
 from portfolio_common.logging_utils import correlation_id_var, request_id_var, trace_id_var
 
 
 def resolve_idempotency_key(request: Request) -> str | None:
     return request.headers.get("X-Idempotency-Key")
+
+
+IdempotencyKeyHeader = Annotated[
+    str | None,
+    Header(
+        alias="X-Idempotency-Key",
+        description=("Optional idempotency key to make retries safe for the same logical request."),
+    ),
+]
 
 
 def create_ingestion_job_id() -> str:

--- a/src/services/ingestion_service/app/routers/business_dates.py
+++ b/src/services/ingestion_service/app/routers/business_dates.py
@@ -1,13 +1,12 @@
 # services/ingestion_service/app/routers/business_dates.py
 import logging
-from typing import Annotated
 
 from app.ack_response import build_batch_ack
 from app.DTOs.business_date_dto import BusinessDateIngestionRequest
 from app.DTOs.ingestion_ack_dto import BatchIngestionAcceptedResponse
-from app.request_metadata import resolve_idempotency_key
+from app.request_metadata import IdempotencyKeyHeader, resolve_idempotency_key
 from app.services.ingestion_service import IngestionService, get_ingestion_service
-from fastapi import APIRouter, Depends, Header, Request, status
+from fastapi import APIRouter, Depends, Request, status
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -24,7 +23,7 @@ router = APIRouter()
 async def ingest_business_dates(
     request: BusinessDateIngestionRequest,
     http_request: Request,
-    idempotency_key_header: Annotated[str | None, Header(alias="X-Idempotency-Key")] = None,
+    idempotency_key_header: IdempotencyKeyHeader = None,
     ingestion_service: IngestionService = Depends(get_ingestion_service),
 ):
     idempotency_key = idempotency_key_header or resolve_idempotency_key(http_request)

--- a/src/services/ingestion_service/app/routers/fx_rates.py
+++ b/src/services/ingestion_service/app/routers/fx_rates.py
@@ -1,13 +1,12 @@
 # services/ingestion_service/app/routers/fx_rates.py
 import logging
-from typing import Annotated
 
 from app.ack_response import build_batch_ack
 from app.DTOs.fx_rate_dto import FxRateIngestionRequest
 from app.DTOs.ingestion_ack_dto import BatchIngestionAcceptedResponse
-from app.request_metadata import resolve_idempotency_key
+from app.request_metadata import IdempotencyKeyHeader, resolve_idempotency_key
 from app.services.ingestion_service import IngestionService, get_ingestion_service
-from fastapi import APIRouter, Depends, Header, Request, status
+from fastapi import APIRouter, Depends, Request, status
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -24,7 +23,7 @@ router = APIRouter()
 async def ingest_fx_rates(
     request: FxRateIngestionRequest,
     http_request: Request,
-    idempotency_key_header: Annotated[str | None, Header(alias="X-Idempotency-Key")] = None,
+    idempotency_key_header: IdempotencyKeyHeader = None,
     ingestion_service: IngestionService = Depends(get_ingestion_service),
 ):
     idempotency_key = idempotency_key_header or resolve_idempotency_key(http_request)

--- a/src/services/ingestion_service/app/routers/instruments.py
+++ b/src/services/ingestion_service/app/routers/instruments.py
@@ -1,13 +1,12 @@
 # services/ingestion_service/app/routers/instruments.py
 import logging
-from typing import Annotated
 
 from app.ack_response import build_batch_ack
 from app.DTOs.ingestion_ack_dto import BatchIngestionAcceptedResponse
 from app.DTOs.instrument_dto import InstrumentIngestionRequest
-from app.request_metadata import resolve_idempotency_key
+from app.request_metadata import IdempotencyKeyHeader, resolve_idempotency_key
 from app.services.ingestion_service import IngestionService, get_ingestion_service
-from fastapi import APIRouter, Depends, Header, Request, status
+from fastapi import APIRouter, Depends, Request, status
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -24,7 +23,7 @@ router = APIRouter()
 async def ingest_instruments(
     request: InstrumentIngestionRequest,
     http_request: Request,
-    idempotency_key_header: Annotated[str | None, Header(alias="X-Idempotency-Key")] = None,
+    idempotency_key_header: IdempotencyKeyHeader = None,
     ingestion_service: IngestionService = Depends(get_ingestion_service),
 ):
     idempotency_key = idempotency_key_header or resolve_idempotency_key(http_request)

--- a/src/services/ingestion_service/app/routers/market_prices.py
+++ b/src/services/ingestion_service/app/routers/market_prices.py
@@ -1,13 +1,12 @@
 # services/ingestion_service/app/routers/market_prices.py
 import logging
-from typing import Annotated
 
 from app.ack_response import build_batch_ack
 from app.DTOs.ingestion_ack_dto import BatchIngestionAcceptedResponse
 from app.DTOs.market_price_dto import MarketPriceIngestionRequest
-from app.request_metadata import resolve_idempotency_key
+from app.request_metadata import IdempotencyKeyHeader, resolve_idempotency_key
 from app.services.ingestion_service import IngestionService, get_ingestion_service
-from fastapi import APIRouter, Depends, Header, Request, status
+from fastapi import APIRouter, Depends, Request, status
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -24,7 +23,7 @@ router = APIRouter()
 async def ingest_market_prices(
     request: MarketPriceIngestionRequest,
     http_request: Request,
-    idempotency_key_header: Annotated[str | None, Header(alias="X-Idempotency-Key")] = None,
+    idempotency_key_header: IdempotencyKeyHeader = None,
     ingestion_service: IngestionService = Depends(get_ingestion_service),
 ):
     idempotency_key = idempotency_key_header or resolve_idempotency_key(http_request)

--- a/src/services/ingestion_service/app/routers/portfolio_bundle.py
+++ b/src/services/ingestion_service/app/routers/portfolio_bundle.py
@@ -1,13 +1,12 @@
 import logging
-from typing import Annotated
 
 from app.ack_response import build_batch_ack
 from app.adapter_mode import require_portfolio_bundle_adapter_enabled
 from app.DTOs.ingestion_ack_dto import BatchIngestionAcceptedResponse
 from app.DTOs.portfolio_bundle_dto import PortfolioBundleIngestionRequest
-from app.request_metadata import resolve_idempotency_key
+from app.request_metadata import IdempotencyKeyHeader, resolve_idempotency_key
 from app.services.ingestion_service import IngestionService, get_ingestion_service
-from fastapi import APIRouter, Depends, Header, Request, status
+from fastapi import APIRouter, Depends, Request, status
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -33,7 +32,7 @@ router = APIRouter()
 async def ingest_portfolio_bundle(
     request: PortfolioBundleIngestionRequest,
     http_request: Request,
-    idempotency_key_header: Annotated[str | None, Header(alias="X-Idempotency-Key")] = None,
+    idempotency_key_header: IdempotencyKeyHeader = None,
     _: None = Depends(require_portfolio_bundle_adapter_enabled),
     ingestion_service: IngestionService = Depends(get_ingestion_service),
 ):

--- a/src/services/ingestion_service/app/routers/portfolios.py
+++ b/src/services/ingestion_service/app/routers/portfolios.py
@@ -1,12 +1,11 @@
 import logging
-from typing import Annotated
 
 from app.ack_response import build_batch_ack
 from app.DTOs.ingestion_ack_dto import BatchIngestionAcceptedResponse
 from app.DTOs.portfolio_dto import PortfolioIngestionRequest
-from app.request_metadata import resolve_idempotency_key
+from app.request_metadata import IdempotencyKeyHeader, resolve_idempotency_key
 from app.services.ingestion_service import IngestionService, get_ingestion_service
-from fastapi import APIRouter, Depends, Header, Request, status
+from fastapi import APIRouter, Depends, Request, status
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -23,7 +22,7 @@ router = APIRouter()
 async def ingest_portfolios(
     request: PortfolioIngestionRequest,
     http_request: Request,
-    idempotency_key_header: Annotated[str | None, Header(alias="X-Idempotency-Key")] = None,
+    idempotency_key_header: IdempotencyKeyHeader = None,
     ingestion_service: IngestionService = Depends(get_ingestion_service),
 ):
     idempotency_key = idempotency_key_header or resolve_idempotency_key(http_request)

--- a/src/services/ingestion_service/app/routers/reprocessing.py
+++ b/src/services/ingestion_service/app/routers/reprocessing.py
@@ -1,11 +1,10 @@
 # src/services/ingestion_service/app/routers/reprocessing.py
 import logging
-from typing import Annotated
 
 from app.ack_response import build_batch_ack
 from app.DTOs.ingestion_ack_dto import BatchIngestionAcceptedResponse
-from app.request_metadata import get_request_lineage, resolve_idempotency_key
-from fastapi import APIRouter, Depends, Header, Request, status
+from app.request_metadata import IdempotencyKeyHeader, get_request_lineage, resolve_idempotency_key
+from fastapi import APIRouter, Depends, Request, status
 from portfolio_common.kafka_utils import KafkaProducer, get_kafka_producer
 
 from ..DTOs.reprocessing_dto import ReprocessingRequest
@@ -31,7 +30,7 @@ REPROCESSING_REQUESTED_TOPIC = "transactions_reprocessing_requested"
 async def reprocess_transactions(
     request: ReprocessingRequest,
     http_request: Request,
-    idempotency_key_header: Annotated[str | None, Header(alias="X-Idempotency-Key")] = None,
+    idempotency_key_header: IdempotencyKeyHeader = None,
     kafka_producer: KafkaProducer = Depends(get_kafka_producer),
 ):
     """

--- a/src/services/ingestion_service/app/routers/transactions.py
+++ b/src/services/ingestion_service/app/routers/transactions.py
@@ -1,12 +1,11 @@
 import logging
-from typing import Annotated
 
 from app.ack_response import build_batch_ack, build_single_ack
 from app.DTOs.ingestion_ack_dto import BatchIngestionAcceptedResponse, IngestionAcceptedResponse
 from app.DTOs.transaction_dto import Transaction, TransactionIngestionRequest
-from app.request_metadata import resolve_idempotency_key
+from app.request_metadata import IdempotencyKeyHeader, resolve_idempotency_key
 from app.services.ingestion_service import IngestionService, get_ingestion_service
-from fastapi import APIRouter, Depends, Header, Request, status
+from fastapi import APIRouter, Depends, Request, status
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -23,15 +22,7 @@ router = APIRouter()
 async def ingest_transaction(
     transaction: Transaction,
     request: Request,
-    idempotency_key_header: Annotated[
-        str | None,
-        Header(
-            alias="X-Idempotency-Key",
-            description=(
-                "Optional idempotency key to make retries safe for the same logical request."
-            ),
-        ),
-    ] = None,
+    idempotency_key_header: IdempotencyKeyHeader = None,
     ingestion_service: IngestionService = Depends(get_ingestion_service),
 ):
     idempotency_key = idempotency_key_header or resolve_idempotency_key(request)
@@ -69,15 +60,7 @@ async def ingest_transaction(
 async def ingest_transactions(
     request: TransactionIngestionRequest,
     http_request: Request,
-    idempotency_key_header: Annotated[
-        str | None,
-        Header(
-            alias="X-Idempotency-Key",
-            description=(
-                "Optional idempotency key to make retries safe for the same logical request."
-            ),
-        ),
-    ] = None,
+    idempotency_key_header: IdempotencyKeyHeader = None,
     ingestion_service: IngestionService = Depends(get_ingestion_service),
 ):
     idempotency_key = idempotency_key_header or resolve_idempotency_key(http_request)


### PR DESCRIPTION
## Summary
- introduce shared IdempotencyKeyHeader type in request metadata
- remove repeated idempotency header annotation boilerplate across ingestion routers
- keep behavior unchanged while improving modularity and readability

## Validation
- python -m ruff check src/services/ingestion_service/app/request_metadata.py src/services/ingestion_service/app/routers/transactions.py src/services/ingestion_service/app/routers/portfolios.py src/services/ingestion_service/app/routers/instruments.py src/services/ingestion_service/app/routers/market_prices.py src/services/ingestion_service/app/routers/fx_rates.py src/services/ingestion_service/app/routers/business_dates.py src/services/ingestion_service/app/routers/portfolio_bundle.py src/services/ingestion_service/app/routers/reprocessing.py
- python -m pytest tests/integration/services/ingestion_service/test_ingestion_routers.py tests/unit/services/ingestion_service/services/test_ingestion_service.py -q
