### PR TITLE
Add ingestion operations job APIs and lifecycle tracking

### DIFF
--- a/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
+++ b/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
@@ -1,0 +1,72 @@
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+IngestionJobStatus = Literal["accepted", "queued", "failed"]
+
+
+class IngestionJobResponse(BaseModel):
+    job_id: str = Field(
+        description="Asynchronous ingestion job identifier.",
+        examples=["job_01J5S0J6D3BAVMK2E1V0WQ7MCC"],
+    )
+    endpoint: str = Field(
+        description="Ingestion API endpoint that created this job.",
+        examples=["/ingest/transactions"],
+    )
+    entity_type: str = Field(
+        description="Canonical entity type accepted by the endpoint.",
+        examples=["transaction"],
+    )
+    status: IngestionJobStatus = Field(
+        description="Current ingestion job lifecycle state.",
+        examples=["queued"],
+    )
+    accepted_count: int = Field(
+        ge=0,
+        description="Number of records accepted by the ingestion request.",
+        examples=[125],
+    )
+    idempotency_key: str | None = Field(
+        default=None,
+        description="Client idempotency key if supplied for the request.",
+        examples=["ingestion-transactions-batch-20260228-001"],
+    )
+    correlation_id: str = Field(
+        description="Correlation identifier for cross-service traceability.",
+        examples=["ING:7f4a64b0-35f4-41bc-8f74-cb556f2ad9a3"],
+    )
+    request_id: str = Field(
+        description="Request identifier for ingress request tracking.",
+        examples=["REQ:3a63936e-bf29-41e2-9f16-faf4e561d845"],
+    )
+    trace_id: str = Field(
+        description="Distributed trace identifier for observability stitching.",
+        examples=["4bf92f3577b34da6a3ce929d0e0e4736"],
+    )
+    submitted_at: datetime = Field(
+        description="Timestamp when the ingestion job was accepted.",
+        examples=["2026-02-28T13:22:24.201Z"],
+    )
+    completed_at: datetime | None = Field(
+        default=None,
+        description="Timestamp when the job reached a terminal or queued state.",
+        examples=["2026-02-28T13:22:24.994Z"],
+    )
+    failure_reason: str | None = Field(
+        default=None,
+        description="Failure reason when status is failed.",
+        examples=["Kafka publish timeout for topic raw_transactions."],
+    )
+
+
+class IngestionJobListResponse(BaseModel):
+    jobs: list[IngestionJobResponse] = Field(
+        description="Ingestion jobs matching the requested filters."
+    )
+    total: int = Field(
+        ge=0,
+        description="Number of jobs returned in this response.",
+        examples=[20],
+    )

--- a/src/services/ingestion_service/app/ack_response.py
+++ b/src/services/ingestion_service/app/ack_response.py
@@ -1,5 +1,5 @@
 from app.DTOs.ingestion_ack_dto import BatchIngestionAcceptedResponse, IngestionAcceptedResponse
-from app.request_metadata import create_ingestion_job_id, get_request_lineage
+from app.request_metadata import get_request_lineage
 
 
 def build_single_ack(
@@ -24,6 +24,7 @@ def build_batch_ack(
     *,
     message: str,
     entity_type: str,
+    job_id: str,
     accepted_count: int,
     idempotency_key: str | None,
 ) -> BatchIngestionAcceptedResponse:
@@ -32,7 +33,7 @@ def build_batch_ack(
         message=message,
         entity_type=entity_type,
         accepted_count=accepted_count,
-        job_id=create_ingestion_job_id(),
+        job_id=job_id,
         correlation_id=correlation_id,
         request_id=request_id,
         trace_id=trace_id,

--- a/src/services/ingestion_service/app/main.py
+++ b/src/services/ingestion_service/app/main.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 from app.routers import (
     business_dates,
     fx_rates,
+    ingestion_jobs,
     instruments,
     market_prices,
     portfolio_bundle,
@@ -202,3 +203,4 @@ app.include_router(business_dates.router)
 app.include_router(reprocessing.router)
 app.include_router(portfolio_bundle.router)
 app.include_router(uploads.router)
+app.include_router(ingestion_jobs.router)

--- a/src/services/ingestion_service/app/routers/business_dates.py
+++ b/src/services/ingestion_service/app/routers/business_dates.py
@@ -4,7 +4,13 @@ import logging
 from app.ack_response import build_batch_ack
 from app.DTOs.business_date_dto import BusinessDateIngestionRequest
 from app.DTOs.ingestion_ack_dto import BatchIngestionAcceptedResponse
-from app.request_metadata import IdempotencyKeyHeader, resolve_idempotency_key
+from app.request_metadata import (
+    IdempotencyKeyHeader,
+    create_ingestion_job_id,
+    get_request_lineage,
+    resolve_idempotency_key,
+)
+from app.services.ingestion_job_service import IngestionJobService, get_ingestion_job_service
 from app.services.ingestion_service import IngestionService, get_ingestion_service
 from fastapi import APIRouter, Depends, Request, status
 
@@ -25,22 +31,41 @@ async def ingest_business_dates(
     http_request: Request,
     idempotency_key_header: IdempotencyKeyHeader = None,
     ingestion_service: IngestionService = Depends(get_ingestion_service),
+    ingestion_job_service: IngestionJobService = Depends(get_ingestion_job_service),
 ):
     idempotency_key = idempotency_key_header or resolve_idempotency_key(http_request)
     num_dates = len(request.business_dates)
+    job_id = create_ingestion_job_id()
+    correlation_id, request_id, trace_id = get_request_lineage()
+    ingestion_job_service.create_job(
+        job_id=job_id,
+        endpoint=str(http_request.url.path),
+        entity_type="business_date",
+        accepted_count=num_dates,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+        request_id=request_id,
+        trace_id=trace_id,
+    )
     logger.info(
         "Received request to ingest business dates.",
         extra={"num_dates": num_dates, "idempotency_key": idempotency_key},
     )
 
-    await ingestion_service.publish_business_dates(
-        request.business_dates, idempotency_key=idempotency_key
-    )
+    try:
+        await ingestion_service.publish_business_dates(
+            request.business_dates, idempotency_key=idempotency_key
+        )
+        ingestion_job_service.mark_queued(job_id)
+    except Exception as exc:
+        ingestion_job_service.mark_failed(job_id, str(exc))
+        raise
 
     logger.info("Business dates successfully queued.", extra={"num_dates": num_dates})
     return build_batch_ack(
         message="Business dates accepted for asynchronous ingestion processing.",
         entity_type="business_date",
+        job_id=job_id,
         accepted_count=num_dates,
         idempotency_key=idempotency_key,
     )

--- a/src/services/ingestion_service/app/routers/fx_rates.py
+++ b/src/services/ingestion_service/app/routers/fx_rates.py
@@ -4,7 +4,13 @@ import logging
 from app.ack_response import build_batch_ack
 from app.DTOs.fx_rate_dto import FxRateIngestionRequest
 from app.DTOs.ingestion_ack_dto import BatchIngestionAcceptedResponse
-from app.request_metadata import IdempotencyKeyHeader, resolve_idempotency_key
+from app.request_metadata import (
+    IdempotencyKeyHeader,
+    create_ingestion_job_id,
+    get_request_lineage,
+    resolve_idempotency_key,
+)
+from app.services.ingestion_job_service import IngestionJobService, get_ingestion_job_service
 from app.services.ingestion_service import IngestionService, get_ingestion_service
 from fastapi import APIRouter, Depends, Request, status
 
@@ -25,20 +31,39 @@ async def ingest_fx_rates(
     http_request: Request,
     idempotency_key_header: IdempotencyKeyHeader = None,
     ingestion_service: IngestionService = Depends(get_ingestion_service),
+    ingestion_job_service: IngestionJobService = Depends(get_ingestion_job_service),
 ):
     idempotency_key = idempotency_key_header or resolve_idempotency_key(http_request)
     num_rates = len(request.fx_rates)
+    job_id = create_ingestion_job_id()
+    correlation_id, request_id, trace_id = get_request_lineage()
+    ingestion_job_service.create_job(
+        job_id=job_id,
+        endpoint=str(http_request.url.path),
+        entity_type="fx_rate",
+        accepted_count=num_rates,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+        request_id=request_id,
+        trace_id=trace_id,
+    )
     logger.info(
         "Received request to ingest fx rates.",
         extra={"num_rates": num_rates, "idempotency_key": idempotency_key},
     )
 
-    await ingestion_service.publish_fx_rates(request.fx_rates, idempotency_key=idempotency_key)
+    try:
+        await ingestion_service.publish_fx_rates(request.fx_rates, idempotency_key=idempotency_key)
+        ingestion_job_service.mark_queued(job_id)
+    except Exception as exc:
+        ingestion_job_service.mark_failed(job_id, str(exc))
+        raise
 
     logger.info("FX rates successfully queued.", extra={"num_rates": num_rates})
     return build_batch_ack(
         message="FX rates accepted for asynchronous ingestion processing.",
         entity_type="fx_rate",
+        job_id=job_id,
         accepted_count=num_rates,
         idempotency_key=idempotency_key,
     )

--- a/src/services/ingestion_service/app/routers/ingestion_jobs.py
+++ b/src/services/ingestion_service/app/routers/ingestion_jobs.py
@@ -1,0 +1,56 @@
+import logging
+
+from app.DTOs.ingestion_job_dto import IngestionJobListResponse, IngestionJobResponse
+from app.services.ingestion_job_service import IngestionJobService, get_ingestion_job_service
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+@router.get(
+    "/ingestion/jobs/{job_id}",
+    response_model=IngestionJobResponse,
+    status_code=status.HTTP_200_OK,
+    tags=["Ingestion Operations"],
+    summary="Get ingestion job status",
+    description="Returns ingestion job lifecycle status and operational metadata by job_id.",
+)
+async def get_ingestion_job(
+    job_id: str,
+    ingestion_job_service: IngestionJobService = Depends(get_ingestion_job_service),
+):
+    job = ingestion_job_service.get_job(job_id)
+    if job is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "code": "INGESTION_JOB_NOT_FOUND",
+                "message": f"Ingestion job '{job_id}' was not found.",
+            },
+        )
+    return job
+
+
+@router.get(
+    "/ingestion/jobs",
+    response_model=IngestionJobListResponse,
+    status_code=status.HTTP_200_OK,
+    tags=["Ingestion Operations"],
+    summary="List ingestion jobs",
+    description=(
+        "Returns recent ingestion jobs for operational monitoring. "
+        "Supports filtering by status and entity_type."
+    ),
+)
+async def list_ingestion_jobs(
+    status_filter: str | None = Query(default=None, alias="status"),
+    entity_type: str | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=500),
+    ingestion_job_service: IngestionJobService = Depends(get_ingestion_job_service),
+):
+    status_value = status_filter if status_filter in {"accepted", "queued", "failed"} else None
+    jobs = ingestion_job_service.list_jobs(
+        status=status_value, entity_type=entity_type, limit=limit
+    )
+    return IngestionJobListResponse(jobs=jobs, total=len(jobs))

--- a/src/services/ingestion_service/app/routers/instruments.py
+++ b/src/services/ingestion_service/app/routers/instruments.py
@@ -4,7 +4,13 @@ import logging
 from app.ack_response import build_batch_ack
 from app.DTOs.ingestion_ack_dto import BatchIngestionAcceptedResponse
 from app.DTOs.instrument_dto import InstrumentIngestionRequest
-from app.request_metadata import IdempotencyKeyHeader, resolve_idempotency_key
+from app.request_metadata import (
+    IdempotencyKeyHeader,
+    create_ingestion_job_id,
+    get_request_lineage,
+    resolve_idempotency_key,
+)
+from app.services.ingestion_job_service import IngestionJobService, get_ingestion_job_service
 from app.services.ingestion_service import IngestionService, get_ingestion_service
 from fastapi import APIRouter, Depends, Request, status
 
@@ -25,22 +31,41 @@ async def ingest_instruments(
     http_request: Request,
     idempotency_key_header: IdempotencyKeyHeader = None,
     ingestion_service: IngestionService = Depends(get_ingestion_service),
+    ingestion_job_service: IngestionJobService = Depends(get_ingestion_job_service),
 ):
     idempotency_key = idempotency_key_header or resolve_idempotency_key(http_request)
     num_instruments = len(request.instruments)
+    job_id = create_ingestion_job_id()
+    correlation_id, request_id, trace_id = get_request_lineage()
+    ingestion_job_service.create_job(
+        job_id=job_id,
+        endpoint=str(http_request.url.path),
+        entity_type="instrument",
+        accepted_count=num_instruments,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+        request_id=request_id,
+        trace_id=trace_id,
+    )
     logger.info(
         "Received request to ingest instruments.",
         extra={"num_instruments": num_instruments, "idempotency_key": idempotency_key},
     )
 
-    await ingestion_service.publish_instruments(
-        request.instruments, idempotency_key=idempotency_key
-    )
+    try:
+        await ingestion_service.publish_instruments(
+            request.instruments, idempotency_key=idempotency_key
+        )
+        ingestion_job_service.mark_queued(job_id)
+    except Exception as exc:
+        ingestion_job_service.mark_failed(job_id, str(exc))
+        raise
 
     logger.info("Instruments successfully queued.", extra={"num_instruments": num_instruments})
     return build_batch_ack(
         message="Instruments accepted for asynchronous ingestion processing.",
         entity_type="instrument",
+        job_id=job_id,
         accepted_count=num_instruments,
         idempotency_key=idempotency_key,
     )

--- a/src/services/ingestion_service/app/routers/market_prices.py
+++ b/src/services/ingestion_service/app/routers/market_prices.py
@@ -4,7 +4,13 @@ import logging
 from app.ack_response import build_batch_ack
 from app.DTOs.ingestion_ack_dto import BatchIngestionAcceptedResponse
 from app.DTOs.market_price_dto import MarketPriceIngestionRequest
-from app.request_metadata import IdempotencyKeyHeader, resolve_idempotency_key
+from app.request_metadata import (
+    IdempotencyKeyHeader,
+    create_ingestion_job_id,
+    get_request_lineage,
+    resolve_idempotency_key,
+)
+from app.services.ingestion_job_service import IngestionJobService, get_ingestion_job_service
 from app.services.ingestion_service import IngestionService, get_ingestion_service
 from fastapi import APIRouter, Depends, Request, status
 
@@ -25,22 +31,41 @@ async def ingest_market_prices(
     http_request: Request,
     idempotency_key_header: IdempotencyKeyHeader = None,
     ingestion_service: IngestionService = Depends(get_ingestion_service),
+    ingestion_job_service: IngestionJobService = Depends(get_ingestion_job_service),
 ):
     idempotency_key = idempotency_key_header or resolve_idempotency_key(http_request)
     num_prices = len(request.market_prices)
+    job_id = create_ingestion_job_id()
+    correlation_id, request_id, trace_id = get_request_lineage()
+    ingestion_job_service.create_job(
+        job_id=job_id,
+        endpoint=str(http_request.url.path),
+        entity_type="market_price",
+        accepted_count=num_prices,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+        request_id=request_id,
+        trace_id=trace_id,
+    )
     logger.info(
         "Received request to ingest market prices.",
         extra={"num_prices": num_prices, "idempotency_key": idempotency_key},
     )
 
-    await ingestion_service.publish_market_prices(
-        request.market_prices, idempotency_key=idempotency_key
-    )
+    try:
+        await ingestion_service.publish_market_prices(
+            request.market_prices, idempotency_key=idempotency_key
+        )
+        ingestion_job_service.mark_queued(job_id)
+    except Exception as exc:
+        ingestion_job_service.mark_failed(job_id, str(exc))
+        raise
 
     logger.info("Market prices successfully queued.", extra={"num_prices": num_prices})
     return build_batch_ack(
         message="Market prices accepted for asynchronous ingestion processing.",
         entity_type="market_price",
+        job_id=job_id,
         accepted_count=num_prices,
         idempotency_key=idempotency_key,
     )

--- a/src/services/ingestion_service/app/routers/portfolio_bundle.py
+++ b/src/services/ingestion_service/app/routers/portfolio_bundle.py
@@ -4,7 +4,13 @@ from app.ack_response import build_batch_ack
 from app.adapter_mode import require_portfolio_bundle_adapter_enabled
 from app.DTOs.ingestion_ack_dto import BatchIngestionAcceptedResponse
 from app.DTOs.portfolio_bundle_dto import PortfolioBundleIngestionRequest
-from app.request_metadata import IdempotencyKeyHeader, resolve_idempotency_key
+from app.request_metadata import (
+    IdempotencyKeyHeader,
+    create_ingestion_job_id,
+    get_request_lineage,
+    resolve_idempotency_key,
+)
+from app.services.ingestion_job_service import IngestionJobService, get_ingestion_job_service
 from app.services.ingestion_service import IngestionService, get_ingestion_service
 from fastapi import APIRouter, Depends, Request, status
 
@@ -35,12 +41,37 @@ async def ingest_portfolio_bundle(
     idempotency_key_header: IdempotencyKeyHeader = None,
     _: None = Depends(require_portfolio_bundle_adapter_enabled),
     ingestion_service: IngestionService = Depends(get_ingestion_service),
+    ingestion_job_service: IngestionJobService = Depends(get_ingestion_job_service),
 ):
     idempotency_key = idempotency_key_header or resolve_idempotency_key(http_request)
-    published_counts = await ingestion_service.publish_portfolio_bundle(
-        request, idempotency_key=idempotency_key
+    accepted_count = (
+        len(request.business_dates)
+        + len(request.portfolios)
+        + len(request.instruments)
+        + len(request.transactions)
+        + len(request.market_prices)
+        + len(request.fx_rates)
     )
-    accepted_count = sum(published_counts.values())
+    job_id = create_ingestion_job_id()
+    correlation_id, request_id, trace_id = get_request_lineage()
+    ingestion_job_service.create_job(
+        job_id=job_id,
+        endpoint=str(http_request.url.path),
+        entity_type="portfolio_bundle",
+        accepted_count=accepted_count,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+        request_id=request_id,
+        trace_id=trace_id,
+    )
+    try:
+        published_counts = await ingestion_service.publish_portfolio_bundle(
+            request, idempotency_key=idempotency_key
+        )
+        ingestion_job_service.mark_queued(job_id)
+    except Exception as exc:
+        ingestion_job_service.mark_failed(job_id, str(exc))
+        raise
 
     logger.info(
         "Portfolio bundle queued for ingestion.",
@@ -57,6 +88,7 @@ async def ingest_portfolio_bundle(
             f"Published counts: {published_counts}"
         ),
         entity_type="portfolio_bundle",
+        job_id=job_id,
         accepted_count=accepted_count,
         idempotency_key=idempotency_key,
     )

--- a/src/services/ingestion_service/app/routers/portfolios.py
+++ b/src/services/ingestion_service/app/routers/portfolios.py
@@ -3,7 +3,13 @@ import logging
 from app.ack_response import build_batch_ack
 from app.DTOs.ingestion_ack_dto import BatchIngestionAcceptedResponse
 from app.DTOs.portfolio_dto import PortfolioIngestionRequest
-from app.request_metadata import IdempotencyKeyHeader, resolve_idempotency_key
+from app.request_metadata import (
+    IdempotencyKeyHeader,
+    create_ingestion_job_id,
+    get_request_lineage,
+    resolve_idempotency_key,
+)
+from app.services.ingestion_job_service import IngestionJobService, get_ingestion_job_service
 from app.services.ingestion_service import IngestionService, get_ingestion_service
 from fastapi import APIRouter, Depends, Request, status
 
@@ -24,20 +30,41 @@ async def ingest_portfolios(
     http_request: Request,
     idempotency_key_header: IdempotencyKeyHeader = None,
     ingestion_service: IngestionService = Depends(get_ingestion_service),
+    ingestion_job_service: IngestionJobService = Depends(get_ingestion_job_service),
 ):
     idempotency_key = idempotency_key_header or resolve_idempotency_key(http_request)
     num_portfolios = len(request.portfolios)
+    job_id = create_ingestion_job_id()
+    correlation_id, request_id, trace_id = get_request_lineage()
+    ingestion_job_service.create_job(
+        job_id=job_id,
+        endpoint=str(http_request.url.path),
+        entity_type="portfolio",
+        accepted_count=num_portfolios,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+        request_id=request_id,
+        trace_id=trace_id,
+    )
     logger.info(
         "Received request to ingest portfolios.",
         extra={"num_portfolios": num_portfolios, "idempotency_key": idempotency_key},
     )
 
-    await ingestion_service.publish_portfolios(request.portfolios, idempotency_key=idempotency_key)
+    try:
+        await ingestion_service.publish_portfolios(
+            request.portfolios, idempotency_key=idempotency_key
+        )
+        ingestion_job_service.mark_queued(job_id)
+    except Exception as exc:
+        ingestion_job_service.mark_failed(job_id, str(exc))
+        raise
 
     logger.info("Portfolios successfully queued.", extra={"num_portfolios": num_portfolios})
     return build_batch_ack(
         message="Portfolios accepted for asynchronous ingestion processing.",
         entity_type="portfolio",
+        job_id=job_id,
         accepted_count=num_portfolios,
         idempotency_key=idempotency_key,
     )

--- a/src/services/ingestion_service/app/routers/reprocessing.py
+++ b/src/services/ingestion_service/app/routers/reprocessing.py
@@ -3,7 +3,13 @@ import logging
 
 from app.ack_response import build_batch_ack
 from app.DTOs.ingestion_ack_dto import BatchIngestionAcceptedResponse
-from app.request_metadata import IdempotencyKeyHeader, get_request_lineage, resolve_idempotency_key
+from app.request_metadata import (
+    IdempotencyKeyHeader,
+    create_ingestion_job_id,
+    get_request_lineage,
+    resolve_idempotency_key,
+)
+from app.services.ingestion_job_service import IngestionJobService, get_ingestion_job_service
 from fastapi import APIRouter, Depends, Request, status
 from portfolio_common.kafka_utils import KafkaProducer, get_kafka_producer
 
@@ -32,6 +38,7 @@ async def reprocess_transactions(
     http_request: Request,
     idempotency_key_header: IdempotencyKeyHeader = None,
     kafka_producer: KafkaProducer = Depends(get_kafka_producer),
+    ingestion_job_service: IngestionJobService = Depends(get_ingestion_job_service),
 ):
     """
     Accepts a list of transaction IDs and publishes a reprocessing request
@@ -39,7 +46,18 @@ async def reprocess_transactions(
     """
     num_to_reprocess = len(request.transaction_ids)
     idempotency_key = idempotency_key_header or resolve_idempotency_key(http_request)
-    correlation_id, _, _ = get_request_lineage()
+    correlation_id, request_id, trace_id = get_request_lineage()
+    job_id = create_ingestion_job_id()
+    ingestion_job_service.create_job(
+        job_id=job_id,
+        endpoint=str(http_request.url.path),
+        entity_type="reprocessing_request",
+        accepted_count=num_to_reprocess,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+        request_id=request_id,
+        trace_id=trace_id,
+    )
     headers: list[tuple[str, bytes]] = []
     if correlation_id:
         headers.append(("correlation_id", correlation_id.encode("utf-8")))
@@ -48,21 +66,27 @@ async def reprocess_transactions(
 
     logger.info(f"Received request to reprocess {num_to_reprocess} transaction(s).")
 
-    for txn_id in request.transaction_ids:
-        event_payload = {"transaction_id": txn_id}
-        kafka_producer.publish_message(
-            topic=REPROCESSING_REQUESTED_TOPIC,
-            key=txn_id,  # Key by transaction_id for partitioning
-            value=event_payload,
-            headers=headers or None,
-        )
+    try:
+        for txn_id in request.transaction_ids:
+            event_payload = {"transaction_id": txn_id}
+            kafka_producer.publish_message(
+                topic=REPROCESSING_REQUESTED_TOPIC,
+                key=txn_id,  # Key by transaction_id for partitioning
+                value=event_payload,
+                headers=headers or None,
+            )
 
-    kafka_producer.flush(timeout=5)
+        kafka_producer.flush(timeout=5)
+        ingestion_job_service.mark_queued(job_id)
+    except Exception as exc:
+        ingestion_job_service.mark_failed(job_id, str(exc))
+        raise
 
     logger.info(f"Successfully queued {num_to_reprocess} reprocessing requests.")
     return build_batch_ack(
         message=f"Successfully queued {num_to_reprocess} transactions for reprocessing.",
         entity_type="reprocessing_request",
+        job_id=job_id,
         accepted_count=num_to_reprocess,
         idempotency_key=idempotency_key,
     )

--- a/src/services/ingestion_service/app/routers/transactions.py
+++ b/src/services/ingestion_service/app/routers/transactions.py
@@ -3,7 +3,13 @@ import logging
 from app.ack_response import build_batch_ack, build_single_ack
 from app.DTOs.ingestion_ack_dto import BatchIngestionAcceptedResponse, IngestionAcceptedResponse
 from app.DTOs.transaction_dto import Transaction, TransactionIngestionRequest
-from app.request_metadata import IdempotencyKeyHeader, resolve_idempotency_key
+from app.request_metadata import (
+    IdempotencyKeyHeader,
+    create_ingestion_job_id,
+    get_request_lineage,
+    resolve_idempotency_key,
+)
+from app.services.ingestion_job_service import IngestionJobService, get_ingestion_job_service
 from app.services.ingestion_service import IngestionService, get_ingestion_service
 from fastapi import APIRouter, Depends, Request, status
 
@@ -62,22 +68,45 @@ async def ingest_transactions(
     http_request: Request,
     idempotency_key_header: IdempotencyKeyHeader = None,
     ingestion_service: IngestionService = Depends(get_ingestion_service),
+    ingestion_job_service: IngestionJobService = Depends(get_ingestion_job_service),
 ):
     idempotency_key = idempotency_key_header or resolve_idempotency_key(http_request)
     num_transactions = len(request.transactions)
+    job_id = create_ingestion_job_id()
+    correlation_id, request_id, trace_id = get_request_lineage()
+    ingestion_job_service.create_job(
+        job_id=job_id,
+        endpoint=str(http_request.url.path),
+        entity_type="transaction",
+        accepted_count=num_transactions,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+        request_id=request_id,
+        trace_id=trace_id,
+    )
     logger.info(
         "Received request to ingest transactions.",
-        extra={"num_transactions": num_transactions, "idempotency_key": idempotency_key},
+        extra={
+            "num_transactions": num_transactions,
+            "idempotency_key": idempotency_key,
+            "job_id": job_id,
+        },
     )
 
-    await ingestion_service.publish_transactions(
-        request.transactions, idempotency_key=idempotency_key
-    )
+    try:
+        await ingestion_service.publish_transactions(
+            request.transactions, idempotency_key=idempotency_key
+        )
+        ingestion_job_service.mark_queued(job_id)
+    except Exception as exc:
+        ingestion_job_service.mark_failed(job_id, str(exc))
+        raise
 
     logger.info("Transactions successfully queued.", extra={"num_transactions": num_transactions})
     return build_batch_ack(
         message="Transactions accepted for asynchronous ingestion processing.",
         entity_type="transaction",
+        job_id=job_id,
         accepted_count=num_transactions,
         idempotency_key=idempotency_key,
     )

--- a/src/services/ingestion_service/app/services/ingestion_job_service.py
+++ b/src/services/ingestion_service/app/services/ingestion_job_service.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from threading import RLock
+
+from app.DTOs.ingestion_job_dto import IngestionJobResponse, IngestionJobStatus
+
+
+@dataclass
+class _IngestionJobRecord:
+    job_id: str
+    endpoint: str
+    entity_type: str
+    accepted_count: int
+    idempotency_key: str | None
+    correlation_id: str
+    request_id: str
+    trace_id: str
+    submitted_at: datetime
+    status: IngestionJobStatus = "accepted"
+    completed_at: datetime | None = None
+    failure_reason: str | None = None
+
+    def to_response(self) -> IngestionJobResponse:
+        return IngestionJobResponse(
+            job_id=self.job_id,
+            endpoint=self.endpoint,
+            entity_type=self.entity_type,
+            status=self.status,
+            accepted_count=self.accepted_count,
+            idempotency_key=self.idempotency_key,
+            correlation_id=self.correlation_id,
+            request_id=self.request_id,
+            trace_id=self.trace_id,
+            submitted_at=self.submitted_at,
+            completed_at=self.completed_at,
+            failure_reason=self.failure_reason,
+        )
+
+
+class IngestionJobService:
+    """
+    Tracks ingestion request lifecycle for API-first operational visibility.
+    """
+
+    def __init__(self) -> None:
+        self._jobs: dict[str, _IngestionJobRecord] = {}
+        self._lock = RLock()
+
+    def create_job(
+        self,
+        *,
+        job_id: str,
+        endpoint: str,
+        entity_type: str,
+        accepted_count: int,
+        idempotency_key: str | None,
+        correlation_id: str,
+        request_id: str,
+        trace_id: str,
+    ) -> None:
+        with self._lock:
+            self._jobs[job_id] = _IngestionJobRecord(
+                job_id=job_id,
+                endpoint=endpoint,
+                entity_type=entity_type,
+                accepted_count=accepted_count,
+                idempotency_key=idempotency_key,
+                correlation_id=correlation_id,
+                request_id=request_id,
+                trace_id=trace_id,
+                submitted_at=datetime.now(UTC),
+            )
+
+    def mark_queued(self, job_id: str) -> None:
+        with self._lock:
+            if job_id not in self._jobs:
+                return
+            job = self._jobs[job_id]
+            job.status = "queued"
+            job.completed_at = datetime.now(UTC)
+            job.failure_reason = None
+
+    def mark_failed(self, job_id: str, failure_reason: str) -> None:
+        with self._lock:
+            if job_id not in self._jobs:
+                return
+            job = self._jobs[job_id]
+            job.status = "failed"
+            job.completed_at = datetime.now(UTC)
+            job.failure_reason = failure_reason
+
+    def get_job(self, job_id: str) -> IngestionJobResponse | None:
+        with self._lock:
+            job = self._jobs.get(job_id)
+            return job.to_response() if job else None
+
+    def list_jobs(
+        self,
+        *,
+        status: IngestionJobStatus | None = None,
+        entity_type: str | None = None,
+        limit: int = 100,
+    ) -> list[IngestionJobResponse]:
+        with self._lock:
+            values = list(self._jobs.values())
+
+        filtered = [
+            job
+            for job in values
+            if (status is None or job.status == status)
+            and (entity_type is None or job.entity_type == entity_type)
+        ]
+        filtered.sort(key=lambda job: job.submitted_at, reverse=True)
+        return [job.to_response() for job in filtered[:limit]]
+
+
+_INGESTION_JOB_SERVICE = IngestionJobService()
+
+
+def get_ingestion_job_service() -> IngestionJobService:
+    return _INGESTION_JOB_SERVICE


### PR DESCRIPTION
## Summary
- add API-first ingestion operations endpoints: GET /ingestion/jobs and GET /ingestion/jobs/{job_id}
- introduce ingestion job lifecycle models and service (ccepted, queued, ailed)
- wire job creation/status transitions into batch ingestion and reprocessing endpoints
- keep canonical response contracts and lineage metadata aligned with RFC-0067 governance
- extend integration tests to validate job endpoints and not-found behavior

## Validation
- python -m pytest tests/integration/services/ingestion_service/test_ingestion_routers.py tests/integration/services/ingestion_service/test_ingestion_main_app_contract.py tests/unit/services/ingestion_service/services/test_ingestion_service.py -q
- python scripts/openapi_quality_gate.py
- python scripts/api_vocabulary_inventory.py --validate-only
