### PR TITLE
Persist ingestion jobs in database for durable operations APIs

### DIFF
--- a/alembic/versions/e5f6a7b8c9d0_feat_add_ingestion_jobs_table.py
+++ b/alembic/versions/e5f6a7b8c9d0_feat_add_ingestion_jobs_table.py
@@ -1,0 +1,62 @@
+"""feat: add ingestion jobs table for API-first ingestion operations
+
+Revision ID: e5f6a7b8c9d0
+Revises: d4e5f6a7b8c9
+Create Date: 2026-02-28 21:36:00
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e5f6a7b8c9d0"
+down_revision: Union[str, None] = "d4e5f6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ingestion_jobs",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("job_id", sa.String(), nullable=False),
+        sa.Column("endpoint", sa.String(), nullable=False),
+        sa.Column("entity_type", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), server_default="accepted", nullable=False),
+        sa.Column("accepted_count", sa.Integer(), nullable=False),
+        sa.Column("idempotency_key", sa.String(), nullable=True),
+        sa.Column("correlation_id", sa.String(), nullable=False),
+        sa.Column("request_id", sa.String(), nullable=False),
+        sa.Column("trace_id", sa.String(), nullable=False),
+        sa.Column(
+            "submitted_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("failure_reason", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("job_id"),
+    )
+    op.create_index("ix_ingestion_jobs_job_id", "ingestion_jobs", ["job_id"], unique=True)
+    op.create_index("ix_ingestion_jobs_endpoint", "ingestion_jobs", ["endpoint"], unique=False)
+    op.create_index(
+        "ix_ingestion_jobs_entity_type", "ingestion_jobs", ["entity_type"], unique=False
+    )
+    op.create_index("ix_ingestion_jobs_status", "ingestion_jobs", ["status"], unique=False)
+    op.create_index(
+        "ix_ingestion_jobs_idempotency_key",
+        "ingestion_jobs",
+        ["idempotency_key"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ingestion_jobs_idempotency_key", table_name="ingestion_jobs")
+    op.drop_index("ix_ingestion_jobs_status", table_name="ingestion_jobs")
+    op.drop_index("ix_ingestion_jobs_entity_type", table_name="ingestion_jobs")
+    op.drop_index("ix_ingestion_jobs_endpoint", table_name="ingestion_jobs")
+    op.drop_index("ix_ingestion_jobs_job_id", table_name="ingestion_jobs")
+    op.drop_table("ingestion_jobs")

--- a/src/libs/portfolio-common/portfolio_common/database_models.py
+++ b/src/libs/portfolio-common/portfolio_common/database_models.py
@@ -1,24 +1,34 @@
 # libs/portfolio-common/portfolio_common/database_models.py
 from sqlalchemy import (
-    Column, Integer, 
-    String, Numeric, DateTime,
-    Date, func,
-    ForeignKey, UniqueConstraint, Boolean, JSON, Index, PrimaryKeyConstraint,
-    Text
+    Column,
+    Integer,
+    String,
+    Numeric,
+    DateTime,
+    Date,
+    func,
+    ForeignKey,
+    UniqueConstraint,
+    Boolean,
+    JSON,
+    Index,
+    PrimaryKeyConstraint,
+    Text,
 )
 from sqlalchemy.orm import relationship
 
 from .db_base import Base
 
-class BusinessDate(Base):
-    __tablename__ = 'business_dates'
 
-    
+class BusinessDate(Base):
+    __tablename__ = "business_dates"
+
     date = Column(Date, primary_key=True, nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
+
 class Portfolio(Base):
-    __tablename__ = 'portfolios'
+    __tablename__ = "portfolios"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     portfolio_id = Column(String, unique=True, index=True, nullable=False)
@@ -34,9 +44,11 @@ class Portfolio(Base):
     is_leverage_allowed = Column(Boolean, default=False, nullable=False)
     advisor_id = Column(String, nullable=True)
     status = Column(String, nullable=False)
-    cost_basis_method = Column(String, server_default='FIFO', nullable=True) 
+    cost_basis_method = Column(String, server_default="FIFO", nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
 
 
 class SimulationSession(Base):
@@ -50,7 +62,9 @@ class SimulationSession(Base):
     created_by = Column(String, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     expires_at = Column(DateTime(timezone=True), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
 
 
 class SimulationChange(Base):
@@ -74,28 +88,31 @@ class SimulationChange(Base):
 
 
 class PositionHistory(Base):
-    __tablename__ = 'position_history'
+    __tablename__ = "position_history"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    portfolio_id = Column(String, ForeignKey('portfolios.portfolio_id'), index=True, nullable=False)
+    portfolio_id = Column(String, ForeignKey("portfolios.portfolio_id"), index=True, nullable=False)
     security_id = Column(String, index=True, nullable=False)
-    transaction_id = Column(String, ForeignKey('transactions.transaction_id'), nullable=False)
+    transaction_id = Column(String, ForeignKey("transactions.transaction_id"), nullable=False)
     position_date = Column(Date, index=True, nullable=False)
-    epoch = Column(Integer, nullable=False, default=0, server_default='0')
+    epoch = Column(Integer, nullable=False, default=0, server_default="0")
     quantity = Column(Numeric(18, 10), nullable=False)
     cost_basis = Column(Numeric(18, 10), nullable=False)
     cost_basis_local = Column(Numeric(18, 10), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
 
 class DailyPositionSnapshot(Base):
-    __tablename__ = 'daily_position_snapshots'
+    __tablename__ = "daily_position_snapshots"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    portfolio_id = Column(String, ForeignKey('portfolios.portfolio_id'), index=True, nullable=False)
+    portfolio_id = Column(String, ForeignKey("portfolios.portfolio_id"), index=True, nullable=False)
     security_id = Column(String, index=True, nullable=False)
     date = Column(Date, index=True, nullable=False)
-    epoch = Column(Integer, nullable=False, default=0, server_default='0')
+    epoch = Column(Integer, nullable=False, default=0, server_default="0")
     quantity = Column(Numeric(18, 10), nullable=False)
     cost_basis = Column(Numeric(18, 10), nullable=False)
     cost_basis_local = Column(Numeric(18, 10), nullable=True)
@@ -104,18 +121,28 @@ class DailyPositionSnapshot(Base):
     market_value_local = Column(Numeric(18, 10), nullable=True)
     unrealized_gain_loss = Column(Numeric(18, 10), nullable=True)
     unrealized_gain_loss_local = Column(Numeric(18, 10), nullable=True)
-    valuation_status = Column(String, nullable=False, server_default='UNVALUED', index=True)
+    valuation_status = Column(String, nullable=False, server_default="UNVALUED", index=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
 
     __table_args__ = (
-        UniqueConstraint('portfolio_id', 'security_id', 'date', 'epoch', name='_portfolio_security_date_epoch_uc'),
-        Index('ix_daily_position_snapshots_covering', 'portfolio_id', 'security_id', date.desc(), id.desc()),
+        UniqueConstraint(
+            "portfolio_id", "security_id", "date", "epoch", name="_portfolio_security_date_epoch_uc"
+        ),
+        Index(
+            "ix_daily_position_snapshots_covering",
+            "portfolio_id",
+            "security_id",
+            date.desc(),
+            id.desc(),
+        ),
     )
 
 
 class FxRate(Base):
-    __tablename__ = 'fx_rates'
+    __tablename__ = "fx_rates"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     from_currency = Column(String(3), nullable=False)
@@ -123,13 +150,19 @@ class FxRate(Base):
     rate_date = Column(Date, nullable=False)
     rate = Column(Numeric(18, 10), nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
 
-    __table_args__ = (UniqueConstraint('from_currency', 'to_currency', 'rate_date', name='_currency_pair_date_uc'),)
+    __table_args__ = (
+        UniqueConstraint(
+            "from_currency", "to_currency", "rate_date", name="_currency_pair_date_uc"
+        ),
+    )
 
 
 class MarketPrice(Base):
-    __tablename__ = 'market_prices'
+    __tablename__ = "market_prices"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     security_id = Column(String, index=True, nullable=False)
@@ -137,13 +170,17 @@ class MarketPrice(Base):
     price = Column(Numeric(18, 10), nullable=False)
     currency = Column(String, nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
 
-    __table_args__ = (UniqueConstraint('security_id', 'price_date', name='_security_price_date_uc'),)
+    __table_args__ = (
+        UniqueConstraint("security_id", "price_date", name="_security_price_date_uc"),
+    )
 
 
 class Instrument(Base):
-    __tablename__ = 'instruments'
+    __tablename__ = "instruments"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     security_id = Column(String, unique=True, index=True, nullable=False)
@@ -161,14 +198,17 @@ class Instrument(Base):
     ultimate_parent_issuer_id = Column(String, nullable=True, index=True)
     ultimate_parent_issuer_name = Column(String, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
 
 class Transaction(Base):
-    __tablename__ = 'transactions'
+    __tablename__ = "transactions"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     transaction_id = Column(String, unique=True, index=True, nullable=False)
-    portfolio_id = Column(String, ForeignKey('portfolios.portfolio_id'), nullable=False)
+    portfolio_id = Column(String, ForeignKey("portfolios.portfolio_id"), nullable=False)
     instrument_id = Column(String, nullable=False)
     security_id = Column(String, nullable=False)
     transaction_type = Column(String, nullable=False)
@@ -181,7 +221,9 @@ class Transaction(Base):
     settlement_date = Column(DateTime(timezone=True), nullable=True)
     trade_fee = Column(Numeric(18, 10), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
     gross_cost = Column(Numeric(18, 10), nullable=True)
     net_cost = Column(Numeric(18, 10), nullable=True)
     realized_gain_loss = Column(Numeric(18, 10), nullable=True)
@@ -194,52 +236,58 @@ class Transaction(Base):
     calculation_policy_version = Column(String, nullable=True)
     source_system = Column(String, nullable=True)
 
-    costs = relationship("TransactionCost", back_populates="transaction", cascade="all, delete-orphan")
-    cashflow = relationship("Cashflow", uselist=False, back_populates="transaction", cascade="all, delete-orphan")
-
-    __table_args__ = (
-        Index('ix_transactions_portfolio_security', 'portfolio_id', 'security_id'),
+    costs = relationship(
+        "TransactionCost", back_populates="transaction", cascade="all, delete-orphan"
+    )
+    cashflow = relationship(
+        "Cashflow", uselist=False, back_populates="transaction", cascade="all, delete-orphan"
     )
 
+    __table_args__ = (Index("ix_transactions_portfolio_security", "portfolio_id", "security_id"),)
 
 
 class TransactionCost(Base):
-    __tablename__ = 'transaction_costs'
+    __tablename__ = "transaction_costs"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    transaction_id = Column(String, ForeignKey('transactions.transaction_id'), nullable=False)
+    transaction_id = Column(String, ForeignKey("transactions.transaction_id"), nullable=False)
     fee_type = Column(String, nullable=False)
     amount = Column(Numeric(18, 10), nullable=False)
     currency = Column(String, nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
 
     transaction = relationship("Transaction", back_populates="costs")
 
+
 class Cashflow(Base):
-    __tablename__ = 'cashflows'
+    __tablename__ = "cashflows"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    transaction_id = Column(String, ForeignKey('transactions.transaction_id'), nullable=False)
-    portfolio_id = Column(String, ForeignKey('portfolios.portfolio_id'), index=True, nullable=False)
+    transaction_id = Column(String, ForeignKey("transactions.transaction_id"), nullable=False)
+    portfolio_id = Column(String, ForeignKey("portfolios.portfolio_id"), index=True, nullable=False)
     security_id = Column(String, index=True, nullable=True)
     cashflow_date = Column(Date, index=True, nullable=False)
-    epoch = Column(Integer, nullable=False, default=0, server_default='0')
+    epoch = Column(Integer, nullable=False, default=0, server_default="0")
     amount = Column(Numeric(18, 10), nullable=False)
     currency = Column(String(3), nullable=False)
     classification = Column(String, nullable=False)
     timing = Column(String, nullable=False)
     calculation_type = Column(String, nullable=False)
-    is_position_flow = Column(Boolean, server_default='f', nullable=False)
-    is_portfolio_flow = Column(Boolean, server_default='f', nullable=False)
+    is_position_flow = Column(Boolean, server_default="f", nullable=False)
+    is_portfolio_flow = Column(Boolean, server_default="f", nullable=False)
     economic_event_id = Column(String, nullable=True, index=True)
     linked_transaction_group_id = Column(String, nullable=True, index=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
 
     transaction = relationship("Transaction", back_populates="cashflow")
 
-    __table_args__ = (UniqueConstraint('transaction_id', name='_transaction_id_uc'),)
+    __table_args__ = (UniqueConstraint("transaction_id", name="_transaction_id_uc"),)
 
 
 class PositionLotState(Base):
@@ -265,7 +313,9 @@ class PositionLotState(Base):
     calculation_policy_version = Column(String, nullable=True)
     source_system = Column(String, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
 
 
 class AccruedIncomeOffsetState(Base):
@@ -287,15 +337,18 @@ class AccruedIncomeOffsetState(Base):
     calculation_policy_version = Column(String, nullable=True)
     source_system = Column(String, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
 
 class PositionTimeseries(Base):
-    __tablename__ = 'position_timeseries'
+    __tablename__ = "position_timeseries"
 
-    portfolio_id = Column(String, ForeignKey('portfolios.portfolio_id'), primary_key=True)
-    security_id = Column(String, ForeignKey('instruments.security_id'), primary_key=True)
+    portfolio_id = Column(String, ForeignKey("portfolios.portfolio_id"), primary_key=True)
+    security_id = Column(String, ForeignKey("instruments.security_id"), primary_key=True)
     date = Column(Date, primary_key=True)
-    epoch = Column(Integer, primary_key=True, default=0, server_default='0')
+    epoch = Column(Integer, primary_key=True, default=0, server_default="0")
     bod_market_value = Column(Numeric(18, 10), nullable=False)
     bod_cashflow_position = Column(Numeric(18, 10), nullable=False)
     eod_cashflow_position = Column(Numeric(18, 10), nullable=False)
@@ -306,25 +359,31 @@ class PositionTimeseries(Base):
     quantity = Column(Numeric(18, 10), nullable=False)
     cost = Column(Numeric(18, 10), nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
 
 class PortfolioTimeseries(Base):
-    __tablename__ = 'portfolio_timeseries'
+    __tablename__ = "portfolio_timeseries"
 
-    portfolio_id = Column(String, ForeignKey('portfolios.portfolio_id'), primary_key=True)
+    portfolio_id = Column(String, ForeignKey("portfolios.portfolio_id"), primary_key=True)
     date = Column(Date, primary_key=True)
-    epoch = Column(Integer, primary_key=True, default=0, server_default='0')
+    epoch = Column(Integer, primary_key=True, default=0, server_default="0")
     bod_market_value = Column(Numeric(18, 10), nullable=False)
     bod_cashflow = Column(Numeric(18, 10), nullable=False)
     eod_cashflow = Column(Numeric(18, 10), nullable=False)
     eod_market_value = Column(Numeric(18, 10), nullable=False)
     fees = Column(Numeric(18, 10), nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
 
     def to_dict(self):
         """Converts the object to a dictionary."""
         return {c.name: getattr(self, c.name) for c in self.__table__.columns}
+
 
 class ProcessedEvent(Base):
     __tablename__ = "processed_events"
@@ -336,12 +395,11 @@ class ProcessedEvent(Base):
     correlation_id = Column(String, nullable=True)
     processed_at = Column(DateTime(timezone=True), server_default=func.now())
 
-    __table_args__ = (
-        UniqueConstraint('event_id', 'service_name', name='_event_service_uc'),
-    )
+    __table_args__ = (UniqueConstraint("event_id", "service_name", name="_event_service_uc"),)
+
 
 class OutboxEvent(Base):
-    __tablename__ = 'outbox_events'
+    __tablename__ = "outbox_events"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     aggregate_type = Column(String, nullable=False, index=True)
@@ -349,7 +407,7 @@ class OutboxEvent(Base):
     event_type = Column(String, nullable=False)
     payload = Column(JSON, nullable=False)
     topic = Column(String, nullable=False)
-    status = Column(String, default='PENDING', nullable=False, index=True)
+    status = Column(String, default="PENDING", nullable=False, index=True)
     correlation_id = Column(String, nullable=True)
     retry_count = Column(Integer, default=0, nullable=False)
     last_attempted_at = Column(DateTime(timezone=True), nullable=True)
@@ -362,19 +420,23 @@ class PortfolioAggregationJob(Base):
     Tracks portfolio-date pairs that require aggregation.
     This table acts as a stateful, idempotent queue to trigger portfolio time series calculations.
     """
-    __tablename__ = 'portfolio_aggregation_jobs'
+
+    __tablename__ = "portfolio_aggregation_jobs"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     portfolio_id = Column(String, nullable=False, index=True)
     aggregation_date = Column(Date, nullable=False, index=True)
-    status = Column(String, nullable=False, default='PENDING', index=True)
+    status = Column(String, nullable=False, default="PENDING", index=True)
     correlation_id = Column(String, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
 
     __table_args__ = (
-        UniqueConstraint('portfolio_id', 'aggregation_date', name='_portfolio_date_uc'),
+        UniqueConstraint("portfolio_id", "aggregation_date", name="_portfolio_date_uc"),
     )
+
 
 class PortfolioValuationJob(Base):
     """
@@ -382,37 +444,69 @@ class PortfolioValuationJob(Base):
     This table acts as a stateful, idempotent work set to trigger valuation calculations,
     preventing race conditions from multiple upstream events.
     """
-    __tablename__ = 'portfolio_valuation_jobs'
+
+    __tablename__ = "portfolio_valuation_jobs"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     portfolio_id = Column(String, nullable=False, index=True)
     security_id = Column(String, nullable=False, index=True)
     valuation_date = Column(Date, nullable=False, index=True)
-    epoch = Column(Integer, nullable=False, default=0, server_default='0')
-    status = Column(String, nullable=False, default='PENDING', index=True)
+    epoch = Column(Integer, nullable=False, default=0, server_default="0")
+    status = Column(String, nullable=False, default="PENDING", index=True)
     correlation_id = Column(String, nullable=True)
     failure_reason = Column(Text, nullable=True)
-    attempt_count = Column(Integer, nullable=False, default=0, server_default='0')
+    attempt_count = Column(Integer, nullable=False, default=0, server_default="0")
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
 
     __table_args__ = (
-        UniqueConstraint('portfolio_id', 'security_id', 'valuation_date', 'epoch', name='_portfolio_security_valuation_date_epoch_uc'),
+        UniqueConstraint(
+            "portfolio_id",
+            "security_id",
+            "valuation_date",
+            "epoch",
+            name="_portfolio_security_valuation_date_epoch_uc",
+        ),
     )
+
+
+class IngestionJob(Base):
+    __tablename__ = "ingestion_jobs"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    job_id = Column(String, unique=True, index=True, nullable=False)
+    endpoint = Column(String, index=True, nullable=False)
+    entity_type = Column(String, index=True, nullable=False)
+    status = Column(String, index=True, nullable=False, server_default="accepted")
+    accepted_count = Column(Integer, nullable=False)
+    idempotency_key = Column(String, nullable=True, index=True)
+    correlation_id = Column(String, nullable=False)
+    request_id = Column(String, nullable=False)
+    trace_id = Column(String, nullable=False)
+    submitted_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+    failure_reason = Column(Text, nullable=True)
+
 
 class PositionState(Base):
     """
     Tracks the current reprocessing state (epoch and watermark) for each portfolio-security key.
     """
-    __tablename__ = 'position_state'
+
+    __tablename__ = "position_state"
 
     portfolio_id = Column(String, primary_key=True)
     security_id = Column(String, primary_key=True)
-    epoch = Column(Integer, nullable=False, server_default='0')
+    epoch = Column(Integer, nullable=False, server_default="0")
     watermark_date = Column(Date, nullable=False)
-    status = Column(String, nullable=False, server_default='CURRENT', index=True)
+    status = Column(String, nullable=False, server_default="CURRENT", index=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
 
 class InstrumentReprocessingState(Base):
     """
@@ -420,37 +514,46 @@ class InstrumentReprocessingState(Base):
     This acts as a trigger for the ValuationScheduler to find and update
     all affected PositionState watermarks.
     """
-    __tablename__ = 'instrument_reprocessing_state'
+
+    __tablename__ = "instrument_reprocessing_state"
 
     security_id = Column(String, primary_key=True)
     earliest_impacted_date = Column(Date, nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
 
 class ReprocessingJob(Base):
     """
     Stores durable, persistent jobs for the reprocessing engine,
     such as fanning out watermark resets for a price change.
     """
-    __tablename__ = 'reprocessing_jobs'
+
+    __tablename__ = "reprocessing_jobs"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     job_type = Column(String, nullable=False, index=True)
     payload = Column(JSON, nullable=False)
-    status = Column(String, nullable=False, default='PENDING', index=True)
-    
-    attempt_count = Column(Integer, nullable=False, default=0, server_default='0')
+    status = Column(String, nullable=False, default="PENDING", index=True)
+
+    attempt_count = Column(Integer, nullable=False, default=0, server_default="0")
     last_attempted_at = Column(DateTime(timezone=True), nullable=True)
     failure_reason = Column(Text, nullable=True)
-    
+
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
 
 class CashflowRule(Base):
     """
     Defines the business rules for generating a cashflow from a transaction type.
     """
-    __tablename__ = 'cashflow_rules'
+
+    __tablename__ = "cashflow_rules"
 
     transaction_type = Column(String(50), primary_key=True)
     classification = Column(String(50), nullable=False)
@@ -458,5 +561,6 @@ class CashflowRule(Base):
     is_position_flow = Column(Boolean, nullable=False)
     is_portfolio_flow = Column(Boolean, nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
-
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/src/services/ingestion_service/app/routers/business_dates.py
+++ b/src/services/ingestion_service/app/routers/business_dates.py
@@ -37,7 +37,7 @@ async def ingest_business_dates(
     num_dates = len(request.business_dates)
     job_id = create_ingestion_job_id()
     correlation_id, request_id, trace_id = get_request_lineage()
-    ingestion_job_service.create_job(
+    await ingestion_job_service.create_job(
         job_id=job_id,
         endpoint=str(http_request.url.path),
         entity_type="business_date",
@@ -56,9 +56,9 @@ async def ingest_business_dates(
         await ingestion_service.publish_business_dates(
             request.business_dates, idempotency_key=idempotency_key
         )
-        ingestion_job_service.mark_queued(job_id)
+        await ingestion_job_service.mark_queued(job_id)
     except Exception as exc:
-        ingestion_job_service.mark_failed(job_id, str(exc))
+        await ingestion_job_service.mark_failed(job_id, str(exc))
         raise
 
     logger.info("Business dates successfully queued.", extra={"num_dates": num_dates})
@@ -69,3 +69,4 @@ async def ingest_business_dates(
         accepted_count=num_dates,
         idempotency_key=idempotency_key,
     )
+

--- a/src/services/ingestion_service/app/routers/fx_rates.py
+++ b/src/services/ingestion_service/app/routers/fx_rates.py
@@ -37,7 +37,7 @@ async def ingest_fx_rates(
     num_rates = len(request.fx_rates)
     job_id = create_ingestion_job_id()
     correlation_id, request_id, trace_id = get_request_lineage()
-    ingestion_job_service.create_job(
+    await ingestion_job_service.create_job(
         job_id=job_id,
         endpoint=str(http_request.url.path),
         entity_type="fx_rate",
@@ -54,9 +54,9 @@ async def ingest_fx_rates(
 
     try:
         await ingestion_service.publish_fx_rates(request.fx_rates, idempotency_key=idempotency_key)
-        ingestion_job_service.mark_queued(job_id)
+        await ingestion_job_service.mark_queued(job_id)
     except Exception as exc:
-        ingestion_job_service.mark_failed(job_id, str(exc))
+        await ingestion_job_service.mark_failed(job_id, str(exc))
         raise
 
     logger.info("FX rates successfully queued.", extra={"num_rates": num_rates})
@@ -67,3 +67,4 @@ async def ingest_fx_rates(
         accepted_count=num_rates,
         idempotency_key=idempotency_key,
     )
+

--- a/src/services/ingestion_service/app/routers/ingestion_jobs.py
+++ b/src/services/ingestion_service/app/routers/ingestion_jobs.py
@@ -20,7 +20,7 @@ async def get_ingestion_job(
     job_id: str,
     ingestion_job_service: IngestionJobService = Depends(get_ingestion_job_service),
 ):
-    job = ingestion_job_service.get_job(job_id)
+    job = await ingestion_job_service.get_job(job_id)
     if job is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -50,7 +50,7 @@ async def list_ingestion_jobs(
     ingestion_job_service: IngestionJobService = Depends(get_ingestion_job_service),
 ):
     status_value = status_filter if status_filter in {"accepted", "queued", "failed"} else None
-    jobs = ingestion_job_service.list_jobs(
+    jobs = await ingestion_job_service.list_jobs(
         status=status_value, entity_type=entity_type, limit=limit
     )
     return IngestionJobListResponse(jobs=jobs, total=len(jobs))

--- a/src/services/ingestion_service/app/routers/instruments.py
+++ b/src/services/ingestion_service/app/routers/instruments.py
@@ -37,7 +37,7 @@ async def ingest_instruments(
     num_instruments = len(request.instruments)
     job_id = create_ingestion_job_id()
     correlation_id, request_id, trace_id = get_request_lineage()
-    ingestion_job_service.create_job(
+    await ingestion_job_service.create_job(
         job_id=job_id,
         endpoint=str(http_request.url.path),
         entity_type="instrument",
@@ -56,9 +56,9 @@ async def ingest_instruments(
         await ingestion_service.publish_instruments(
             request.instruments, idempotency_key=idempotency_key
         )
-        ingestion_job_service.mark_queued(job_id)
+        await ingestion_job_service.mark_queued(job_id)
     except Exception as exc:
-        ingestion_job_service.mark_failed(job_id, str(exc))
+        await ingestion_job_service.mark_failed(job_id, str(exc))
         raise
 
     logger.info("Instruments successfully queued.", extra={"num_instruments": num_instruments})
@@ -69,3 +69,4 @@ async def ingest_instruments(
         accepted_count=num_instruments,
         idempotency_key=idempotency_key,
     )
+

--- a/src/services/ingestion_service/app/routers/market_prices.py
+++ b/src/services/ingestion_service/app/routers/market_prices.py
@@ -37,7 +37,7 @@ async def ingest_market_prices(
     num_prices = len(request.market_prices)
     job_id = create_ingestion_job_id()
     correlation_id, request_id, trace_id = get_request_lineage()
-    ingestion_job_service.create_job(
+    await ingestion_job_service.create_job(
         job_id=job_id,
         endpoint=str(http_request.url.path),
         entity_type="market_price",
@@ -56,9 +56,9 @@ async def ingest_market_prices(
         await ingestion_service.publish_market_prices(
             request.market_prices, idempotency_key=idempotency_key
         )
-        ingestion_job_service.mark_queued(job_id)
+        await ingestion_job_service.mark_queued(job_id)
     except Exception as exc:
-        ingestion_job_service.mark_failed(job_id, str(exc))
+        await ingestion_job_service.mark_failed(job_id, str(exc))
         raise
 
     logger.info("Market prices successfully queued.", extra={"num_prices": num_prices})
@@ -69,3 +69,4 @@ async def ingest_market_prices(
         accepted_count=num_prices,
         idempotency_key=idempotency_key,
     )
+

--- a/src/services/ingestion_service/app/routers/portfolio_bundle.py
+++ b/src/services/ingestion_service/app/routers/portfolio_bundle.py
@@ -54,7 +54,7 @@ async def ingest_portfolio_bundle(
     )
     job_id = create_ingestion_job_id()
     correlation_id, request_id, trace_id = get_request_lineage()
-    ingestion_job_service.create_job(
+    await ingestion_job_service.create_job(
         job_id=job_id,
         endpoint=str(http_request.url.path),
         entity_type="portfolio_bundle",
@@ -68,9 +68,9 @@ async def ingest_portfolio_bundle(
         published_counts = await ingestion_service.publish_portfolio_bundle(
             request, idempotency_key=idempotency_key
         )
-        ingestion_job_service.mark_queued(job_id)
+        await ingestion_job_service.mark_queued(job_id)
     except Exception as exc:
-        ingestion_job_service.mark_failed(job_id, str(exc))
+        await ingestion_job_service.mark_failed(job_id, str(exc))
         raise
 
     logger.info(
@@ -92,3 +92,4 @@ async def ingest_portfolio_bundle(
         accepted_count=accepted_count,
         idempotency_key=idempotency_key,
     )
+

--- a/src/services/ingestion_service/app/routers/portfolios.py
+++ b/src/services/ingestion_service/app/routers/portfolios.py
@@ -36,7 +36,7 @@ async def ingest_portfolios(
     num_portfolios = len(request.portfolios)
     job_id = create_ingestion_job_id()
     correlation_id, request_id, trace_id = get_request_lineage()
-    ingestion_job_service.create_job(
+    await ingestion_job_service.create_job(
         job_id=job_id,
         endpoint=str(http_request.url.path),
         entity_type="portfolio",
@@ -55,9 +55,9 @@ async def ingest_portfolios(
         await ingestion_service.publish_portfolios(
             request.portfolios, idempotency_key=idempotency_key
         )
-        ingestion_job_service.mark_queued(job_id)
+        await ingestion_job_service.mark_queued(job_id)
     except Exception as exc:
-        ingestion_job_service.mark_failed(job_id, str(exc))
+        await ingestion_job_service.mark_failed(job_id, str(exc))
         raise
 
     logger.info("Portfolios successfully queued.", extra={"num_portfolios": num_portfolios})
@@ -68,3 +68,4 @@ async def ingest_portfolios(
         accepted_count=num_portfolios,
         idempotency_key=idempotency_key,
     )
+

--- a/src/services/ingestion_service/app/routers/reprocessing.py
+++ b/src/services/ingestion_service/app/routers/reprocessing.py
@@ -48,7 +48,7 @@ async def reprocess_transactions(
     idempotency_key = idempotency_key_header or resolve_idempotency_key(http_request)
     correlation_id, request_id, trace_id = get_request_lineage()
     job_id = create_ingestion_job_id()
-    ingestion_job_service.create_job(
+    await ingestion_job_service.create_job(
         job_id=job_id,
         endpoint=str(http_request.url.path),
         entity_type="reprocessing_request",
@@ -77,9 +77,9 @@ async def reprocess_transactions(
             )
 
         kafka_producer.flush(timeout=5)
-        ingestion_job_service.mark_queued(job_id)
+        await ingestion_job_service.mark_queued(job_id)
     except Exception as exc:
-        ingestion_job_service.mark_failed(job_id, str(exc))
+        await ingestion_job_service.mark_failed(job_id, str(exc))
         raise
 
     logger.info(f"Successfully queued {num_to_reprocess} reprocessing requests.")
@@ -90,3 +90,4 @@ async def reprocess_transactions(
         accepted_count=num_to_reprocess,
         idempotency_key=idempotency_key,
     )
+

--- a/src/services/ingestion_service/app/routers/transactions.py
+++ b/src/services/ingestion_service/app/routers/transactions.py
@@ -74,7 +74,7 @@ async def ingest_transactions(
     num_transactions = len(request.transactions)
     job_id = create_ingestion_job_id()
     correlation_id, request_id, trace_id = get_request_lineage()
-    ingestion_job_service.create_job(
+    await ingestion_job_service.create_job(
         job_id=job_id,
         endpoint=str(http_request.url.path),
         entity_type="transaction",
@@ -97,9 +97,9 @@ async def ingest_transactions(
         await ingestion_service.publish_transactions(
             request.transactions, idempotency_key=idempotency_key
         )
-        ingestion_job_service.mark_queued(job_id)
+        await ingestion_job_service.mark_queued(job_id)
     except Exception as exc:
-        ingestion_job_service.mark_failed(job_id, str(exc))
+        await ingestion_job_service.mark_failed(job_id, str(exc))
         raise
 
     logger.info("Transactions successfully queued.", extra={"num_transactions": num_transactions})
@@ -110,3 +110,4 @@ async def ingest_transactions(
         accepted_count=num_transactions,
         idempotency_key=idempotency_key,
     )
+

--- a/src/services/ingestion_service/app/services/ingestion_job_service.py
+++ b/src/services/ingestion_service/app/services/ingestion_job_service.py
@@ -1,54 +1,36 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from datetime import UTC, datetime
-from threading import RLock
 
 from app.DTOs.ingestion_job_dto import IngestionJobResponse, IngestionJobStatus
+from portfolio_common.database_models import IngestionJob as DBIngestionJob
+from portfolio_common.db import get_async_db_session
+from sqlalchemy import desc, select
 
 
-@dataclass
-class _IngestionJobRecord:
-    job_id: str
-    endpoint: str
-    entity_type: str
-    accepted_count: int
-    idempotency_key: str | None
-    correlation_id: str
-    request_id: str
-    trace_id: str
-    submitted_at: datetime
-    status: IngestionJobStatus = "accepted"
-    completed_at: datetime | None = None
-    failure_reason: str | None = None
-
-    def to_response(self) -> IngestionJobResponse:
-        return IngestionJobResponse(
-            job_id=self.job_id,
-            endpoint=self.endpoint,
-            entity_type=self.entity_type,
-            status=self.status,
-            accepted_count=self.accepted_count,
-            idempotency_key=self.idempotency_key,
-            correlation_id=self.correlation_id,
-            request_id=self.request_id,
-            trace_id=self.trace_id,
-            submitted_at=self.submitted_at,
-            completed_at=self.completed_at,
-            failure_reason=self.failure_reason,
-        )
+def _to_response(job: DBIngestionJob) -> IngestionJobResponse:
+    return IngestionJobResponse(
+        job_id=job.job_id,
+        endpoint=job.endpoint,
+        entity_type=job.entity_type,
+        status=job.status,  # type: ignore[arg-type]
+        accepted_count=job.accepted_count,
+        idempotency_key=job.idempotency_key,
+        correlation_id=job.correlation_id,
+        request_id=job.request_id,
+        trace_id=job.trace_id,
+        submitted_at=job.submitted_at,
+        completed_at=job.completed_at,
+        failure_reason=job.failure_reason,
+    )
 
 
 class IngestionJobService:
     """
-    Tracks ingestion request lifecycle for API-first operational visibility.
+    Persists ingestion request lifecycle for API-first operational visibility.
     """
 
-    def __init__(self) -> None:
-        self._jobs: dict[str, _IngestionJobRecord] = {}
-        self._lock = RLock()
-
-    def create_job(
+    async def create_job(
         self,
         *,
         job_id: str,
@@ -60,60 +42,71 @@ class IngestionJobService:
         request_id: str,
         trace_id: str,
     ) -> None:
-        with self._lock:
-            self._jobs[job_id] = _IngestionJobRecord(
-                job_id=job_id,
-                endpoint=endpoint,
-                entity_type=entity_type,
-                accepted_count=accepted_count,
-                idempotency_key=idempotency_key,
-                correlation_id=correlation_id,
-                request_id=request_id,
-                trace_id=trace_id,
-                submitted_at=datetime.now(UTC),
+        async for db in get_async_db_session():
+            async with db.begin():
+                db.add(
+                    DBIngestionJob(
+                        job_id=job_id,
+                        endpoint=endpoint,
+                        entity_type=entity_type,
+                        status="accepted",
+                        accepted_count=accepted_count,
+                        idempotency_key=idempotency_key,
+                        correlation_id=correlation_id,
+                        request_id=request_id,
+                        trace_id=trace_id,
+                    )
+                )
+
+    async def mark_queued(self, job_id: str) -> None:
+        async for db in get_async_db_session():
+            async with db.begin():
+                row = await db.scalar(
+                    select(DBIngestionJob).where(DBIngestionJob.job_id == job_id).limit(1)
+                )
+                if row is None:
+                    return
+                row.status = "queued"
+                row.completed_at = datetime.now(UTC)
+                row.failure_reason = None
+
+    async def mark_failed(self, job_id: str, failure_reason: str) -> None:
+        async for db in get_async_db_session():
+            async with db.begin():
+                row = await db.scalar(
+                    select(DBIngestionJob).where(DBIngestionJob.job_id == job_id).limit(1)
+                )
+                if row is None:
+                    return
+                row.status = "failed"
+                row.completed_at = datetime.now(UTC)
+                row.failure_reason = failure_reason
+
+    async def get_job(self, job_id: str) -> IngestionJobResponse | None:
+        async for db in get_async_db_session():
+            row = await db.scalar(
+                select(DBIngestionJob).where(DBIngestionJob.job_id == job_id).limit(1)
             )
+            return _to_response(row) if row else None
+        return None
 
-    def mark_queued(self, job_id: str) -> None:
-        with self._lock:
-            if job_id not in self._jobs:
-                return
-            job = self._jobs[job_id]
-            job.status = "queued"
-            job.completed_at = datetime.now(UTC)
-            job.failure_reason = None
-
-    def mark_failed(self, job_id: str, failure_reason: str) -> None:
-        with self._lock:
-            if job_id not in self._jobs:
-                return
-            job = self._jobs[job_id]
-            job.status = "failed"
-            job.completed_at = datetime.now(UTC)
-            job.failure_reason = failure_reason
-
-    def get_job(self, job_id: str) -> IngestionJobResponse | None:
-        with self._lock:
-            job = self._jobs.get(job_id)
-            return job.to_response() if job else None
-
-    def list_jobs(
+    async def list_jobs(
         self,
         *,
         status: IngestionJobStatus | None = None,
         entity_type: str | None = None,
         limit: int = 100,
     ) -> list[IngestionJobResponse]:
-        with self._lock:
-            values = list(self._jobs.values())
-
-        filtered = [
-            job
-            for job in values
-            if (status is None or job.status == status)
-            and (entity_type is None or job.entity_type == entity_type)
-        ]
-        filtered.sort(key=lambda job: job.submitted_at, reverse=True)
-        return [job.to_response() for job in filtered[:limit]]
+        async for db in get_async_db_session():
+            stmt = select(DBIngestionJob)
+            if status is not None:
+                stmt = stmt.where(DBIngestionJob.status == status)
+            if entity_type is not None:
+                stmt = stmt.where(DBIngestionJob.entity_type == entity_type)
+            stmt = stmt.order_by(desc(DBIngestionJob.submitted_at)).limit(limit)
+            rows = (await db.scalars(stmt)).all()
+            return [_to_response(row) for row in rows]
+        return []
 
 
 _INGESTION_JOB_SERVICE = IngestionJobService()


### PR DESCRIPTION
## Summary
- add durable ingestion_jobs persistence model and Alembic migration
- replace in-memory ingestion job service with async DB-backed implementation
- keep existing ingestion operations APIs (GET /ingestion/jobs, GET /ingestion/jobs/{job_id}) but now backed by durable storage
- update ingestion routers to await async job lifecycle writes (ccepted, queued, ailed)
- keep integration tests API-first by overriding ingestion job dependency with a fake async service

## Validation
- python -m pytest tests/integration/services/ingestion_service/test_ingestion_routers.py tests/integration/services/ingestion_service/test_ingestion_main_app_contract.py tests/unit/services/ingestion_service/services/test_ingestion_service.py -q
- python scripts/openapi_quality_gate.py
- python scripts/api_vocabulary_inventory.py --validate-only
