### PR TITLE
feat: ingestion operations gold-standard APIs in one pass

### DIFF
--- a/alembic/versions/f1a2b3c4d5e6_feat_add_ingestion_job_failures_and_retry_metadata.py
+++ b/alembic/versions/f1a2b3c4d5e6_feat_add_ingestion_job_failures_and_retry_metadata.py
@@ -1,0 +1,67 @@
+"""feat: add ingestion job failure history and retry metadata
+
+Revision ID: f1a2b3c4d5e6
+Revises: e5f6a7b8c9d0
+Create Date: 2026-02-28 23:50:00
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f1a2b3c4d5e6"
+down_revision: Union[str, None] = "e5f6a7b8c9d0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("ingestion_jobs", sa.Column("request_payload", sa.JSON(), nullable=True))
+    op.add_column(
+        "ingestion_jobs",
+        sa.Column("retry_count", sa.Integer(), server_default="0", nullable=False),
+    )
+    op.add_column("ingestion_jobs", sa.Column("last_retried_at", sa.DateTime(timezone=True)))
+
+    op.create_table(
+        "ingestion_job_failures",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("failure_id", sa.String(), nullable=False),
+        sa.Column("job_id", sa.String(), nullable=False),
+        sa.Column("failure_phase", sa.String(), nullable=False),
+        sa.Column("failure_reason", sa.Text(), nullable=False),
+        sa.Column(
+            "failed_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["job_id"], ["ingestion_jobs.job_id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("failure_id"),
+    )
+    op.create_index(
+        "ix_ingestion_job_failures_failure_id",
+        "ingestion_job_failures",
+        ["failure_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_ingestion_job_failures_job_id",
+        "ingestion_job_failures",
+        ["job_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ingestion_job_failures_job_id", table_name="ingestion_job_failures")
+    op.drop_index("ix_ingestion_job_failures_failure_id", table_name="ingestion_job_failures")
+    op.drop_table("ingestion_job_failures")
+
+    op.drop_column("ingestion_jobs", "last_retried_at")
+    op.drop_column("ingestion_jobs", "retry_count")
+    op.drop_column("ingestion_jobs", "request_payload")

--- a/src/libs/portfolio-common/portfolio_common/database_models.py
+++ b/src/libs/portfolio-common/portfolio_common/database_models.py
@@ -488,6 +488,20 @@ class IngestionJob(Base):
     submitted_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     completed_at = Column(DateTime(timezone=True), nullable=True)
     failure_reason = Column(Text, nullable=True)
+    request_payload = Column(JSON, nullable=True)
+    retry_count = Column(Integer, nullable=False, default=0, server_default="0")
+    last_retried_at = Column(DateTime(timezone=True), nullable=True)
+
+
+class IngestionJobFailure(Base):
+    __tablename__ = "ingestion_job_failures"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    failure_id = Column(String, unique=True, index=True, nullable=False)
+    job_id = Column(String, ForeignKey("ingestion_jobs.job_id"), index=True, nullable=False)
+    failure_phase = Column(String, nullable=False)
+    failure_reason = Column(Text, nullable=False)
+    failed_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
 
 class PositionState(Base):

--- a/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
+++ b/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
@@ -59,6 +59,16 @@ class IngestionJobResponse(BaseModel):
         description="Failure reason when status is failed.",
         examples=["Kafka publish timeout for topic raw_transactions."],
     )
+    retry_count: int = Field(
+        ge=0,
+        description="Number of retry attempts executed for this ingestion job.",
+        examples=[1],
+    )
+    last_retried_at: datetime | None = Field(
+        default=None,
+        description="Timestamp of the most recent retry attempt.",
+        examples=["2026-02-28T13:24:10.512Z"],
+    )
 
 
 class IngestionJobListResponse(BaseModel):
@@ -69,4 +79,73 @@ class IngestionJobListResponse(BaseModel):
         ge=0,
         description="Number of jobs returned in this response.",
         examples=[20],
+    )
+    next_cursor: str | None = Field(
+        default=None,
+        description=(
+            "Opaque cursor to fetch the next page of jobs, based on descending ingestion job order."
+        ),
+        examples=["job_01J5S0J6D3BAVMK2E1V0WQ7MCC"],
+    )
+
+
+class IngestionJobFailureResponse(BaseModel):
+    failure_id: str = Field(
+        description="Unique failure record identifier for this job failure event.",
+        examples=["fail_01J5S27P16BSKQ3R2P2HK67GQZ"],
+    )
+    job_id: str = Field(
+        description="Ingestion job identifier this failure event belongs to.",
+        examples=["job_01J5S0J6D3BAVMK2E1V0WQ7MCC"],
+    )
+    failure_phase: str = Field(
+        description="Pipeline phase where the job failure occurred.",
+        examples=["publish"],
+    )
+    failure_reason: str = Field(
+        description="Detailed failure reason captured at runtime.",
+        examples=["Kafka publish timeout for topic raw_transactions."],
+    )
+    failed_at: datetime = Field(
+        description="Timestamp when this failure event was captured.",
+        examples=["2026-02-28T13:23:09.021Z"],
+    )
+
+
+class IngestionJobFailureListResponse(BaseModel):
+    failures: list[IngestionJobFailureResponse] = Field(
+        description="Failure events captured for the requested ingestion job."
+    )
+    total: int = Field(
+        ge=0,
+        description="Number of failure events returned in this response.",
+        examples=[1],
+    )
+
+
+class IngestionHealthSummaryResponse(BaseModel):
+    total_jobs: int = Field(
+        ge=0,
+        description="Total ingestion jobs stored in operational state.",
+        examples=[2450],
+    )
+    accepted_jobs: int = Field(
+        ge=0,
+        description="Total jobs currently in accepted state.",
+        examples=[3],
+    )
+    queued_jobs: int = Field(
+        ge=0,
+        description="Total jobs currently queued for asynchronous processing.",
+        examples=[7],
+    )
+    failed_jobs: int = Field(
+        ge=0,
+        description="Total jobs currently marked as failed.",
+        examples=[2],
+    )
+    backlog_jobs: int = Field(
+        ge=0,
+        description="Operational backlog count (accepted + queued).",
+        examples=[10],
     )

--- a/src/services/ingestion_service/app/routers/fx_rates.py
+++ b/src/services/ingestion_service/app/routers/fx_rates.py
@@ -37,7 +37,7 @@ async def ingest_fx_rates(
     num_rates = len(request.fx_rates)
     job_id = create_ingestion_job_id()
     correlation_id, request_id, trace_id = get_request_lineage()
-    await ingestion_job_service.create_job(
+    job_result = await ingestion_job_service.create_or_get_job(
         job_id=job_id,
         endpoint=str(http_request.url.path),
         entity_type="fx_rate",
@@ -46,7 +46,16 @@ async def ingest_fx_rates(
         correlation_id=correlation_id,
         request_id=request_id,
         trace_id=trace_id,
+        request_payload=request.model_dump(mode="json"),
     )
+    if not job_result.created:
+        return build_batch_ack(
+            message="Duplicate ingestion request accepted via idempotency replay.",
+            entity_type="fx_rate",
+            job_id=job_result.job.job_id,
+            accepted_count=job_result.job.accepted_count,
+            idempotency_key=idempotency_key,
+        )
     logger.info(
         "Received request to ingest fx rates.",
         extra={"num_rates": num_rates, "idempotency_key": idempotency_key},
@@ -54,16 +63,16 @@ async def ingest_fx_rates(
 
     try:
         await ingestion_service.publish_fx_rates(request.fx_rates, idempotency_key=idempotency_key)
-        await ingestion_job_service.mark_queued(job_id)
+        await ingestion_job_service.mark_queued(job_result.job.job_id)
     except Exception as exc:
-        await ingestion_job_service.mark_failed(job_id, str(exc))
+        await ingestion_job_service.mark_failed(job_result.job.job_id, str(exc))
         raise
 
     logger.info("FX rates successfully queued.", extra={"num_rates": num_rates})
     return build_batch_ack(
         message="FX rates accepted for asynchronous ingestion processing.",
         entity_type="fx_rate",
-        job_id=job_id,
+        job_id=job_result.job.job_id,
         accepted_count=num_rates,
         idempotency_key=idempotency_key,
     )

--- a/src/services/ingestion_service/app/routers/ingestion_jobs.py
+++ b/src/services/ingestion_service/app/routers/ingestion_jobs.py
@@ -1,11 +1,100 @@
-import logging
+from datetime import datetime
 
-from app.DTOs.ingestion_job_dto import IngestionJobListResponse, IngestionJobResponse
-from app.services.ingestion_job_service import IngestionJobService, get_ingestion_job_service
+from app.DTOs.business_date_dto import BusinessDateIngestionRequest
+from app.DTOs.fx_rate_dto import FxRateIngestionRequest
+from app.DTOs.ingestion_job_dto import (
+    IngestionHealthSummaryResponse,
+    IngestionJobFailureListResponse,
+    IngestionJobListResponse,
+    IngestionJobResponse,
+)
+from app.DTOs.instrument_dto import InstrumentIngestionRequest
+from app.DTOs.market_price_dto import MarketPriceIngestionRequest
+from app.DTOs.portfolio_bundle_dto import PortfolioBundleIngestionRequest
+from app.DTOs.portfolio_dto import PortfolioIngestionRequest
+from app.DTOs.reprocessing_dto import ReprocessingRequest
+from app.DTOs.transaction_dto import TransactionIngestionRequest
+from app.request_metadata import get_request_lineage
+from app.routers.reprocessing import REPROCESSING_REQUESTED_TOPIC
+from app.services.ingestion_job_service import (
+    IngestionJobService,
+    get_ingestion_job_service,
+)
+from app.services.ingestion_service import IngestionService, get_ingestion_service
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from portfolio_common.kafka_utils import KafkaProducer, get_kafka_producer
 
-logger = logging.getLogger(__name__)
 router = APIRouter()
+
+
+async def _replay_job_payload(
+    *,
+    endpoint: str,
+    payload: dict,
+    idempotency_key: str | None,
+    ingestion_service: IngestionService,
+    kafka_producer: KafkaProducer,
+) -> None:
+    if endpoint == "/ingest/transactions":
+        request_model = TransactionIngestionRequest.model_validate(payload)
+        await ingestion_service.publish_transactions(
+            request_model.transactions, idempotency_key=idempotency_key
+        )
+        return
+    if endpoint == "/ingest/portfolios":
+        request_model = PortfolioIngestionRequest.model_validate(payload)
+        await ingestion_service.publish_portfolios(
+            request_model.portfolios, idempotency_key=idempotency_key
+        )
+        return
+    if endpoint == "/ingest/instruments":
+        request_model = InstrumentIngestionRequest.model_validate(payload)
+        await ingestion_service.publish_instruments(
+            request_model.instruments, idempotency_key=idempotency_key
+        )
+        return
+    if endpoint == "/ingest/market-prices":
+        request_model = MarketPriceIngestionRequest.model_validate(payload)
+        await ingestion_service.publish_market_prices(
+            request_model.market_prices, idempotency_key=idempotency_key
+        )
+        return
+    if endpoint == "/ingest/fx-rates":
+        request_model = FxRateIngestionRequest.model_validate(payload)
+        await ingestion_service.publish_fx_rates(
+            request_model.fx_rates, idempotency_key=idempotency_key
+        )
+        return
+    if endpoint == "/ingest/business-dates":
+        request_model = BusinessDateIngestionRequest.model_validate(payload)
+        await ingestion_service.publish_business_dates(
+            request_model.business_dates, idempotency_key=idempotency_key
+        )
+        return
+    if endpoint == "/ingest/portfolio-bundle":
+        request_model = PortfolioBundleIngestionRequest.model_validate(payload)
+        await ingestion_service.publish_portfolio_bundle(
+            request_model, idempotency_key=idempotency_key
+        )
+        return
+    if endpoint == "/reprocess/transactions":
+        request_model = ReprocessingRequest.model_validate(payload)
+        correlation_id, _, _ = get_request_lineage()
+        headers: list[tuple[str, bytes]] = []
+        if correlation_id:
+            headers.append(("correlation_id", correlation_id.encode("utf-8")))
+        if idempotency_key:
+            headers.append(("idempotency_key", idempotency_key.encode("utf-8")))
+        for txn_id in request_model.transaction_ids:
+            kafka_producer.publish_message(
+                topic=REPROCESSING_REQUESTED_TOPIC,
+                key=txn_id,
+                value={"transaction_id": txn_id},
+                headers=headers or None,
+            )
+        kafka_producer.flush(timeout=5)
+        return
+    raise ValueError(f"Retry not supported for endpoint '{endpoint}'.")
 
 
 @router.get(
@@ -39,18 +128,146 @@ async def get_ingestion_job(
     tags=["Ingestion Operations"],
     summary="List ingestion jobs",
     description=(
-        "Returns recent ingestion jobs for operational monitoring. "
-        "Supports filtering by status and entity_type."
+        "Returns ingestion jobs for operational monitoring with status/entity/date filters "
+        "and cursor pagination."
     ),
 )
 async def list_ingestion_jobs(
     status_filter: str | None = Query(default=None, alias="status"),
     entity_type: str | None = Query(default=None),
+    submitted_from: datetime | None = Query(default=None, alias="from"),
+    submitted_to: datetime | None = Query(default=None, alias="to"),
+    cursor: str | None = Query(default=None),
     limit: int = Query(default=100, ge=1, le=500),
     ingestion_job_service: IngestionJobService = Depends(get_ingestion_job_service),
 ):
     status_value = status_filter if status_filter in {"accepted", "queued", "failed"} else None
-    jobs = await ingestion_job_service.list_jobs(
-        status=status_value, entity_type=entity_type, limit=limit
+    jobs, next_cursor = await ingestion_job_service.list_jobs(
+        status=status_value,
+        entity_type=entity_type,
+        submitted_from=submitted_from,
+        submitted_to=submitted_to,
+        cursor=cursor,
+        limit=limit,
     )
-    return IngestionJobListResponse(jobs=jobs, total=len(jobs))
+    return IngestionJobListResponse(jobs=jobs, total=len(jobs), next_cursor=next_cursor)
+
+
+@router.get(
+    "/ingestion/jobs/{job_id}/failures",
+    response_model=IngestionJobFailureListResponse,
+    status_code=status.HTTP_200_OK,
+    tags=["Ingestion Operations"],
+    summary="List ingestion job failures",
+    description="Returns failure history captured for an ingestion job.",
+)
+async def list_ingestion_job_failures(
+    job_id: str,
+    limit: int = Query(default=100, ge=1, le=500),
+    ingestion_job_service: IngestionJobService = Depends(get_ingestion_job_service),
+):
+    job = await ingestion_job_service.get_job(job_id)
+    if job is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "code": "INGESTION_JOB_NOT_FOUND",
+                "message": f"Ingestion job '{job_id}' was not found.",
+            },
+        )
+    failures = await ingestion_job_service.list_failures(job_id=job_id, limit=limit)
+    return IngestionJobFailureListResponse(failures=failures, total=len(failures))
+
+
+@router.post(
+    "/ingestion/jobs/{job_id}/retry",
+    response_model=IngestionJobResponse,
+    status_code=status.HTTP_200_OK,
+    tags=["Ingestion Operations"],
+    summary="Retry a failed ingestion job",
+    description=(
+        "Replays the original payload for a failed ingestion job using stored request payload."
+    ),
+)
+async def retry_ingestion_job(
+    job_id: str,
+    ingestion_job_service: IngestionJobService = Depends(get_ingestion_job_service),
+    ingestion_service: IngestionService = Depends(get_ingestion_service),
+    kafka_producer: KafkaProducer = Depends(get_kafka_producer),
+):
+    context = await ingestion_job_service.get_job_replay_context(job_id)
+    if context is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "code": "INGESTION_JOB_NOT_FOUND",
+                "message": f"Ingestion job '{job_id}' was not found.",
+            },
+        )
+    if context.request_payload is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "INGESTION_JOB_RETRY_UNSUPPORTED",
+                "message": (
+                    f"Ingestion job '{job_id}' does not have stored request payload and "
+                    "cannot be retried."
+                ),
+            },
+        )
+    try:
+        await _replay_job_payload(
+            endpoint=context.endpoint,
+            payload=context.request_payload,
+            idempotency_key=context.idempotency_key,
+            ingestion_service=ingestion_service,
+            kafka_producer=kafka_producer,
+        )
+        await ingestion_job_service.mark_retried(job_id)
+        await ingestion_job_service.mark_queued(job_id)
+    except Exception as exc:
+        await ingestion_job_service.mark_failed(
+            job_id, str(exc), failure_phase="retry_publish"
+        )
+        raise
+
+    job = await ingestion_job_service.get_job(job_id)
+    if job is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "code": "INGESTION_JOB_NOT_FOUND",
+                "message": f"Ingestion job '{job_id}' was not found after retry.",
+            },
+        )
+    return job
+
+
+@router.get(
+    "/ingestion/health/summary",
+    response_model=IngestionHealthSummaryResponse,
+    status_code=status.HTTP_200_OK,
+    tags=["Ingestion Operations"],
+    summary="Get ingestion operational health summary",
+    description="Returns aggregate ingestion job health counters for operations.",
+)
+async def get_ingestion_health_summary(
+    ingestion_job_service: IngestionJobService = Depends(get_ingestion_job_service),
+):
+    return await ingestion_job_service.get_health_summary()
+
+
+@router.get(
+    "/ingestion/health/lag",
+    response_model=IngestionHealthSummaryResponse,
+    status_code=status.HTTP_200_OK,
+    tags=["Ingestion Operations"],
+    summary="Get ingestion backlog indicators",
+    description=(
+        "Returns ingestion lag indicators derived from accepted and queued jobs."
+    ),
+)
+async def get_ingestion_health_lag(
+    ingestion_job_service: IngestionJobService = Depends(get_ingestion_job_service),
+):
+    return await ingestion_job_service.get_health_summary()

--- a/src/services/ingestion_service/app/routers/instruments.py
+++ b/src/services/ingestion_service/app/routers/instruments.py
@@ -37,7 +37,7 @@ async def ingest_instruments(
     num_instruments = len(request.instruments)
     job_id = create_ingestion_job_id()
     correlation_id, request_id, trace_id = get_request_lineage()
-    await ingestion_job_service.create_job(
+    job_result = await ingestion_job_service.create_or_get_job(
         job_id=job_id,
         endpoint=str(http_request.url.path),
         entity_type="instrument",
@@ -46,7 +46,16 @@ async def ingest_instruments(
         correlation_id=correlation_id,
         request_id=request_id,
         trace_id=trace_id,
+        request_payload=request.model_dump(mode="json"),
     )
+    if not job_result.created:
+        return build_batch_ack(
+            message="Duplicate ingestion request accepted via idempotency replay.",
+            entity_type="instrument",
+            job_id=job_result.job.job_id,
+            accepted_count=job_result.job.accepted_count,
+            idempotency_key=idempotency_key,
+        )
     logger.info(
         "Received request to ingest instruments.",
         extra={"num_instruments": num_instruments, "idempotency_key": idempotency_key},
@@ -56,16 +65,16 @@ async def ingest_instruments(
         await ingestion_service.publish_instruments(
             request.instruments, idempotency_key=idempotency_key
         )
-        await ingestion_job_service.mark_queued(job_id)
+        await ingestion_job_service.mark_queued(job_result.job.job_id)
     except Exception as exc:
-        await ingestion_job_service.mark_failed(job_id, str(exc))
+        await ingestion_job_service.mark_failed(job_result.job.job_id, str(exc))
         raise
 
     logger.info("Instruments successfully queued.", extra={"num_instruments": num_instruments})
     return build_batch_ack(
         message="Instruments accepted for asynchronous ingestion processing.",
         entity_type="instrument",
-        job_id=job_id,
+        job_id=job_result.job.job_id,
         accepted_count=num_instruments,
         idempotency_key=idempotency_key,
     )

--- a/src/services/ingestion_service/app/routers/portfolio_bundle.py
+++ b/src/services/ingestion_service/app/routers/portfolio_bundle.py
@@ -54,7 +54,7 @@ async def ingest_portfolio_bundle(
     )
     job_id = create_ingestion_job_id()
     correlation_id, request_id, trace_id = get_request_lineage()
-    await ingestion_job_service.create_job(
+    job_result = await ingestion_job_service.create_or_get_job(
         job_id=job_id,
         endpoint=str(http_request.url.path),
         entity_type="portfolio_bundle",
@@ -63,14 +63,23 @@ async def ingest_portfolio_bundle(
         correlation_id=correlation_id,
         request_id=request_id,
         trace_id=trace_id,
+        request_payload=request.model_dump(mode="json"),
     )
+    if not job_result.created:
+        return build_batch_ack(
+            message="Duplicate ingestion request accepted via idempotency replay.",
+            entity_type="portfolio_bundle",
+            job_id=job_result.job.job_id,
+            accepted_count=job_result.job.accepted_count,
+            idempotency_key=idempotency_key,
+        )
     try:
         published_counts = await ingestion_service.publish_portfolio_bundle(
             request, idempotency_key=idempotency_key
         )
-        await ingestion_job_service.mark_queued(job_id)
+        await ingestion_job_service.mark_queued(job_result.job.job_id)
     except Exception as exc:
-        await ingestion_job_service.mark_failed(job_id, str(exc))
+        await ingestion_job_service.mark_failed(job_result.job.job_id, str(exc))
         raise
 
     logger.info(
@@ -88,7 +97,7 @@ async def ingest_portfolio_bundle(
             f"Published counts: {published_counts}"
         ),
         entity_type="portfolio_bundle",
-        job_id=job_id,
+        job_id=job_result.job.job_id,
         accepted_count=accepted_count,
         idempotency_key=idempotency_key,
     )

--- a/src/services/ingestion_service/app/routers/portfolios.py
+++ b/src/services/ingestion_service/app/routers/portfolios.py
@@ -36,7 +36,7 @@ async def ingest_portfolios(
     num_portfolios = len(request.portfolios)
     job_id = create_ingestion_job_id()
     correlation_id, request_id, trace_id = get_request_lineage()
-    await ingestion_job_service.create_job(
+    job_result = await ingestion_job_service.create_or_get_job(
         job_id=job_id,
         endpoint=str(http_request.url.path),
         entity_type="portfolio",
@@ -45,7 +45,16 @@ async def ingest_portfolios(
         correlation_id=correlation_id,
         request_id=request_id,
         trace_id=trace_id,
+        request_payload=request.model_dump(mode="json"),
     )
+    if not job_result.created:
+        return build_batch_ack(
+            message="Duplicate ingestion request accepted via idempotency replay.",
+            entity_type="portfolio",
+            job_id=job_result.job.job_id,
+            accepted_count=job_result.job.accepted_count,
+            idempotency_key=idempotency_key,
+        )
     logger.info(
         "Received request to ingest portfolios.",
         extra={"num_portfolios": num_portfolios, "idempotency_key": idempotency_key},
@@ -55,16 +64,16 @@ async def ingest_portfolios(
         await ingestion_service.publish_portfolios(
             request.portfolios, idempotency_key=idempotency_key
         )
-        await ingestion_job_service.mark_queued(job_id)
+        await ingestion_job_service.mark_queued(job_result.job.job_id)
     except Exception as exc:
-        await ingestion_job_service.mark_failed(job_id, str(exc))
+        await ingestion_job_service.mark_failed(job_result.job.job_id, str(exc))
         raise
 
     logger.info("Portfolios successfully queued.", extra={"num_portfolios": num_portfolios})
     return build_batch_ack(
         message="Portfolios accepted for asynchronous ingestion processing.",
         entity_type="portfolio",
-        job_id=job_id,
+        job_id=job_result.job.job_id,
         accepted_count=num_portfolios,
         idempotency_key=idempotency_key,
     )

--- a/src/services/ingestion_service/app/routers/reprocessing.py
+++ b/src/services/ingestion_service/app/routers/reprocessing.py
@@ -48,7 +48,7 @@ async def reprocess_transactions(
     idempotency_key = idempotency_key_header or resolve_idempotency_key(http_request)
     correlation_id, request_id, trace_id = get_request_lineage()
     job_id = create_ingestion_job_id()
-    await ingestion_job_service.create_job(
+    job_result = await ingestion_job_service.create_or_get_job(
         job_id=job_id,
         endpoint=str(http_request.url.path),
         entity_type="reprocessing_request",
@@ -57,7 +57,16 @@ async def reprocess_transactions(
         correlation_id=correlation_id,
         request_id=request_id,
         trace_id=trace_id,
+        request_payload=request.model_dump(mode="json"),
     )
+    if not job_result.created:
+        return build_batch_ack(
+            message="Duplicate reprocessing request accepted via idempotency replay.",
+            entity_type="reprocessing_request",
+            job_id=job_result.job.job_id,
+            accepted_count=job_result.job.accepted_count,
+            idempotency_key=idempotency_key,
+        )
     headers: list[tuple[str, bytes]] = []
     if correlation_id:
         headers.append(("correlation_id", correlation_id.encode("utf-8")))
@@ -77,16 +86,16 @@ async def reprocess_transactions(
             )
 
         kafka_producer.flush(timeout=5)
-        await ingestion_job_service.mark_queued(job_id)
+        await ingestion_job_service.mark_queued(job_result.job.job_id)
     except Exception as exc:
-        await ingestion_job_service.mark_failed(job_id, str(exc))
+        await ingestion_job_service.mark_failed(job_result.job.job_id, str(exc))
         raise
 
     logger.info(f"Successfully queued {num_to_reprocess} reprocessing requests.")
     return build_batch_ack(
         message=f"Successfully queued {num_to_reprocess} transactions for reprocessing.",
         entity_type="reprocessing_request",
-        job_id=job_id,
+        job_id=job_result.job.job_id,
         accepted_count=num_to_reprocess,
         idempotency_key=idempotency_key,
     )

--- a/src/services/ingestion_service/app/services/ingestion_job_service.py
+++ b/src/services/ingestion_service/app/services/ingestion_job_service.py
@@ -1,11 +1,40 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
 
-from app.DTOs.ingestion_job_dto import IngestionJobResponse, IngestionJobStatus
-from portfolio_common.database_models import IngestionJob as DBIngestionJob
+from app.DTOs.ingestion_job_dto import (
+    IngestionHealthSummaryResponse,
+    IngestionJobFailureResponse,
+    IngestionJobResponse,
+    IngestionJobStatus,
+)
+from portfolio_common.database_models import (
+    IngestionJob as DBIngestionJob,
+)
+from portfolio_common.database_models import (
+    IngestionJobFailure as DBIngestionJobFailure,
+)
 from portfolio_common.db import get_async_db_session
-from sqlalchemy import desc, select
+from sqlalchemy import and_, desc, func, select
+
+
+@dataclass(slots=True)
+class IngestionJobReplayContext:
+    job_id: str
+    endpoint: str
+    entity_type: str
+    accepted_count: int
+    idempotency_key: str | None
+    request_payload: dict[str, Any] | None
+
+
+@dataclass(slots=True)
+class IngestionJobCreateResult:
+    job: IngestionJobResponse
+    created: bool
 
 
 def _to_response(job: DBIngestionJob) -> IngestionJobResponse:
@@ -22,6 +51,18 @@ def _to_response(job: DBIngestionJob) -> IngestionJobResponse:
         submitted_at=job.submitted_at,
         completed_at=job.completed_at,
         failure_reason=job.failure_reason,
+        retry_count=job.retry_count,
+        last_retried_at=job.last_retried_at,
+    )
+
+
+def _to_failure_response(failure: DBIngestionJobFailure) -> IngestionJobFailureResponse:
+    return IngestionJobFailureResponse(
+        failure_id=failure.failure_id,
+        job_id=failure.job_id,
+        failure_phase=failure.failure_phase,
+        failure_reason=failure.failure_reason,
+        failed_at=failure.failed_at,
     )
 
 
@@ -30,7 +71,7 @@ class IngestionJobService:
     Persists ingestion request lifecycle for API-first operational visibility.
     """
 
-    async def create_job(
+    async def create_or_get_job(
         self,
         *,
         job_id: str,
@@ -41,22 +82,43 @@ class IngestionJobService:
         correlation_id: str,
         request_id: str,
         trace_id: str,
-    ) -> None:
+        request_payload: dict[str, Any] | None,
+    ) -> IngestionJobCreateResult:
         async for db in get_async_db_session():
             async with db.begin():
-                db.add(
-                    DBIngestionJob(
-                        job_id=job_id,
-                        endpoint=endpoint,
-                        entity_type=entity_type,
-                        status="accepted",
-                        accepted_count=accepted_count,
-                        idempotency_key=idempotency_key,
-                        correlation_id=correlation_id,
-                        request_id=request_id,
-                        trace_id=trace_id,
+                if idempotency_key:
+                    existing = await db.scalar(
+                        select(DBIngestionJob)
+                        .where(
+                            and_(
+                                DBIngestionJob.endpoint == endpoint,
+                                DBIngestionJob.idempotency_key == idempotency_key,
+                            )
+                        )
+                        .order_by(desc(DBIngestionJob.submitted_at))
+                        .limit(1)
                     )
+                    if existing is not None:
+                        return IngestionJobCreateResult(job=_to_response(existing), created=False)
+
+                row = DBIngestionJob(
+                    job_id=job_id,
+                    endpoint=endpoint,
+                    entity_type=entity_type,
+                    status="accepted",
+                    accepted_count=accepted_count,
+                    idempotency_key=idempotency_key,
+                    correlation_id=correlation_id,
+                    request_id=request_id,
+                    trace_id=trace_id,
+                    request_payload=request_payload,
                 )
+                db.add(row)
+                await db.flush()
+                return IngestionJobCreateResult(job=_to_response(row), created=True)
+
+        msg = "Unable to create ingestion job due to unavailable database session."
+        raise RuntimeError(msg)
 
     async def mark_queued(self, job_id: str) -> None:
         async for db in get_async_db_session():
@@ -70,7 +132,9 @@ class IngestionJobService:
                 row.completed_at = datetime.now(UTC)
                 row.failure_reason = None
 
-    async def mark_failed(self, job_id: str, failure_reason: str) -> None:
+    async def mark_failed(
+        self, job_id: str, failure_reason: str, failure_phase: str = "publish"
+    ) -> None:
         async for db in get_async_db_session():
             async with db.begin():
                 row = await db.scalar(
@@ -81,6 +145,25 @@ class IngestionJobService:
                 row.status = "failed"
                 row.completed_at = datetime.now(UTC)
                 row.failure_reason = failure_reason
+                db.add(
+                    DBIngestionJobFailure(
+                        failure_id=f"fail_{uuid4().hex}",
+                        job_id=job_id,
+                        failure_phase=failure_phase,
+                        failure_reason=failure_reason,
+                    )
+                )
+
+    async def mark_retried(self, job_id: str) -> None:
+        async for db in get_async_db_session():
+            async with db.begin():
+                row = await db.scalar(
+                    select(DBIngestionJob).where(DBIngestionJob.job_id == job_id).limit(1)
+                )
+                if row is None:
+                    return
+                row.retry_count = int(row.retry_count or 0) + 1
+                row.last_retried_at = datetime.now(UTC)
 
     async def get_job(self, job_id: str) -> IngestionJobResponse | None:
         async for db in get_async_db_session():
@@ -90,23 +173,120 @@ class IngestionJobService:
             return _to_response(row) if row else None
         return None
 
+    async def get_job_replay_context(self, job_id: str) -> IngestionJobReplayContext | None:
+        async for db in get_async_db_session():
+            row = await db.scalar(
+                select(DBIngestionJob).where(DBIngestionJob.job_id == job_id).limit(1)
+            )
+            if row is None:
+                return None
+            payload = row.request_payload if isinstance(row.request_payload, dict) else None
+            return IngestionJobReplayContext(
+                job_id=row.job_id,
+                endpoint=row.endpoint,
+                entity_type=row.entity_type,
+                accepted_count=row.accepted_count,
+                idempotency_key=row.idempotency_key,
+                request_payload=payload,
+            )
+        return None
+
     async def list_jobs(
         self,
         *,
         status: IngestionJobStatus | None = None,
         entity_type: str | None = None,
+        submitted_from: datetime | None = None,
+        submitted_to: datetime | None = None,
+        cursor: str | None = None,
         limit: int = 100,
-    ) -> list[IngestionJobResponse]:
+    ) -> tuple[list[IngestionJobResponse], str | None]:
         async for db in get_async_db_session():
             stmt = select(DBIngestionJob)
             if status is not None:
                 stmt = stmt.where(DBIngestionJob.status == status)
             if entity_type is not None:
                 stmt = stmt.where(DBIngestionJob.entity_type == entity_type)
-            stmt = stmt.order_by(desc(DBIngestionJob.submitted_at)).limit(limit)
-            rows = (await db.scalars(stmt)).all()
-            return [_to_response(row) for row in rows]
+            if submitted_from is not None:
+                stmt = stmt.where(DBIngestionJob.submitted_at >= submitted_from)
+            if submitted_to is not None:
+                stmt = stmt.where(DBIngestionJob.submitted_at <= submitted_to)
+            if cursor is not None:
+                cursor_row = await db.scalar(
+                    select(DBIngestionJob).where(DBIngestionJob.job_id == cursor).limit(1)
+                )
+                if cursor_row is not None:
+                    stmt = stmt.where(DBIngestionJob.id < cursor_row.id)
+            stmt = stmt.order_by(desc(DBIngestionJob.id)).limit(limit + 1)
+            rows = list((await db.scalars(stmt)).all())
+            has_more = len(rows) > limit
+            page_rows = rows[:limit]
+            next_cursor = page_rows[-1].job_id if has_more and page_rows else None
+            return ([_to_response(row) for row in page_rows], next_cursor)
+        return ([], None)
+
+    async def list_failures(
+        self, job_id: str, limit: int = 100
+    ) -> list[IngestionJobFailureResponse]:
+        async for db in get_async_db_session():
+            rows = (
+                await db.scalars(
+                    select(DBIngestionJobFailure)
+                    .where(DBIngestionJobFailure.job_id == job_id)
+                    .order_by(desc(DBIngestionJobFailure.failed_at))
+                    .limit(limit)
+                )
+            ).all()
+            return [_to_failure_response(row) for row in rows]
         return []
+
+    async def get_health_summary(self) -> IngestionHealthSummaryResponse:
+        async for db in get_async_db_session():
+            total_jobs = int((await db.scalar(select(func.count(DBIngestionJob.id)))) or 0)
+            accepted_jobs = int(
+                (
+                    await db.scalar(
+                        select(func.count(DBIngestionJob.id)).where(
+                            DBIngestionJob.status == "accepted"
+                        )
+                    )
+                )
+                or 0
+            )
+            queued_jobs = int(
+                (
+                    await db.scalar(
+                        select(func.count(DBIngestionJob.id)).where(
+                            DBIngestionJob.status == "queued"
+                        )
+                    )
+                )
+                or 0
+            )
+            failed_jobs = int(
+                (
+                    await db.scalar(
+                        select(func.count(DBIngestionJob.id)).where(
+                            DBIngestionJob.status == "failed"
+                        )
+                    )
+                )
+                or 0
+            )
+            return IngestionHealthSummaryResponse(
+                total_jobs=total_jobs,
+                accepted_jobs=accepted_jobs,
+                queued_jobs=queued_jobs,
+                failed_jobs=failed_jobs,
+                backlog_jobs=accepted_jobs + queued_jobs,
+            )
+        return IngestionHealthSummaryResponse(
+            total_jobs=0,
+            accepted_jobs=0,
+            queued_jobs=0,
+            failed_jobs=0,
+            backlog_jobs=0,
+        )
 
 
 _INGESTION_JOB_SERVICE = IngestionJobService()


### PR DESCRIPTION
## Summary
- add DB-backed ingestion failure history and retry metadata
- add idempotent job creation (ndpoint + idempotency_key) with request payload capture for safe replay
- add ingestion operations APIs:
  - GET /ingestion/jobs with status/entity/from/to/cursor/limit
  - GET /ingestion/jobs/{job_id}/failures
  - POST /ingestion/jobs/{job_id}/retry
  - GET /ingestion/health/summary
  - GET /ingestion/health/lag
- update ingestion batch/reprocessing routers to use durable idempotent job lifecycle
- add integration tests for idempotency replay, failure history, retry, and health

## Validation
- python -m ruff check on touched files
- python -m pytest tests/integration/services/ingestion_service/test_ingestion_routers.py tests/integration/services/ingestion_service/test_ingestion_main_app_contract.py tests/unit/services/ingestion_service/services/test_ingestion_service.py
- python scripts/openapi_quality_gate.py
- python scripts/api_vocabulary_inventory.py --validate-only
- python -m mypy src/services/ingestion_service/app/services/ingestion_job_service.py src/services/ingestion_service/app/routers/ingestion_jobs.py
