### PR TITLE
feat(ingestion): enforce What-How-When API contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,23 @@
-.PHONY: install lint typecheck architecture-guard monetary-float-guard no-alias-gate openapi-gate api-vocabulary-gate warning-gate migration-smoke migration-apply test test-unit test-unit-db test-integration-lite test-buy-rfc test-e2e-smoke test-docker-smoke security-audit check coverage-gate ci ci-local docker-build clean
+.PHONY: install lint typecheck architecture-guard monetary-float-guard ingestion-contract-gate no-alias-gate openapi-gate api-vocabulary-gate warning-gate migration-smoke migration-apply test test-unit test-unit-db test-integration-lite test-buy-rfc test-e2e-smoke test-docker-smoke security-audit check coverage-gate ci ci-local docker-build clean
 
 install:
 	python scripts/bootstrap_dev.py
 
 lint:
-	python -m ruff check src/services/query_service/app src/services/ingestion_service/app/main.py src/libs/portfolio-common/portfolio_common/openapi_enrichment.py tests/unit/services/query_service tests/unit/libs/portfolio-common/test_openapi_enrichment.py tests/test_support tests/unit/test_support scripts/test_manifest.py scripts/coverage_gate.py scripts/openapi_quality_gate.py scripts/warning_budget_gate.py scripts/api_vocabulary_inventory.py scripts/no_alias_contract_guard.py --ignore E501,I001
+	python -m ruff check src/services/query_service/app src/services/ingestion_service/app/main.py src/libs/portfolio-common/portfolio_common/openapi_enrichment.py tests/unit/services/query_service tests/unit/libs/portfolio-common/test_openapi_enrichment.py tests/test_support tests/unit/test_support scripts/test_manifest.py scripts/coverage_gate.py scripts/openapi_quality_gate.py scripts/warning_budget_gate.py scripts/api_vocabulary_inventory.py scripts/no_alias_contract_guard.py scripts/ingestion_endpoint_contract_gate.py --ignore E501,I001
 	python -m ruff check scripts/docker_endpoint_smoke.py --ignore E501,I001
-	python -m ruff format --check src/services/query_service/app/main.py src/services/ingestion_service/app/main.py src/libs/portfolio-common/portfolio_common/openapi_enrichment.py tests/unit/services/query_service/test_openapi_quality_gate.py tests/unit/services/query_service/test_api_vocabulary_inventory.py tests/unit/libs/portfolio-common/test_openapi_enrichment.py scripts/test_manifest.py scripts/coverage_gate.py scripts/openapi_quality_gate.py scripts/warning_budget_gate.py scripts/api_vocabulary_inventory.py scripts/no_alias_contract_guard.py scripts/docker_endpoint_smoke.py
+	python -m ruff format --check src/services/query_service/app/main.py src/services/ingestion_service/app/main.py src/libs/portfolio-common/portfolio_common/openapi_enrichment.py tests/unit/services/query_service/test_openapi_quality_gate.py tests/unit/services/query_service/test_api_vocabulary_inventory.py tests/unit/libs/portfolio-common/test_openapi_enrichment.py scripts/test_manifest.py scripts/coverage_gate.py scripts/openapi_quality_gate.py scripts/warning_budget_gate.py scripts/api_vocabulary_inventory.py scripts/no_alias_contract_guard.py scripts/docker_endpoint_smoke.py scripts/ingestion_endpoint_contract_gate.py
 	$(MAKE) monetary-float-guard
+	$(MAKE) ingestion-contract-gate
 
 monetary-float-guard:
 	python scripts/check_monetary_float_usage.py
 
 no-alias-gate:
 	python scripts/no_alias_contract_guard.py
+
+ingestion-contract-gate:
+	python scripts/ingestion_endpoint_contract_gate.py
 
 typecheck:
 	python -m mypy --config-file mypy.ini

--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ To run the full local quality gate (lint + mypy + combined coverage gate):
 make ci-local
 ```
 
+To enforce ingestion endpoint documentation contract (`What/How/When` in OpenAPI descriptions):
+
+```bash
+make ingestion-contract-gate
+```
+
 To run architecture boundary checks:
 
 ```bash

--- a/scripts/ingestion_endpoint_contract_gate.py
+++ b/scripts/ingestion_endpoint_contract_gate.py
@@ -1,0 +1,98 @@
+"""Enforce What/How/When description contract for ingestion router endpoints."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ROUTERS_DIR = REPO_ROOT / "src" / "services" / "ingestion_service" / "app" / "routers"
+REQUIRED_MARKERS = ("What:", "How:", "When:")
+HTTP_DECORATORS = {"get", "post", "put", "delete", "patch"}
+
+
+def _extract_description_value(decorator: ast.Call) -> str | None:
+    for keyword in decorator.keywords:
+        if keyword.arg != "description":
+            continue
+        value_node = keyword.value
+        if isinstance(value_node, ast.Constant) and isinstance(value_node.value, str):
+            return value_node.value
+        if isinstance(value_node, ast.JoinedStr):
+            parts: list[str] = []
+            for segment in value_node.values:
+                if isinstance(segment, ast.Constant) and isinstance(segment.value, str):
+                    parts.append(segment.value)
+                else:
+                    return None
+            return "".join(parts)
+        return None
+    return None
+
+
+def _is_router_http_decorator(decorator: ast.AST) -> bool:
+    if not isinstance(decorator, ast.Call):
+        return False
+    func = decorator.func
+    if not isinstance(func, ast.Attribute):
+        return False
+    return func.attr in HTTP_DECORATORS
+
+
+def _check_file(path: Path) -> list[dict[str, str]]:
+    violations: list[dict[str, str]] = []
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef):
+            continue
+        for decorator in node.decorator_list:
+            if not _is_router_http_decorator(decorator):
+                continue
+            assert isinstance(decorator, ast.Call)
+            route_path = ""
+            if decorator.args and isinstance(decorator.args[0], ast.Constant):
+                if isinstance(decorator.args[0].value, str):
+                    route_path = decorator.args[0].value
+            description = _extract_description_value(decorator)
+            if not description:
+                violations.append(
+                    {
+                        "file": str(path.relative_to(REPO_ROOT)).replace("\\", "/"),
+                        "function": node.name,
+                        "route": route_path or "<unknown>",
+                        "issue": "Missing description or non-literal description expression.",
+                    }
+                )
+                continue
+            missing = [marker for marker in REQUIRED_MARKERS if marker not in description]
+            if missing:
+                violations.append(
+                    {
+                        "file": str(path.relative_to(REPO_ROOT)).replace("\\", "/"),
+                        "function": node.name,
+                        "route": route_path or "<unknown>",
+                        "issue": f"Missing markers: {', '.join(missing)}",
+                    }
+                )
+    return violations
+
+
+def main() -> int:
+    violations: list[dict[str, str]] = []
+    for path in sorted(ROUTERS_DIR.glob("*.py")):
+        if path.name in {"__init__.py"}:
+            continue
+        violations.extend(_check_file(path))
+
+    if violations:
+        print("Ingestion endpoint What/How/When gate failed:")
+        print(json.dumps(violations, indent=2))
+        return 1
+
+    print("Ingestion endpoint What/How/When gate passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/services/ingestion_service/app/routers/business_dates.py
+++ b/src/services/ingestion_service/app/routers/business_dates.py
@@ -28,7 +28,11 @@ router = APIRouter()
     response_model=BatchIngestionAcceptedResponse,
     tags=["Business Dates"],
     summary="Ingest business dates",
-    description="Accepts canonical business dates and publishes them for asynchronous processing.",
+    description=(
+        "What: Accept canonical business calendar dates used by valuation and processing lifecycles.\n"
+        "How: Validate date records, apply ingestion controls, and publish asynchronous persistence events.\n"
+        "When: Use for calendar setup, holiday updates, and date-correction operations."
+    ),
 )
 async def ingest_business_dates(
     request: BusinessDateIngestionRequest,
@@ -96,4 +100,3 @@ async def ingest_business_dates(
         accepted_count=num_dates,
         idempotency_key=idempotency_key,
     )
-

--- a/src/services/ingestion_service/app/routers/fx_rates.py
+++ b/src/services/ingestion_service/app/routers/fx_rates.py
@@ -28,7 +28,11 @@ router = APIRouter()
     response_model=BatchIngestionAcceptedResponse,
     tags=["FX Rates"],
     summary="Ingest FX rates",
-    description="Accepts canonical FX rates and publishes them for asynchronous processing.",
+    description=(
+        "What: Accept canonical foreign-exchange rate observations.\n"
+        "How: Validate FX rate contract, enforce ingestion controls, and publish asynchronous events for downstream valuation.\n"
+        "When: Use for scheduled FX reference updates and approved manual corrections."
+    ),
 )
 async def ingest_fx_rates(
     request: FxRateIngestionRequest,
@@ -94,4 +98,3 @@ async def ingest_fx_rates(
         accepted_count=num_rates,
         idempotency_key=idempotency_key,
     )
-

--- a/src/services/ingestion_service/app/routers/instruments.py
+++ b/src/services/ingestion_service/app/routers/instruments.py
@@ -28,7 +28,11 @@ router = APIRouter()
     response_model=BatchIngestionAcceptedResponse,
     tags=["Instruments"],
     summary="Ingest instruments",
-    description="Accepts canonical instruments and publishes them for asynchronous processing.",
+    description=(
+        "What: Accept canonical instrument/security reference records.\n"
+        "How: Validate schema, enforce ingestion mode/idempotency controls, and publish to asynchronous persistence pipeline.\n"
+        "When: Use for security master onboarding and reference data corrections."
+    ),
 )
 async def ingest_instruments(
     request: InstrumentIngestionRequest,
@@ -96,4 +100,3 @@ async def ingest_instruments(
         accepted_count=num_instruments,
         idempotency_key=idempotency_key,
     )
-

--- a/src/services/ingestion_service/app/routers/market_prices.py
+++ b/src/services/ingestion_service/app/routers/market_prices.py
@@ -28,7 +28,11 @@ router = APIRouter()
     response_model=BatchIngestionAcceptedResponse,
     tags=["Market Prices"],
     summary="Ingest market prices",
-    description="Accepts canonical market prices and publishes them for asynchronous processing.",
+    description=(
+        "What: Accept canonical market price observations for securities.\n"
+        "How: Validate payload, enforce ingestion guardrails, and publish asynchronous events for valuation processing.\n"
+        "When: Use for daily close pricing loads or intraday approved market data updates."
+    ),
 )
 async def ingest_market_prices(
     request: MarketPriceIngestionRequest,
@@ -96,4 +100,3 @@ async def ingest_market_prices(
         accepted_count=num_prices,
         idempotency_key=idempotency_key,
     )
-

--- a/src/services/ingestion_service/app/routers/portfolio_bundle.py
+++ b/src/services/ingestion_service/app/routers/portfolio_bundle.py
@@ -34,9 +34,10 @@ router = APIRouter()
     tags=["Portfolio Bundle"],
     summary="Ingest a complete portfolio bundle",
     description=(
-        "Accepts a mixed payload (portfolio, instruments, transactions, market prices, FX rates, "
-        "business dates) for UI/manual/file-based onboarding and publishes to "
-        "existing lotus-core topics."
+        "What: Accept a mixed onboarding bundle containing portfolio, instrument, transaction, "
+        "market-price, FX-rate, and business-date records.\n"
+        "How: Validate adapter payload and fan out records into existing canonical ingestion topics.\n"
+        "When: Use for adapter-mode onboarding (UI/manual/file workflows), not primary upstream integration."
     ),
 )
 async def ingest_portfolio_bundle(
@@ -119,4 +120,3 @@ async def ingest_portfolio_bundle(
         accepted_count=accepted_count,
         idempotency_key=idempotency_key,
     )
-

--- a/src/services/ingestion_service/app/routers/portfolios.py
+++ b/src/services/ingestion_service/app/routers/portfolios.py
@@ -27,7 +27,11 @@ router = APIRouter()
     response_model=BatchIngestionAcceptedResponse,
     tags=["Portfolios"],
     summary="Ingest portfolios",
-    description="Accepts canonical portfolios and publishes them for asynchronous processing.",
+    description=(
+        "What: Accept canonical portfolio master records.\n"
+        "How: Validate portfolio schema, enforce idempotency/mode checks, and publish asynchronously for persistence.\n"
+        "When: Use when onboarding or updating portfolio metadata from upstream systems."
+    ),
 )
 async def ingest_portfolios(
     request: PortfolioIngestionRequest,
@@ -95,4 +99,3 @@ async def ingest_portfolios(
         accepted_count=num_portfolios,
         idempotency_key=idempotency_key,
     )
-

--- a/src/services/ingestion_service/app/routers/reprocessing.py
+++ b/src/services/ingestion_service/app/routers/reprocessing.py
@@ -29,8 +29,9 @@ REPROCESSING_REQUESTED_TOPIC = "transactions_reprocessing_requested"
     tags=["Reprocessing"],
     summary="Request transaction reprocessing",
     description=(
-        "Accepts transaction identifiers and publishes reprocessing requests "
-        "for asynchronous handling."
+        "What: Accept transaction identifiers that require deterministic historical recalculation.\n"
+        "How: Validate request, persist ingestion job metadata, and publish reprocessing command events.\n"
+        "When: Use for operational correction workflows after retroactive data changes."
     ),
 )
 async def reprocess_transactions(
@@ -110,4 +111,3 @@ async def reprocess_transactions(
         accepted_count=num_to_reprocess,
         idempotency_key=idempotency_key,
     )
-

--- a/src/services/ingestion_service/app/routers/transactions.py
+++ b/src/services/ingestion_service/app/routers/transactions.py
@@ -27,7 +27,11 @@ router = APIRouter()
     response_model=IngestionAcceptedResponse,
     tags=["Transactions"],
     summary="Ingest a single transaction",
-    description=("Accepts a canonical transaction and publishes it for asynchronous processing."),
+    description=(
+        "What: Accept one canonical transaction record for ledger ingestion.\n"
+        "How: Validate contract, enforce idempotency/mode controls, then publish asynchronously to Kafka.\n"
+        "When: Use for low-volume operational corrections or single-record onboarding."
+    ),
 )
 async def ingest_transaction(
     transaction: Transaction,
@@ -82,7 +86,9 @@ async def ingest_transaction(
     tags=["Transactions"],
     summary="Ingest a transaction batch",
     description=(
-        "Accepts a batch of canonical transactions and publishes them for asynchronous processing."
+        "What: Accept a batch of canonical transaction records.\n"
+        "How: Persist ingestion job metadata, validate payload, and publish all valid records asynchronously.\n"
+        "When: Use for standard API-driven batch ingestion workflows."
     ),
 )
 async def ingest_transactions(
@@ -155,4 +161,3 @@ async def ingest_transactions(
         accepted_count=num_transactions,
         idempotency_key=idempotency_key,
     )
-

--- a/src/services/ingestion_service/app/routers/uploads.py
+++ b/src/services/ingestion_service/app/routers/uploads.py
@@ -28,8 +28,9 @@ router = APIRouter()
     tags=["Bulk Uploads"],
     summary="Preview and validate bulk upload data",
     description=(
-        "Validates CSV/XLSX rows against lotus-core ingestion contracts without publishing events. "
-        "Returns row-level errors and normalized sample rows for UI correction workflows."
+        "What: Validate CSV/XLSX ingestion payloads without publishing records.\n"
+        "How: Parse file rows, apply entity-specific schema checks, and return row-level validation feedback.\n"
+        "When: Use before commit to catch data-quality issues in bulk adapter uploads."
     ),
 )
 async def preview_upload(
@@ -74,9 +75,9 @@ async def preview_upload(
     tags=["Bulk Uploads"],
     summary="Commit validated bulk upload data",
     description=(
-        "Validates CSV/XLSX rows and publishes valid records to "
-        "existing lotus-core ingestion topics. "
-        "By default rejects partial uploads; set allowPartial=true to publish valid rows only."
+        "What: Commit CSV/XLSX data into canonical ingestion topics.\n"
+        "How: Validate rows, enforce mode controls, and publish valid records (optionally partial when allowPartial=true).\n"
+        "When: Use after preview passes for adapter-mode bulk ingestion."
     ),
 )
 async def commit_upload(
@@ -111,4 +112,3 @@ async def commit_upload(
         },
     )
     return response
-


### PR DESCRIPTION
## Summary
- standardize ingestion endpoint documentation descriptions to include explicit `What`, `How`, and `When` sections
- add `scripts/ingestion_endpoint_contract_gate.py` to enforce this contract across ingestion routers
- wire new gate into `make lint` and expose standalone `make ingestion-contract-gate`
- update README with new contract gate command

## Validation
- `make ingestion-contract-gate`
- `python -m pytest tests/integration/services/ingestion_service/test_ingestion_routers.py -q`
- `python -m ruff check src/services/ingestion_service/app/routers scripts/ingestion_endpoint_contract_gate.py --ignore E501,I001`
- `python -m ruff format --check src/services/ingestion_service/app/routers scripts/ingestion_endpoint_contract_gate.py`
- `python scripts/openapi_quality_gate.py`
