### PR TITLE
feat(ingestion): complete gold-standard ops enhancements (1-8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,49 @@ jobs:
       - name: Build query-service image
         run: make docker-build
 
+  docker-smoke-contract:
+    name: Docker Smoke Contract
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-docker-smoke'))
+    needs: [quality, coverage-gate]
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+
+      - name: Install Tooling and Project Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          make install
+
+      - name: Run deterministic docker endpoint smoke
+        run: make test-docker-smoke
+
+      - name: Capture docker compose logs on failure
+        if: failure()
+        run: docker compose logs > docker-smoke-logs.txt
+
+      - name: Upload smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-smoke-artifacts
+          path: |
+            output/task-runs/*.json
+            output/task-runs/*.md
+            docker-smoke-logs.txt
+          if-no-files-found: warn
+          retention-days: 14
+
   e2e-smoke:
     name: E2E Smoke
     if: >

--- a/docs/operations/ingestion-api-gold-standard.md
+++ b/docs/operations/ingestion-api-gold-standard.md
@@ -1,0 +1,37 @@
+# Lotus Core Ingestion API Gold Standard Controls
+
+This runbook summarizes the ingestion operations controls expected for production-grade usage.
+
+## What/How/When endpoint contract
+
+- Every ingestion endpoint description follows:
+  - `What:` the business intent.
+  - `How:` processing behavior and controls.
+  - `When:` recommended operational usage context.
+- Validation gate: `python scripts/ingestion_endpoint_contract_gate.py`
+
+## Operations authorization
+
+- Privileged operations APIs under `/ingestion/*` require `X-Lotus-Ops-Token` by default.
+- Controls:
+  - `LOTUS_CORE_INGEST_OPS_TOKEN_REQUIRED` (default: `true`)
+  - `LOTUS_CORE_INGEST_OPS_TOKEN` (default: `lotus-core-ops-local`)
+
+## Ingestion write rate limiting
+
+- Canonical ingestion write APIs enforce rolling-window rate limits.
+- Controls:
+  - `LOTUS_CORE_INGEST_RATE_LIMIT_ENABLED` (default: `true`)
+  - `LOTUS_CORE_INGEST_RATE_LIMIT_WINDOW_SECONDS` (default: `60`)
+  - `LOTUS_CORE_INGEST_RATE_LIMIT_MAX_REQUESTS` (default: `120`)
+  - `LOTUS_CORE_INGEST_RATE_LIMIT_MAX_RECORDS` (default: `10000`)
+
+## High-value operations endpoints
+
+- `GET /ingestion/health/consumer-lag`
+- `GET /ingestion/health/error-budget`
+- `GET /ingestion/jobs/{job_id}/records`
+- `GET /ingestion/idempotency/diagnostics`
+- `POST /ingestion/dlq/consumer-events/{event_id}/replay`
+
+These endpoints are designed so operations teams can triage and recover ingestion without direct DB access.

--- a/docs/standards/api-vocabulary/lotus-core-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-core-api-vocabulary.v1.json
@@ -13,14 +13,42 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-02-28T11:45:39.792930+00:00",
+  "generatedAt": "2026-03-01T02:11:43.652261+00:00",
   "attributeCatalog": [
+    {
+      "semanticId": "lotus.accepted_count",
+      "canonicalTerm": "accepted_count",
+      "preferredName": "accepted_count",
+      "description": "Number of records accepted for asynchronous processing.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.accepted_jobs",
+      "canonicalTerm": "accepted_jobs",
+      "preferredName": "accepted_jobs",
+      "description": "Total jobs currently in accepted state.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
     {
       "semanticId": "lotus.accrued_interest_paid_local",
       "canonicalTerm": "accrued_interest_paid_local",
       "preferredName": "accrued_interest_paid_local",
       "description": "Accrued interest paid on acquisition in local currency.",
-      "example": "STANDARD",
+      "example": "example_accrued_interest_paid_local",
       "type": "string",
       "locations": [
         "body"
@@ -77,7 +105,7 @@
       "preferredName": "allowed_sections",
       "description": "effective integration policy response field: allowed sections.",
       "example": [
-        "ALLOWED_SECTIONS_ITEM_VALUE"
+        "example_allowed_sections_item"
       ],
       "type": "array",
       "locations": [
@@ -92,7 +120,7 @@
       "canonicalTerm": "amount",
       "preferredName": "amount",
       "description": "Monetary value for amount.",
-      "example": 125000.5,
+      "example": "amount_example",
       "type": "object",
       "locations": [
         "body"
@@ -120,7 +148,7 @@
       "canonicalTerm": "asset_class",
       "preferredName": "asset_class",
       "description": "Asset class for grouping and reporting.",
-      "example": "EQUITY",
+      "example": "Equity",
       "type": "object",
       "locations": [
         "body"
@@ -134,13 +162,83 @@
       "canonicalTerm": "attempt_count",
       "preferredName": "attempt_count",
       "description": "Current retry attempt count for valuation jobs.",
-      "example": 1,
+      "example": "attempt_count_example",
       "type": "object",
       "locations": [
         "body"
       ],
       "observedTypes": [
         "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.backlog_age_seconds",
+      "canonicalTerm": "backlog_age_seconds",
+      "preferredName": "backlog_age_seconds",
+      "description": "Age in seconds of the oldest non-terminal ingestion job.",
+      "example": 10.5,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.backlog_age_threshold_seconds",
+      "canonicalTerm": "backlog_age_threshold_seconds",
+      "preferredName": "backlog_age_threshold_seconds",
+      "description": "Canonical backlog age threshold seconds value used in request parameter.",
+      "example": 10.5,
+      "type": "number",
+      "locations": [
+        "query"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.backlog_growth",
+      "canonicalTerm": "backlog_growth",
+      "preferredName": "backlog_growth",
+      "description": "Backlog growth compared with previous window.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.backlog_growth_threshold",
+      "canonicalTerm": "backlog_growth_threshold",
+      "preferredName": "backlog_growth_threshold",
+      "description": "Canonical backlog growth threshold value used in request parameter.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "query"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.backlog_jobs",
+      "canonicalTerm": "backlog_jobs",
+      "preferredName": "backlog_jobs",
+      "description": "Operational backlog count (accepted + queued).",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
       ]
     },
     {
@@ -162,7 +260,7 @@
       "canonicalTerm": "baseline_as_of",
       "preferredName": "baseline_as_of",
       "description": "projected positions response field: baseline as of.",
-      "example": "2026-02-27",
+      "example": "baseline_as_of_example",
       "type": "object",
       "locations": [
         "body"
@@ -201,6 +299,62 @@
       "observedTypes": [
         "object",
         "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.breach_backlog_age",
+      "canonicalTerm": "breach_backlog_age",
+      "preferredName": "breach_backlog_age",
+      "description": "Whether backlog age exceeds configured threshold.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
+      "semanticId": "lotus.breach_backlog_growth",
+      "canonicalTerm": "breach_backlog_growth",
+      "preferredName": "breach_backlog_growth",
+      "description": "Whether backlog growth exceeds threshold.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
+      "semanticId": "lotus.breach_failure_rate",
+      "canonicalTerm": "breach_failure_rate",
+      "preferredName": "breach_failure_rate",
+      "description": "Whether failure rate exceeds configured threshold.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
+      "semanticId": "lotus.breach_queue_latency",
+      "canonicalTerm": "breach_queue_latency",
+      "preferredName": "breach_queue_latency",
+      "description": "Whether p95 queue latency exceeds configured threshold.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
       ]
     },
     {
@@ -252,9 +406,7 @@
       "canonicalTerm": "calculation_policy_version",
       "preferredName": "calculation_policy_version",
       "description": "Version of calculation policy used.",
-      "example": {
-        "id": "OBJ_001"
-      },
+      "example": "calculation_policy_version_example",
       "type": "object",
       "locations": [
         "body"
@@ -268,7 +420,7 @@
       "canonicalTerm": "cashflow",
       "preferredName": "cashflow",
       "description": "transaction record field: cashflow.",
-      "example": 3200.0,
+      "example": "cashflow_example",
       "type": "object",
       "locations": [
         "body"
@@ -282,9 +434,7 @@
       "canonicalTerm": "cashflow_amount",
       "preferredName": "cashflow_amount",
       "description": "Linked cashflow amount.",
-      "example": {
-        "id": "OBJ_001"
-      },
+      "example": "cashflow_amount_example",
       "type": "object",
       "locations": [
         "body"
@@ -298,9 +448,7 @@
       "canonicalTerm": "cashflow_classification",
       "preferredName": "cashflow_classification",
       "description": "Cashflow classification.",
-      "example": {
-        "id": "OBJ_001"
-      },
+      "example": "cashflow_classification_example",
       "type": "object",
       "locations": [
         "body"
@@ -358,7 +506,7 @@
       "preferredName": "changes",
       "description": "simulation change upsert request field: changes.",
       "example": [
-        "CHANGES_ITEM_VALUE"
+        "changes_item_example"
       ],
       "type": "array",
       "locations": [
@@ -399,6 +547,64 @@
       ]
     },
     {
+      "semanticId": "lotus.collision_detected",
+      "canonicalTerm": "collision_detected",
+      "preferredName": "collision_detected",
+      "description": "True when same key is reused across multiple endpoints.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
+      "semanticId": "lotus.collisions",
+      "canonicalTerm": "collisions",
+      "preferredName": "collisions",
+      "description": "Number of keys reused across multiple endpoints.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.completed_at",
+      "canonicalTerm": "completed_at",
+      "preferredName": "completed_at",
+      "description": "Timestamp when the job reached a terminal or queued state.",
+      "example": "completed_at_example",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.consumer_group",
+      "canonicalTerm": "consumer_group",
+      "preferredName": "consumer_group",
+      "description": "Consumer group observed in dead-letter diagnostics.",
+      "example": "example_consumer_group",
+      "type": "string",
+      "locations": [
+        "body",
+        "query"
+      ],
+      "observedTypes": [
+        "object",
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.consumer_system",
       "canonicalTerm": "consumer_system",
       "preferredName": "consumer_system",
@@ -428,13 +634,26 @@
       ]
     },
     {
+      "semanticId": "lotus.correlation_id",
+      "canonicalTerm": "correlation_id",
+      "preferredName": "correlation_id",
+      "description": "Correlation identifier used for cross-service traceability.",
+      "example": "ING:1a2b3c4d-1234-5678-9abc-000000000001",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object",
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.cost_basis",
       "canonicalTerm": "cost_basis",
       "preferredName": "cost_basis",
       "description": "The total cost basis of the holding as of this record.",
-      "example": {
-        "id": "OBJ_001"
-      },
+      "example": "example_cost_basis",
       "type": "string",
       "locations": [
         "body"
@@ -449,7 +668,7 @@
       "canonicalTerm": "cost_basis_local",
       "preferredName": "cost_basis_local",
       "description": "The total cost basis in the instrument's local currency.",
-      "example": 95000.0,
+      "example": "cost_basis_local_example",
       "type": "object",
       "locations": [
         "body"
@@ -463,7 +682,7 @@
       "canonicalTerm": "cost_basis_method",
       "preferredName": "cost_basis_method",
       "description": "portfolio field: cost basis method.",
-      "example": "FIFO",
+      "example": "cost_basis_method_example",
       "type": "object",
       "locations": [
         "body"
@@ -477,7 +696,7 @@
       "canonicalTerm": "country_of_risk",
       "preferredName": "country_of_risk",
       "description": "Instrument country of risk (ISO 3166-1 alpha-2).",
-      "example": "US",
+      "example": "country_of_risk_example",
       "type": "object",
       "locations": [
         "body"
@@ -505,7 +724,7 @@
       "canonicalTerm": "created_by",
       "preferredName": "created_by",
       "description": "simulation session create request field: created by.",
-      "example": "lotus-manage",
+      "example": "created_by_example",
       "type": "object",
       "locations": [
         "body"
@@ -534,10 +753,26 @@
       "canonicalTerm": "current_epoch",
       "preferredName": "current_epoch",
       "description": "Current active epoch for the portfolio across position state keys.",
-      "example": 42,
+      "example": "current_epoch_example",
       "type": "object",
       "locations": [
         "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.cursor",
+      "canonicalTerm": "cursor",
+      "preferredName": "cursor",
+      "description": "Canonical cursor value used in request parameter.",
+      "example": {
+        "id": "OBJ_001"
+      },
+      "type": "object",
+      "locations": [
+        "query"
       ],
       "observedTypes": [
         "object"
@@ -562,13 +797,55 @@
       "canonicalTerm": "description",
       "preferredName": "description",
       "description": "Human-readable capability summary.",
-      "example": "Portfolio-level metric description.",
+      "example": "example_description",
       "type": "string",
       "locations": [
         "body"
       ],
       "observedTypes": [
         "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.dlq_events",
+      "canonicalTerm": "dlq_events",
+      "preferredName": "dlq_events",
+      "description": "Number of DLQ events for this consumer/topic in lookback window.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.dlq_topic",
+      "canonicalTerm": "dlq_topic",
+      "preferredName": "dlq_topic",
+      "description": "Dead-letter topic where failed message was published.",
+      "example": "example_dlq_topic",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.dry_run",
+      "canonicalTerm": "dry_run",
+      "preferredName": "dry_run",
+      "description": "When true, validates retry scope without publishing messages.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
       ]
     },
     {
@@ -628,11 +905,11 @@
       ]
     },
     {
-      "semanticId": "lotus.entity_type",
-      "canonicalTerm": "entity_type",
-      "preferredName": "entity_type",
-      "description": "upload preview response field: entity type.",
-      "example": "portfolios",
+      "semanticId": "lotus.endpoint",
+      "canonicalTerm": "endpoint",
+      "preferredName": "endpoint",
+      "description": "Ingestion API endpoint that created this job.",
+      "example": "example_endpoint",
       "type": "string",
       "locations": [
         "body"
@@ -642,11 +919,57 @@
       ]
     },
     {
+      "semanticId": "lotus.endpoint_count",
+      "canonicalTerm": "endpoint_count",
+      "preferredName": "endpoint_count",
+      "description": "Number of distinct ingestion endpoints using this key.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.endpoints",
+      "canonicalTerm": "endpoints",
+      "preferredName": "endpoints",
+      "description": "Distinct ingestion endpoints observed for this idempotency key.",
+      "example": [
+        "example_endpoints_item"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.entity_type",
+      "canonicalTerm": "entity_type",
+      "preferredName": "entity_type",
+      "description": "Canonical entity type accepted by the endpoint.",
+      "example": "example_entity_type",
+      "type": "string",
+      "locations": [
+        "body",
+        "query"
+      ],
+      "observedTypes": [
+        "object",
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.epoch",
       "canonicalTerm": "epoch",
       "preferredName": "epoch",
       "description": "Epoch for valuation jobs.",
-      "example": 42,
+      "example": "epoch_example",
       "type": "integer",
       "locations": [
         "body"
@@ -657,12 +980,57 @@
       ]
     },
     {
+      "semanticId": "lotus.error_reason",
+      "canonicalTerm": "error_reason",
+      "preferredName": "error_reason",
+      "description": "Error reason captured when consumer rejected the message.",
+      "example": "example_error_reason",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.errors",
       "canonicalTerm": "errors",
       "preferredName": "errors",
       "description": "Validation errors by row for correction before commit.",
       "example": [
-        "ERRORS_ITEM_VALUE"
+        "errors_item_example"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.event_id",
+      "canonicalTerm": "event_id",
+      "preferredName": "event_id",
+      "description": "Unique audit identifier for a consumer dead-letter event.",
+      "example": "EVENT_001",
+      "type": "string",
+      "locations": [
+        "body",
+        "path"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.events",
+      "canonicalTerm": "events",
+      "preferredName": "events",
+      "description": "Consumer dead-letter events for operational triage.",
+      "example": [
+        "events_item_example"
       ],
       "type": "array",
       "locations": [
@@ -687,17 +1055,136 @@
       ]
     },
     {
-      "semanticId": "lotus.failure_reason",
-      "canonicalTerm": "failure_reason",
-      "preferredName": "failure_reason",
-      "description": "Failure reason (when status=FAILED).",
-      "example": "missing_market_price",
-      "type": "object",
+      "semanticId": "lotus.failed_at",
+      "canonicalTerm": "failed_at",
+      "preferredName": "failed_at",
+      "description": "Timestamp when this failure event was captured.",
+      "example": "2026-02-27T10:30:00Z",
+      "type": "string",
       "locations": [
         "body"
       ],
       "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.failed_jobs",
+      "canonicalTerm": "failed_jobs",
+      "preferredName": "failed_jobs",
+      "description": "Total jobs currently marked as failed.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.failed_record_keys",
+      "canonicalTerm": "failed_record_keys",
+      "preferredName": "failed_record_keys",
+      "description": "Subset of record keys that failed during publish/retry processing.",
+      "example": [
+        "example_failed_record_keys_item"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.failure_id",
+      "canonicalTerm": "failure_id",
+      "preferredName": "failure_id",
+      "description": "Unique failure record identifier for this job failure event.",
+      "example": "FAILURE_001",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.failure_phase",
+      "canonicalTerm": "failure_phase",
+      "preferredName": "failure_phase",
+      "description": "Pipeline phase where the job failure occurred.",
+      "example": "example_failure_phase",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.failure_rate",
+      "canonicalTerm": "failure_rate",
+      "preferredName": "failure_rate",
+      "description": "Failed jobs divided by total jobs in the lookback window.",
+      "example": "example_failure_rate",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.failure_rate_threshold",
+      "canonicalTerm": "failure_rate_threshold",
+      "preferredName": "failure_rate_threshold",
+      "description": "Rate/price value for failure rate threshold.",
+      "example": {
+        "id": "OBJ_001"
+      },
+      "type": "object",
+      "locations": [
+        "query"
+      ],
+      "observedTypes": [
         "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.failure_reason",
+      "canonicalTerm": "failure_reason",
+      "preferredName": "failure_reason",
+      "description": "Failure reason (when status=FAILED).",
+      "example": "failure_reason_example",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object",
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.failures",
+      "canonicalTerm": "failures",
+      "preferredName": "failures",
+      "description": "Failure events captured for the requested ingestion job.",
+      "example": [
+        "failures_item_example"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
       ]
     },
     {
@@ -706,7 +1193,7 @@
       "preferredName": "features",
       "description": "integration capabilities response field: features.",
       "example": [
-        "FEATURES_ITEM_VALUE"
+        "features_item_example"
       ],
       "type": "array",
       "locations": [
@@ -731,6 +1218,36 @@
       ]
     },
     {
+      "semanticId": "lotus.first_seen_at",
+      "canonicalTerm": "first_seen_at",
+      "preferredName": "first_seen_at",
+      "description": "First observed timestamp for this idempotency key.",
+      "example": "2026-02-27T10:30:00Z",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.from",
+      "canonicalTerm": "from",
+      "preferredName": "from",
+      "description": "Canonical from value used in request parameter.",
+      "example": {
+        "id": "OBJ_001"
+      },
+      "type": "object",
+      "locations": [
+        "query"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
       "semanticId": "lotus.from_currency",
       "canonicalTerm": "from_currency",
       "preferredName": "from_currency",
@@ -751,7 +1268,7 @@
       "preferredName": "fx_rates",
       "description": "Rate/price value for fx rates.",
       "example": [
-        "FX_RATES_ITEM_VALUE"
+        "fx_rates_item_example"
       ],
       "type": "array",
       "locations": [
@@ -780,7 +1297,7 @@
       "canonicalTerm": "gross_transaction_amount",
       "preferredName": "gross_transaction_amount",
       "description": "Monetary value for gross transaction amount.",
-      "example": 125000.5,
+      "example": 18235.0,
       "type": "number",
       "locations": [
         "body"
@@ -788,6 +1305,22 @@
       "observedTypes": [
         "number",
         "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.groups",
+      "canonicalTerm": "groups",
+      "preferredName": "groups",
+      "description": "Consumer lag group diagnostics sorted by highest pressure first.",
+      "example": [
+        "groups_item_example"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
       ]
     },
     {
@@ -809,12 +1342,27 @@
       "canonicalTerm": "id",
       "preferredName": "id",
       "description": "Canonical identifier used by UI selectors.",
-      "example": "ITEM_001",
+      "example": "example_id",
       "type": "string",
       "locations": [
         "body"
       ],
       "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.idempotency_key",
+      "canonicalTerm": "idempotency_key",
+      "preferredName": "idempotency_key",
+      "description": "Client-supplied idempotency key if provided in X-Idempotency-Key header.",
+      "example": "idempotency_key_example",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object",
         "string"
       ]
     },
@@ -867,9 +1415,7 @@
       "canonicalTerm": "instrument_enrichment",
       "preferredName": "instrument_enrichment",
       "description": "Reference enrichment for securities included in snapshot sections.",
-      "example": {
-        "id": "OBJ_001"
-      },
+      "example": "instrument_enrichment_example",
       "type": "object",
       "locations": [
         "body"
@@ -897,7 +1443,7 @@
       "canonicalTerm": "instrument_name",
       "preferredName": "instrument_name",
       "description": "Instrument display name.",
-      "example": "Apple Inc.",
+      "example": "example_instrument_name",
       "type": "string",
       "locations": [
         "body"
@@ -926,7 +1472,7 @@
       "preferredName": "instruments",
       "description": "The list of instrument records for the current page.",
       "example": [
-        "INSTRUMENTS_ITEM_VALUE"
+        "instruments_item_example"
       ],
       "type": "array",
       "locations": [
@@ -1012,9 +1558,7 @@
       "canonicalTerm": "issuer_name",
       "preferredName": "issuer_name",
       "description": "Display name for direct issuer, when available.",
-      "example": {
-        "id": "OBJ_001"
-      },
+      "example": "Apple Inc.",
       "type": "object",
       "locations": [
         "body"
@@ -1029,7 +1573,7 @@
       "preferredName": "items",
       "description": "Operational jobs for support workflows.",
       "example": [
-        "ITEMS_ITEM_VALUE"
+        "items_item_example"
       ],
       "type": "array",
       "locations": [
@@ -1037,6 +1581,22 @@
       ],
       "observedTypes": [
         "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.job_id",
+      "canonicalTerm": "job_id",
+      "preferredName": "job_id",
+      "description": "Asynchronous ingestion job identifier for client-side tracking.",
+      "example": "JOB_001",
+      "type": "string",
+      "locations": [
+        "body",
+        "path"
+      ],
+      "observedTypes": [
+        "object",
+        "string"
       ]
     },
     {
@@ -1054,11 +1614,27 @@
       ]
     },
     {
+      "semanticId": "lotus.jobs",
+      "canonicalTerm": "jobs",
+      "preferredName": "jobs",
+      "description": "Ingestion jobs matching the requested filters.",
+      "example": [
+        "jobs_item_example"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
       "semanticId": "lotus.key",
       "canonicalTerm": "key",
       "preferredName": "key",
       "description": "Canonical feature key.",
-      "example": "portfolio_state",
+      "example": "example_key",
       "type": "string",
       "locations": [
         "body"
@@ -1068,11 +1644,83 @@
       ]
     },
     {
+      "semanticId": "lotus.keys",
+      "canonicalTerm": "keys",
+      "preferredName": "keys",
+      "description": "Key-level diagnostics sorted by highest usage count.",
+      "example": [
+        "keys_item_example"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
       "semanticId": "lotus.label",
       "canonicalTerm": "label",
       "preferredName": "label",
       "description": "Display label for UI selector option.",
-      "example": "Global Equity Portfolio",
+      "example": "example_label",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.lag_severity",
+      "canonicalTerm": "lag_severity",
+      "preferredName": "lag_severity",
+      "description": "Derived lag severity from DLQ pressure.",
+      "example": "low",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.last_observed_at",
+      "canonicalTerm": "last_observed_at",
+      "preferredName": "last_observed_at",
+      "description": "Most recent DLQ observation timestamp for this group/topic.",
+      "example": "last_observed_at_example",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.last_retried_at",
+      "canonicalTerm": "last_retried_at",
+      "preferredName": "last_retried_at",
+      "description": "Timestamp of the most recent retry attempt.",
+      "example": "last_retried_at_example",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.last_seen_at",
+      "canonicalTerm": "last_seen_at",
+      "preferredName": "last_seen_at",
+      "description": "Most recent observed timestamp for this idempotency key.",
+      "example": "2026-02-27T10:30:00Z",
       "type": "string",
       "locations": [
         "body"
@@ -1195,11 +1843,26 @@
       ]
     },
     {
+      "semanticId": "lotus.lookback_minutes",
+      "canonicalTerm": "lookback_minutes",
+      "preferredName": "lookback_minutes",
+      "description": "Canonical lookback minutes value used in request parameter.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body",
+        "query"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
       "semanticId": "lotus.lot_cost_base",
       "canonicalTerm": "lot_cost_base",
       "preferredName": "lot_cost_base",
       "description": "Lot cost in base currency.",
-      "example": "STANDARD",
+      "example": "example_lot_cost_base",
       "type": "string",
       "locations": [
         "body"
@@ -1213,7 +1876,7 @@
       "canonicalTerm": "lot_cost_local",
       "preferredName": "lot_cost_local",
       "description": "Lot cost in trade/local currency.",
-      "example": "STANDARD",
+      "example": "example_lot_cost_local",
       "type": "string",
       "locations": [
         "body"
@@ -1242,7 +1905,7 @@
       "preferredName": "lots",
       "description": "Current lot records for the portfolio-security key.",
       "example": [
-        "LOTS_ITEM_VALUE"
+        "lots_item_example"
       ],
       "type": "array",
       "locations": [
@@ -1258,7 +1921,7 @@
       "preferredName": "market_prices",
       "description": "Rate/price value for market prices.",
       "example": [
-        "MARKET_PRICES_ITEM_VALUE"
+        "market_prices_item_example"
       ],
       "type": "array",
       "locations": [
@@ -1300,8 +1963,8 @@
       "semanticId": "lotus.message",
       "canonicalTerm": "message",
       "preferredName": "message",
-      "description": "Validation error message for the row.",
-      "example": "Operation completed successfully.",
+      "description": "Human-readable acceptance message for the ingestion request.",
+      "example": "example_message",
       "type": "string",
       "locations": [
         "body"
@@ -1315,9 +1978,7 @@
       "canonicalTerm": "metadata",
       "preferredName": "metadata",
       "description": "simulation change input field: metadata.",
-      "example": {
-        "source": "lotus-core"
-      },
+      "example": "metadata_example",
       "type": "object",
       "locations": [
         "body"
@@ -1345,7 +2006,7 @@
       "canonicalTerm": "name",
       "preferredName": "name",
       "description": "instrument record field: name.",
-      "example": "Global Balanced Portfolio",
+      "example": "example_name",
       "type": "string",
       "locations": [
         "body"
@@ -1359,7 +2020,7 @@
       "canonicalTerm": "net_cost",
       "preferredName": "net_cost",
       "description": "transaction record field: net cost.",
-      "example": 98000.0,
+      "example": 18242.5,
       "type": "object",
       "locations": [
         "body"
@@ -1373,7 +2034,7 @@
       "canonicalTerm": "net_cost_local",
       "preferredName": "net_cost_local",
       "description": "transaction record field: net cost local.",
-      "example": 98000.0,
+      "example": "net_cost_local_example",
       "type": "object",
       "locations": [
         "body"
@@ -1397,17 +2058,45 @@
       ]
     },
     {
-      "semanticId": "lotus.objective",
-      "canonicalTerm": "objective",
-      "preferredName": "objective",
-      "description": "Primary client objective for this portfolio.",
-      "example": "CAPITAL_APPRECIATION",
+      "semanticId": "lotus.next_cursor",
+      "canonicalTerm": "next_cursor",
+      "preferredName": "next_cursor",
+      "description": "Opaque cursor to fetch the next page of jobs, based on descending ingestion job order.",
+      "example": "next_cursor_example",
       "type": "object",
       "locations": [
         "body"
       ],
       "observedTypes": [
         "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.objective",
+      "canonicalTerm": "objective",
+      "preferredName": "objective",
+      "description": "Primary client objective for this portfolio.",
+      "example": "objective_example",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.observed_at",
+      "canonicalTerm": "observed_at",
+      "preferredName": "observed_at",
+      "description": "Timestamp when the DLQ event was observed.",
+      "example": "2026-02-27T10:30:00Z",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -1430,7 +2119,7 @@
       "preferredName": "offsets",
       "description": "Accrued-income offset records for the portfolio-security key.",
       "example": [
-        "OFFSETS_ITEM_VALUE"
+        "offsets_item_example"
       ],
       "type": "array",
       "locations": [
@@ -1438,6 +2127,34 @@
       ],
       "observedTypes": [
         "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.oldest_backlog_age_seconds",
+      "canonicalTerm": "oldest_backlog_age_seconds",
+      "preferredName": "oldest_backlog_age_seconds",
+      "description": "Age in seconds of oldest non-terminal job in this group.",
+      "example": 10.5,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.oldest_backlog_submitted_at",
+      "canonicalTerm": "oldest_backlog_submitted_at",
+      "preferredName": "oldest_backlog_submitted_at",
+      "description": "Submitted timestamp of oldest non-terminal job in this group.",
+      "example": "oldest_backlog_submitted_at_example",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
       ]
     },
     {
@@ -1473,13 +2190,27 @@
       "canonicalTerm": "options",
       "preferredName": "options",
       "description": "Section behavior options.",
-      "example": "STANDARD",
+      "example": "options_example",
       "type": "string",
       "locations": [
         "body"
       ],
       "observedTypes": [
         "CoreSnapshotRequestOptions"
+      ]
+    },
+    {
+      "semanticId": "lotus.original_key",
+      "canonicalTerm": "original_key",
+      "preferredName": "original_key",
+      "description": "Original message key, if available.",
+      "example": "original_key_example",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
       ]
     },
     {
@@ -1497,17 +2228,61 @@
       ]
     },
     {
+      "semanticId": "lotus.original_topic",
+      "canonicalTerm": "original_topic",
+      "preferredName": "original_topic",
+      "description": "Original topic associated with the lag signal.",
+      "example": "example_original_topic",
+      "type": "string",
+      "locations": [
+        "body",
+        "query"
+      ],
+      "observedTypes": [
+        "object",
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.owner_service",
       "canonicalTerm": "owner_service",
       "preferredName": "owner_service",
       "description": "Owning service for the feature capability.",
-      "example": "lotus-core",
+      "example": "example_owner_service",
       "type": "string",
       "locations": [
         "body"
       ],
       "observedTypes": [
         "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.p95_queue_latency_seconds",
+      "canonicalTerm": "p95_queue_latency_seconds",
+      "preferredName": "p95_queue_latency_seconds",
+      "description": "95th percentile latency from job submission to queue completion.",
+      "example": 10.5,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.payload_excerpt",
+      "canonicalTerm": "payload_excerpt",
+      "preferredName": "payload_excerpt",
+      "description": "Truncated payload excerpt for operational triage.",
+      "example": "payload_excerpt_example",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
       ]
     },
     {
@@ -1543,7 +2318,7 @@
       "canonicalTerm": "policy_provenance",
       "preferredName": "policy_provenance",
       "description": "effective integration policy response field: policy provenance.",
-      "example": "STANDARD",
+      "example": "policy_provenance_example",
       "type": "string",
       "locations": [
         "body"
@@ -1557,7 +2332,7 @@
       "canonicalTerm": "policy_source",
       "preferredName": "policy_source",
       "description": "policy provenance metadata field: policy source.",
-      "example": "tenant-default-policy",
+      "example": "example_policy_source",
       "type": "string",
       "locations": [
         "body"
@@ -1616,9 +2391,7 @@
       "canonicalTerm": "portfolio_totals",
       "preferredName": "portfolio_totals",
       "description": "Portfolio-level baseline/projected totals and delta.",
-      "example": {
-        "id": "OBJ_001"
-      },
+      "example": "portfolio_totals_example",
       "type": "object",
       "locations": [
         "body"
@@ -1632,7 +2405,7 @@
       "canonicalTerm": "portfolio_type",
       "preferredName": "portfolio_type",
       "description": "Portfolio product/type classification.",
-      "example": "DISCRETIONARY",
+      "example": "example_portfolio_type",
       "type": "string",
       "locations": [
         "body"
@@ -1647,7 +2420,7 @@
       "preferredName": "portfolios",
       "description": "List of portfolios matching query filters.",
       "example": [
-        "PORTFOLIOS_ITEM_VALUE"
+        "portfolios_item_example"
       ],
       "type": "array",
       "locations": [
@@ -1662,7 +2435,7 @@
       "canonicalTerm": "position_basis",
       "preferredName": "position_basis",
       "description": "Basis used for position valuation fields.",
-      "example": "STANDARD",
+      "example": "position_basis_example",
       "type": "string",
       "locations": [
         "body"
@@ -1691,7 +2464,7 @@
       "preferredName": "positions",
       "description": "A time-series list of position records.",
       "example": [
-        "POSITIONS_ITEM_VALUE"
+        "positions_item_example"
       ],
       "type": "array",
       "locations": [
@@ -1706,12 +2479,7 @@
       "canonicalTerm": "positions_baseline",
       "preferredName": "positions_baseline",
       "description": "Baseline positions resolved for as_of_date.",
-      "example": [
-        {
-          "security_id": "SEC_AAPL_US",
-          "quantity": "100.0000000000"
-        }
-      ],
+      "example": "positions_baseline_example",
       "type": "object",
       "locations": [
         "body"
@@ -1725,12 +2493,7 @@
       "canonicalTerm": "positions_delta",
       "preferredName": "positions_delta",
       "description": "Per-security baseline versus projected deltas.",
-      "example": [
-        {
-          "security_id": "SEC_AAPL_US",
-          "delta_quantity": "20.0000000000"
-        }
-      ],
+      "example": "positions_delta_example",
       "type": "object",
       "locations": [
         "body"
@@ -1744,12 +2507,7 @@
       "canonicalTerm": "positions_projected",
       "preferredName": "positions_projected",
       "description": "Projected positions after applying simulation changes.",
-      "example": [
-        {
-          "security_id": "SEC_AAPL_US",
-          "quantity": "120.0000000000"
-        }
-      ],
+      "example": "positions_projected_example",
       "type": "object",
       "locations": [
         "body"
@@ -1759,11 +2517,39 @@
       ]
     },
     {
+      "semanticId": "lotus.previous_backlog_jobs",
+      "canonicalTerm": "previous_backlog_jobs",
+      "preferredName": "previous_backlog_jobs",
+      "description": "Backlog jobs in previous lookback window.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.previous_lookback_minutes",
+      "canonicalTerm": "previous_lookback_minutes",
+      "preferredName": "previous_lookback_minutes",
+      "description": "Previous lookback window in minutes used for trend comparison.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
       "semanticId": "lotus.price",
       "canonicalTerm": "price",
       "preferredName": "price",
       "description": "Rate/price value for price.",
-      "example": 1.2345,
+      "example": 182.35,
       "type": "string",
       "locations": [
         "body"
@@ -1794,7 +2580,7 @@
       "preferredName": "prices",
       "description": "A list of market price records.",
       "example": [
-        "PRICES_ITEM_VALUE"
+        "prices_item_example"
       ],
       "type": "array",
       "locations": [
@@ -1882,11 +2668,53 @@
       ]
     },
     {
+      "semanticId": "lotus.queue_age_seconds",
+      "canonicalTerm": "queue_age_seconds",
+      "preferredName": "queue_age_seconds",
+      "description": "Current age in seconds since submission.",
+      "example": 10.5,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.queue_latency_threshold_seconds",
+      "canonicalTerm": "queue_latency_threshold_seconds",
+      "preferredName": "queue_latency_threshold_seconds",
+      "description": "Canonical queue latency threshold seconds value used in request parameter.",
+      "example": 10.5,
+      "type": "number",
+      "locations": [
+        "query"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.queued_jobs",
+      "canonicalTerm": "queued_jobs",
+      "preferredName": "queued_jobs",
+      "description": "Total jobs currently queued for asynchronous processing.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
       "semanticId": "lotus.rate",
       "canonicalTerm": "rate",
       "preferredName": "rate",
       "description": "Rate/price value for rate.",
-      "example": 1.2345,
+      "example": 1.3524,
       "type": "string",
       "locations": [
         "body"
@@ -1916,7 +2744,7 @@
       "preferredName": "rates",
       "description": "A list of FX rate records.",
       "example": [
-        "RATES_ITEM_VALUE"
+        "rates_item_example"
       ],
       "type": "array",
       "locations": [
@@ -1931,7 +2759,7 @@
       "canonicalTerm": "rating",
       "preferredName": "rating",
       "description": "Credit rating for fixed income instruments (e.g., 'AAA').",
-      "example": "A",
+      "example": "rating_example",
       "type": "object",
       "locations": [
         "body"
@@ -1945,7 +2773,7 @@
       "canonicalTerm": "realized_gain_loss",
       "preferredName": "realized_gain_loss",
       "description": "transaction record field: realized gain loss.",
-      "example": 525.75,
+      "example": "realized_gain_loss_example",
       "type": "object",
       "locations": [
         "body"
@@ -1959,7 +2787,7 @@
       "canonicalTerm": "realized_gain_loss_local",
       "preferredName": "realized_gain_loss_local",
       "description": "transaction record field: realized gain loss local.",
-      "example": 525.75,
+      "example": "realized_gain_loss_local_example",
       "type": "object",
       "locations": [
         "body"
@@ -1969,12 +2797,12 @@
       ]
     },
     {
-      "semanticId": "lotus.records",
-      "canonicalTerm": "records",
-      "preferredName": "records",
-      "description": "Deterministic enrichment records in the same order as request security_ids.",
+      "semanticId": "lotus.record_keys",
+      "canonicalTerm": "record_keys",
+      "preferredName": "record_keys",
+      "description": "Optional subset of record keys to replay. Empty list replays full stored payload.",
       "example": [
-        "RECORDS_ITEM_VALUE"
+        "example_record_keys_item"
       ],
       "type": "array",
       "locations": [
@@ -1985,17 +2813,105 @@
       ]
     },
     {
-      "semanticId": "lotus.remaining_offset_local",
-      "canonicalTerm": "remaining_offset_local",
-      "preferredName": "remaining_offset_local",
-      "description": "Remaining accrued-income offset available for net-income calculations.",
-      "example": "STANDARD",
+      "semanticId": "lotus.records",
+      "canonicalTerm": "records",
+      "preferredName": "records",
+      "description": "Deterministic enrichment records in the same order as request security_ids.",
+      "example": [
+        "records_item_example"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.remaining_error_budget",
+      "canonicalTerm": "remaining_error_budget",
+      "preferredName": "remaining_error_budget",
+      "description": "Remaining budget to threshold (max(0, threshold - failure_rate)).",
+      "example": "example_remaining_error_budget",
       "type": "string",
       "locations": [
         "body"
       ],
       "observedTypes": [
         "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.remaining_offset_local",
+      "canonicalTerm": "remaining_offset_local",
+      "preferredName": "remaining_offset_local",
+      "description": "Remaining accrued-income offset available for net-income calculations.",
+      "example": "example_remaining_offset_local",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.replay_status",
+      "canonicalTerm": "replay_status",
+      "preferredName": "replay_status",
+      "description": "Replay execution result.",
+      "example": "dry_run",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.replay_window_end",
+      "canonicalTerm": "replay_window_end",
+      "preferredName": "replay_window_end",
+      "description": "End timestamp for allowed retry replay operations.",
+      "example": "replay_window_end_example",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.replay_window_start",
+      "canonicalTerm": "replay_window_start",
+      "preferredName": "replay_window_start",
+      "description": "Start timestamp for allowed retry replay operations.",
+      "example": "replay_window_start_example",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.replayable_record_keys",
+      "canonicalTerm": "replayable_record_keys",
+      "preferredName": "replayable_record_keys",
+      "description": "Record keys available for deterministic partial replay operations.",
+      "example": [
+        "example_replayable_record_keys_item"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
       ]
     },
     {
@@ -2030,12 +2946,26 @@
       ]
     },
     {
+      "semanticId": "lotus.request_id",
+      "canonicalTerm": "request_id",
+      "preferredName": "request_id",
+      "description": "Request identifier for ingress request tracking.",
+      "example": "REQ:1a2b3c4d-1234-5678-9abc-000000000001",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.required_features",
       "canonicalTerm": "required_features",
       "preferredName": "required_features",
       "description": "Feature keys required for workflow execution.",
       "example": [
-        "REQUIRED_FEATURES_ITEM_VALUE"
+        "example_required_features_item"
       ],
       "type": "array",
       "locations": [
@@ -2046,11 +2976,25 @@
       ]
     },
     {
+      "semanticId": "lotus.retry_count",
+      "canonicalTerm": "retry_count",
+      "preferredName": "retry_count",
+      "description": "Number of retry attempts executed for this ingestion job.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
       "semanticId": "lotus.risk_exposure",
       "canonicalTerm": "risk_exposure",
       "preferredName": "risk_exposure",
       "description": "Client risk exposure classification.",
-      "example": "MODERATE",
+      "example": "example_risk_exposure",
       "type": "string",
       "locations": [
         "body"
@@ -2097,7 +3041,7 @@
       "preferredName": "sections",
       "description": "Requested snapshot sections to include in the response payload.",
       "example": [
-        "SECTIONS_ITEM_VALUE"
+        "sections_item_example"
       ],
       "type": "array",
       "locations": [
@@ -2113,7 +3057,7 @@
       "canonicalTerm": "sector",
       "preferredName": "sector",
       "description": "Instrument sector classification.",
-      "example": "TECHNOLOGY",
+      "example": "sector_example",
       "type": "object",
       "locations": [
         "body"
@@ -2145,7 +3089,7 @@
       "preferredName": "security_ids",
       "description": "Canonical Lotus security identifiers to enrich.",
       "example": [
-        "SECURITY_IDS_ITEM_VALUE"
+        "example_security_ids_item"
       ],
       "type": "array",
       "locations": [
@@ -2160,7 +3104,7 @@
       "canonicalTerm": "session",
       "preferredName": "session",
       "description": "simulation session response field: session.",
-      "example": "STANDARD",
+      "example": "session_example",
       "type": "string",
       "locations": [
         "body"
@@ -2203,9 +3147,7 @@
       "canonicalTerm": "simulation",
       "preferredName": "simulation",
       "description": "Simulation options required for SIMULATION mode.",
-      "example": {
-        "id": "OBJ_001"
-      },
+      "example": "simulation_example",
       "type": "object",
       "locations": [
         "body"
@@ -2248,7 +3190,7 @@
       "canonicalTerm": "snapshot_mode",
       "preferredName": "snapshot_mode",
       "description": "Snapshot mode: BASELINE for current state or SIMULATION for projected state.",
-      "example": "STANDARD",
+      "example": "snapshot_mode_example",
       "type": "string",
       "locations": [
         "body"
@@ -2322,9 +3264,7 @@
       "canonicalTerm": "source_system",
       "preferredName": "source_system",
       "description": "Source system from which this transaction originated.",
-      "example": {
-        "id": "OBJ_001"
-      },
+      "example": "OMS_PRIMARY",
       "type": "object",
       "locations": [
         "body"
@@ -2369,9 +3309,11 @@
       "example": "ACTIVE",
       "type": "string",
       "locations": [
-        "body"
+        "body",
+        "query"
       ],
       "observedTypes": [
+        "object",
         "string"
       ]
     },
@@ -2404,12 +3346,40 @@
       ]
     },
     {
+      "semanticId": "lotus.submitted_at",
+      "canonicalTerm": "submitted_at",
+      "preferredName": "submitted_at",
+      "description": "Timestamp when the ingestion job was accepted.",
+      "example": "2026-02-27T10:30:00Z",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.suggested_action",
+      "canonicalTerm": "suggested_action",
+      "preferredName": "suggested_action",
+      "description": "Runbook-oriented suggested action for operations.",
+      "example": "example_suggested_action",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.supported_input_modes",
       "canonicalTerm": "supported_input_modes",
       "preferredName": "supported_input_modes",
       "description": "integration capabilities response field: supported input modes.",
       "example": [
-        "SUPPORTED_INPUT_MODES_ITEM_VALUE"
+        "example_supported_input_modes_item"
       ],
       "type": "array",
       "locations": [
@@ -2432,6 +3402,37 @@
       ],
       "observedTypes": [
         "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.threshold_seconds",
+      "canonicalTerm": "threshold_seconds",
+      "preferredName": "threshold_seconds",
+      "description": "Canonical threshold seconds value used in request parameter.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body",
+        "query"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.to",
+      "canonicalTerm": "to",
+      "preferredName": "to",
+      "description": "Canonical to value used in request parameter.",
+      "example": {
+        "id": "OBJ_001"
+      },
+      "type": "object",
+      "locations": [
+        "query"
+      ],
+      "observedTypes": [
+        "object"
       ]
     },
     {
@@ -2464,10 +3465,66 @@
       ]
     },
     {
+      "semanticId": "lotus.total_backlog_jobs",
+      "canonicalTerm": "total_backlog_jobs",
+      "preferredName": "total_backlog_jobs",
+      "description": "Total backlog jobs across all returned groups.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
       "semanticId": "lotus.total_baseline_positions",
       "canonicalTerm": "total_baseline_positions",
       "preferredName": "total_baseline_positions",
       "description": "projected summary response field: total baseline positions.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.total_groups",
+      "canonicalTerm": "total_groups",
+      "preferredName": "total_groups",
+      "description": "Number of consumer/topic lag groups returned.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.total_jobs",
+      "canonicalTerm": "total_jobs",
+      "preferredName": "total_jobs",
+      "description": "Total ingestion jobs stored in operational state.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.total_keys",
+      "canonicalTerm": "total_keys",
+      "preferredName": "total_keys",
+      "description": "Number of distinct idempotency keys returned.",
       "example": 10,
       "type": "integer",
       "locations": [
@@ -2503,6 +3560,20 @@
       ],
       "observedTypes": [
         "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.trace_id",
+      "canonicalTerm": "trace_id",
+      "preferredName": "trace_id",
+      "description": "Distributed trace identifier for observability stitching.",
+      "example": "5f475bcbfb2c4fb68b1b6a2ed2d1c216",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -2552,7 +3623,7 @@
       "canonicalTerm": "transaction_fx_rate",
       "preferredName": "transaction_fx_rate",
       "description": "Rate/price value for transaction fx rate.",
-      "example": 1.1032,
+      "example": "transaction_fx_rate_example",
       "type": "object",
       "locations": [
         "body"
@@ -2582,7 +3653,7 @@
       "preferredName": "transaction_ids",
       "description": "A non-empty list of transaction_id strings to be reprocessed.",
       "example": [
-        "TRANSACTION_IDS_ITEM_VALUE"
+        "example_transaction_ids_item"
       ],
       "type": "array",
       "locations": [
@@ -2612,7 +3683,7 @@
       "preferredName": "transactions",
       "description": "The list of transaction records for the current page.",
       "example": [
-        "TRANSACTIONS_ITEM_VALUE"
+        "transactions_item_example"
       ],
       "type": "array",
       "locations": [
@@ -2655,15 +3726,55 @@
       "canonicalTerm": "ultimate_parent_issuer_name",
       "preferredName": "ultimate_parent_issuer_name",
       "description": "Display name for ultimate parent issuer, when available.",
-      "example": {
-        "id": "OBJ_001"
-      },
+      "example": "ultimate_parent_issuer_name_example",
       "type": "object",
       "locations": [
         "body"
       ],
       "observedTypes": [
         "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.updated_at",
+      "canonicalTerm": "updated_at",
+      "preferredName": "updated_at",
+      "description": "Timestamp of last ops mode update.",
+      "example": "2026-02-27T10:30:00Z",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.updated_by",
+      "canonicalTerm": "updated_by",
+      "preferredName": "updated_by",
+      "description": "Principal or automation actor who last changed ops mode.",
+      "example": "2026-02-27",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.usage_count",
+      "canonicalTerm": "usage_count",
+      "preferredName": "usage_count",
+      "description": "Number of ingestion jobs observed with this idempotency key.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
       ]
     },
     {
@@ -2685,7 +3796,7 @@
       "canonicalTerm": "valuation",
       "preferredName": "valuation",
       "description": "Valuation details for this record.",
-      "example": 125000.5,
+      "example": "valuation_example",
       "type": "object",
       "locations": [
         "body"
@@ -2699,13 +3810,8 @@
       "canonicalTerm": "valuation_context",
       "preferredName": "valuation_context",
       "description": "Valuation and weight basis context applied to all sections.",
-      "example": {
-        "portfolio_currency": "EUR",
-        "reporting_currency": "USD",
-        "position_basis": "market_value_base",
-        "weight_basis": "total_market_value_base"
-      },
-      "type": "object",
+      "example": "valuation_context_example",
+      "type": "string",
       "locations": [
         "body"
       ],
@@ -2733,7 +3839,7 @@
       "preferredName": "warnings",
       "description": "effective integration policy response field: warnings.",
       "example": [
-        "WARNINGS_ITEM_VALUE"
+        "example_warnings_item"
       ],
       "type": "array",
       "locations": [
@@ -2762,9 +3868,7 @@
       "canonicalTerm": "weight",
       "preferredName": "weight",
       "description": "Position weight versus total portfolio market value (0.0 to 1.0).",
-      "example": {
-        "id": "OBJ_001"
-      },
+      "example": "weight_example",
       "type": "object",
       "locations": [
         "body"
@@ -2778,7 +3882,7 @@
       "canonicalTerm": "weight_basis",
       "preferredName": "weight_basis",
       "description": "Basis used to calculate weight fields.",
-      "example": "STANDARD",
+      "example": "weight_basis_example",
       "type": "string",
       "locations": [
         "body"
@@ -2807,7 +3911,7 @@
       "preferredName": "workflows",
       "description": "integration capabilities response field: workflows.",
       "example": [
-        "WORKFLOWS_ITEM_VALUE"
+        "workflows_item_example"
       ],
       "type": "array",
       "locations": [
@@ -2815,6 +3919,38 @@
       ],
       "observedTypes": [
         "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.x_idempotency_key",
+      "canonicalTerm": "x_idempotency_key",
+      "preferredName": "x_idempotency_key",
+      "description": "Optional idempotency key to make retries safe for the same logical request.",
+      "example": {
+        "id": "OBJ_001"
+      },
+      "type": "object",
+      "locations": [
+        "header"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.x_lotus_ops_token",
+      "canonicalTerm": "x_lotus_ops_token",
+      "preferredName": "x_lotus_ops_token",
+      "description": "Operations token for privileged ingestion runbook APIs (health controls, retry, DLQ triage, idempotency diagnostics).",
+      "example": {
+        "id": "OBJ_001"
+      },
+      "type": "object",
+      "locations": [
+        "header"
+      ],
+      "observedTypes": [
+        "object"
       ]
     }
   ],
@@ -3934,6 +5070,846 @@
       "exposure": "consumer_visible",
       "canonicalTerm": "session_id",
       "semanticId": "lotus.session_id"
+    },
+    {
+      "name": "X-Idempotency-Key",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Optional idempotency key to make retries safe for the same logical request.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects ingest_portfolios_ingest_portfolios_post request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_idempotency_key",
+      "semanticId": "lotus.x_idempotency_key"
+    },
+    {
+      "name": "X-Idempotency-Key",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Optional idempotency key to make retries safe for the same logical request.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects ingest_transaction_ingest_transaction_post request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_idempotency_key",
+      "semanticId": "lotus.x_idempotency_key"
+    },
+    {
+      "name": "X-Idempotency-Key",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Optional idempotency key to make retries safe for the same logical request.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects ingest_transactions_ingest_transactions_post request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_idempotency_key",
+      "semanticId": "lotus.x_idempotency_key"
+    },
+    {
+      "name": "X-Idempotency-Key",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Optional idempotency key to make retries safe for the same logical request.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects ingest_instruments_ingest_instruments_post request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_idempotency_key",
+      "semanticId": "lotus.x_idempotency_key"
+    },
+    {
+      "name": "X-Idempotency-Key",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Optional idempotency key to make retries safe for the same logical request.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects ingest_market_prices_ingest_market_prices_post request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_idempotency_key",
+      "semanticId": "lotus.x_idempotency_key"
+    },
+    {
+      "name": "X-Idempotency-Key",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Optional idempotency key to make retries safe for the same logical request.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects ingest_fx_rates_ingest_fx_rates_post request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_idempotency_key",
+      "semanticId": "lotus.x_idempotency_key"
+    },
+    {
+      "name": "X-Idempotency-Key",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Optional idempotency key to make retries safe for the same logical request.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects ingest_business_dates_ingest_business_dates_post request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_idempotency_key",
+      "semanticId": "lotus.x_idempotency_key"
+    },
+    {
+      "name": "X-Idempotency-Key",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Optional idempotency key to make retries safe for the same logical request.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects reprocess_transactions_reprocess_transactions_post request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_idempotency_key",
+      "semanticId": "lotus.x_idempotency_key"
+    },
+    {
+      "name": "X-Idempotency-Key",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Optional idempotency key to make retries safe for the same logical request.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects ingest_portfolio_bundle_ingest_portfolio_bundle_post request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_idempotency_key",
+      "semanticId": "lotus.x_idempotency_key"
+    },
+    {
+      "name": "job_id",
+      "kind": "request_option",
+      "location": "path",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "Unique job identifier.",
+      "example": "JOB_001",
+      "behaviorImpact": "Affects get_ingestion_job_ingestion_jobs__job_id__get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "job_id",
+      "semanticId": "lotus.job_id"
+    },
+    {
+      "name": "X-Lotus-Ops-Token",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Operations token for privileged ingestion runbook APIs (health controls, retry, DLQ triage, idempotency diagnostics).",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects get_ingestion_job_ingestion_jobs__job_id__get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_lotus_ops_token",
+      "semanticId": "lotus.x_lotus_ops_token"
+    },
+    {
+      "name": "status",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Status for status.",
+      "example": "ACTIVE",
+      "behaviorImpact": "Affects list_ingestion_jobs_ingestion_jobs_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "status",
+      "semanticId": "lotus.status"
+    },
+    {
+      "name": "entity_type",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Canonical entity type value used in request parameter.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects list_ingestion_jobs_ingestion_jobs_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "entity_type",
+      "semanticId": "lotus.entity_type"
+    },
+    {
+      "name": "from",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Canonical from value used in request parameter.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects list_ingestion_jobs_ingestion_jobs_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "from",
+      "semanticId": "lotus.from"
+    },
+    {
+      "name": "to",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Canonical to value used in request parameter.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects list_ingestion_jobs_ingestion_jobs_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "to",
+      "semanticId": "lotus.to"
+    },
+    {
+      "name": "cursor",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Canonical cursor value used in request parameter.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects list_ingestion_jobs_ingestion_jobs_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "cursor",
+      "semanticId": "lotus.cursor"
+    },
+    {
+      "name": "limit",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 100,
+      "allowedValues": [],
+      "description": "Canonical limit value used in request parameter.",
+      "example": 10,
+      "behaviorImpact": "Affects list_ingestion_jobs_ingestion_jobs_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "limit",
+      "semanticId": "lotus.limit"
+    },
+    {
+      "name": "X-Lotus-Ops-Token",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Operations token for privileged ingestion runbook APIs (health controls, retry, DLQ triage, idempotency diagnostics).",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects list_ingestion_jobs_ingestion_jobs_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_lotus_ops_token",
+      "semanticId": "lotus.x_lotus_ops_token"
+    },
+    {
+      "name": "job_id",
+      "kind": "request_option",
+      "location": "path",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "Unique job identifier.",
+      "example": "JOB_001",
+      "behaviorImpact": "Affects list_ingestion_job_failures_ingestion_jobs__job_id__failures_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "job_id",
+      "semanticId": "lotus.job_id"
+    },
+    {
+      "name": "limit",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 100,
+      "allowedValues": [],
+      "description": "Canonical limit value used in request parameter.",
+      "example": 10,
+      "behaviorImpact": "Affects list_ingestion_job_failures_ingestion_jobs__job_id__failures_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "limit",
+      "semanticId": "lotus.limit"
+    },
+    {
+      "name": "X-Lotus-Ops-Token",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Operations token for privileged ingestion runbook APIs (health controls, retry, DLQ triage, idempotency diagnostics).",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects list_ingestion_job_failures_ingestion_jobs__job_id__failures_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_lotus_ops_token",
+      "semanticId": "lotus.x_lotus_ops_token"
+    },
+    {
+      "name": "job_id",
+      "kind": "request_option",
+      "location": "path",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "Unique job identifier.",
+      "example": "JOB_001",
+      "behaviorImpact": "Affects get_ingestion_job_records_ingestion_jobs__job_id__records_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "job_id",
+      "semanticId": "lotus.job_id"
+    },
+    {
+      "name": "X-Lotus-Ops-Token",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Operations token for privileged ingestion runbook APIs (health controls, retry, DLQ triage, idempotency diagnostics).",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects get_ingestion_job_records_ingestion_jobs__job_id__records_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_lotus_ops_token",
+      "semanticId": "lotus.x_lotus_ops_token"
+    },
+    {
+      "name": "job_id",
+      "kind": "request_option",
+      "location": "path",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "Unique job identifier.",
+      "example": "JOB_001",
+      "behaviorImpact": "Affects retry_ingestion_job_ingestion_jobs__job_id__retry_post request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "job_id",
+      "semanticId": "lotus.job_id"
+    },
+    {
+      "name": "X-Lotus-Ops-Token",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Operations token for privileged ingestion runbook APIs (health controls, retry, DLQ triage, idempotency diagnostics).",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects retry_ingestion_job_ingestion_jobs__job_id__retry_post request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_lotus_ops_token",
+      "semanticId": "lotus.x_lotus_ops_token"
+    },
+    {
+      "name": "X-Lotus-Ops-Token",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Operations token for privileged ingestion runbook APIs (health controls, retry, DLQ triage, idempotency diagnostics).",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects get_ingestion_health_summary_ingestion_health_summary_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_lotus_ops_token",
+      "semanticId": "lotus.x_lotus_ops_token"
+    },
+    {
+      "name": "X-Lotus-Ops-Token",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Operations token for privileged ingestion runbook APIs (health controls, retry, DLQ triage, idempotency diagnostics).",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects get_ingestion_health_lag_ingestion_health_lag_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_lotus_ops_token",
+      "semanticId": "lotus.x_lotus_ops_token"
+    },
+    {
+      "name": "lookback_minutes",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 60,
+      "allowedValues": [],
+      "description": "Canonical lookback minutes value used in request parameter.",
+      "example": 10,
+      "behaviorImpact": "Affects get_ingestion_consumer_lag_ingestion_health_consumer_lag_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "lookback_minutes",
+      "semanticId": "lotus.lookback_minutes"
+    },
+    {
+      "name": "limit",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 100,
+      "allowedValues": [],
+      "description": "Canonical limit value used in request parameter.",
+      "example": 10,
+      "behaviorImpact": "Affects get_ingestion_consumer_lag_ingestion_health_consumer_lag_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "limit",
+      "semanticId": "lotus.limit"
+    },
+    {
+      "name": "X-Lotus-Ops-Token",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Operations token for privileged ingestion runbook APIs (health controls, retry, DLQ triage, idempotency diagnostics).",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects get_ingestion_consumer_lag_ingestion_health_consumer_lag_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_lotus_ops_token",
+      "semanticId": "lotus.x_lotus_ops_token"
+    },
+    {
+      "name": "lookback_minutes",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 60,
+      "allowedValues": [],
+      "description": "Canonical lookback minutes value used in request parameter.",
+      "example": 10,
+      "behaviorImpact": "Affects get_ingestion_slo_status_ingestion_health_slo_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "lookback_minutes",
+      "semanticId": "lotus.lookback_minutes"
+    },
+    {
+      "name": "failure_rate_threshold",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "0.03",
+      "allowedValues": [],
+      "description": "Rate/price value for failure rate threshold.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects get_ingestion_slo_status_ingestion_health_slo_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "failure_rate_threshold",
+      "semanticId": "lotus.failure_rate_threshold"
+    },
+    {
+      "name": "queue_latency_threshold_seconds",
+      "kind": "request_option",
+      "location": "query",
+      "type": "number",
+      "required": false,
+      "default": 5.0,
+      "allowedValues": [],
+      "description": "Canonical queue latency threshold seconds value used in request parameter.",
+      "example": 10.5,
+      "behaviorImpact": "Affects get_ingestion_slo_status_ingestion_health_slo_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "queue_latency_threshold_seconds",
+      "semanticId": "lotus.queue_latency_threshold_seconds"
+    },
+    {
+      "name": "backlog_age_threshold_seconds",
+      "kind": "request_option",
+      "location": "query",
+      "type": "number",
+      "required": false,
+      "default": 300,
+      "allowedValues": [],
+      "description": "Canonical backlog age threshold seconds value used in request parameter.",
+      "example": 10.5,
+      "behaviorImpact": "Affects get_ingestion_slo_status_ingestion_health_slo_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "backlog_age_threshold_seconds",
+      "semanticId": "lotus.backlog_age_threshold_seconds"
+    },
+    {
+      "name": "X-Lotus-Ops-Token",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Operations token for privileged ingestion runbook APIs (health controls, retry, DLQ triage, idempotency diagnostics).",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects get_ingestion_slo_status_ingestion_health_slo_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_lotus_ops_token",
+      "semanticId": "lotus.x_lotus_ops_token"
+    },
+    {
+      "name": "lookback_minutes",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 60,
+      "allowedValues": [],
+      "description": "Canonical lookback minutes value used in request parameter.",
+      "example": 10,
+      "behaviorImpact": "Affects get_ingestion_error_budget_status_ingestion_health_error_budget_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "lookback_minutes",
+      "semanticId": "lotus.lookback_minutes"
+    },
+    {
+      "name": "failure_rate_threshold",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "0.03",
+      "allowedValues": [],
+      "description": "Rate/price value for failure rate threshold.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects get_ingestion_error_budget_status_ingestion_health_error_budget_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "failure_rate_threshold",
+      "semanticId": "lotus.failure_rate_threshold"
+    },
+    {
+      "name": "backlog_growth_threshold",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 5,
+      "allowedValues": [],
+      "description": "Canonical backlog growth threshold value used in request parameter.",
+      "example": 10,
+      "behaviorImpact": "Affects get_ingestion_error_budget_status_ingestion_health_error_budget_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "backlog_growth_threshold",
+      "semanticId": "lotus.backlog_growth_threshold"
+    },
+    {
+      "name": "X-Lotus-Ops-Token",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Operations token for privileged ingestion runbook APIs (health controls, retry, DLQ triage, idempotency diagnostics).",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects get_ingestion_error_budget_status_ingestion_health_error_budget_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_lotus_ops_token",
+      "semanticId": "lotus.x_lotus_ops_token"
+    },
+    {
+      "name": "lookback_minutes",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 1440,
+      "allowedValues": [],
+      "description": "Canonical lookback minutes value used in request parameter.",
+      "example": 10,
+      "behaviorImpact": "Affects get_ingestion_backlog_breakdown_ingestion_health_backlog_breakdown_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "lookback_minutes",
+      "semanticId": "lotus.lookback_minutes"
+    },
+    {
+      "name": "limit",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 200,
+      "allowedValues": [],
+      "description": "Canonical limit value used in request parameter.",
+      "example": 10,
+      "behaviorImpact": "Affects get_ingestion_backlog_breakdown_ingestion_health_backlog_breakdown_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "limit",
+      "semanticId": "lotus.limit"
+    },
+    {
+      "name": "X-Lotus-Ops-Token",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Operations token for privileged ingestion runbook APIs (health controls, retry, DLQ triage, idempotency diagnostics).",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects get_ingestion_backlog_breakdown_ingestion_health_backlog_breakdown_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_lotus_ops_token",
+      "semanticId": "lotus.x_lotus_ops_token"
+    },
+    {
+      "name": "threshold_seconds",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 300,
+      "allowedValues": [],
+      "description": "Canonical threshold seconds value used in request parameter.",
+      "example": 10,
+      "behaviorImpact": "Affects list_ingestion_stalled_jobs_ingestion_health_stalled_jobs_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "threshold_seconds",
+      "semanticId": "lotus.threshold_seconds"
+    },
+    {
+      "name": "limit",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 100,
+      "allowedValues": [],
+      "description": "Canonical limit value used in request parameter.",
+      "example": 10,
+      "behaviorImpact": "Affects list_ingestion_stalled_jobs_ingestion_health_stalled_jobs_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "limit",
+      "semanticId": "lotus.limit"
+    },
+    {
+      "name": "X-Lotus-Ops-Token",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Operations token for privileged ingestion runbook APIs (health controls, retry, DLQ triage, idempotency diagnostics).",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects list_ingestion_stalled_jobs_ingestion_health_stalled_jobs_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_lotus_ops_token",
+      "semanticId": "lotus.x_lotus_ops_token"
+    },
+    {
+      "name": "limit",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 100,
+      "allowedValues": [],
+      "description": "Canonical limit value used in request parameter.",
+      "example": 10,
+      "behaviorImpact": "Affects list_consumer_dlq_events_ingestion_dlq_consumer_events_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "limit",
+      "semanticId": "lotus.limit"
+    },
+    {
+      "name": "original_topic",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Canonical original topic value used in request parameter.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects list_consumer_dlq_events_ingestion_dlq_consumer_events_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "original_topic",
+      "semanticId": "lotus.original_topic"
+    },
+    {
+      "name": "consumer_group",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Canonical consumer group value used in request parameter.",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects list_consumer_dlq_events_ingestion_dlq_consumer_events_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "consumer_group",
+      "semanticId": "lotus.consumer_group"
+    },
+    {
+      "name": "X-Lotus-Ops-Token",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Operations token for privileged ingestion runbook APIs (health controls, retry, DLQ triage, idempotency diagnostics).",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects list_consumer_dlq_events_ingestion_dlq_consumer_events_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_lotus_ops_token",
+      "semanticId": "lotus.x_lotus_ops_token"
+    },
+    {
+      "name": "event_id",
+      "kind": "request_option",
+      "location": "path",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "Unique event identifier.",
+      "example": "EVENT_001",
+      "behaviorImpact": "Affects replay_consumer_dlq_event_ingestion_dlq_consumer_events__event_id__replay_post request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "event_id",
+      "semanticId": "lotus.event_id"
+    },
+    {
+      "name": "X-Lotus-Ops-Token",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Operations token for privileged ingestion runbook APIs (health controls, retry, DLQ triage, idempotency diagnostics).",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects replay_consumer_dlq_event_ingestion_dlq_consumer_events__event_id__replay_post request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_lotus_ops_token",
+      "semanticId": "lotus.x_lotus_ops_token"
+    },
+    {
+      "name": "X-Lotus-Ops-Token",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Operations token for privileged ingestion runbook APIs (health controls, retry, DLQ triage, idempotency diagnostics).",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects get_ingestion_ops_control_ingestion_ops_control_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_lotus_ops_token",
+      "semanticId": "lotus.x_lotus_ops_token"
+    },
+    {
+      "name": "X-Lotus-Ops-Token",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Operations token for privileged ingestion runbook APIs (health controls, retry, DLQ triage, idempotency diagnostics).",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects update_ingestion_ops_control_ingestion_ops_control_put request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_lotus_ops_token",
+      "semanticId": "lotus.x_lotus_ops_token"
+    },
+    {
+      "name": "lookback_minutes",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 1440,
+      "allowedValues": [],
+      "description": "Canonical lookback minutes value used in request parameter.",
+      "example": 10,
+      "behaviorImpact": "Affects get_ingestion_idempotency_diagnostics_ingestion_idempotency_diagnostics_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "lookback_minutes",
+      "semanticId": "lotus.lookback_minutes"
+    },
+    {
+      "name": "limit",
+      "kind": "request_option",
+      "location": "query",
+      "type": "integer",
+      "required": false,
+      "default": 200,
+      "allowedValues": [],
+      "description": "Canonical limit value used in request parameter.",
+      "example": 10,
+      "behaviorImpact": "Affects get_ingestion_idempotency_diagnostics_ingestion_idempotency_diagnostics_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "limit",
+      "semanticId": "lotus.limit"
+    },
+    {
+      "name": "X-Lotus-Ops-Token",
+      "kind": "request_option",
+      "location": "header",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Operations token for privileged ingestion runbook APIs (health controls, retry, DLQ triage, idempotency diagnostics).",
+      "example": "STANDARD",
+      "behaviorImpact": "Affects get_ingestion_idempotency_diagnostics_ingestion_idempotency_diagnostics_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "x_lotus_ops_token",
+      "semanticId": "lotus.x_lotus_ops_token"
     },
     {
       "name": "LOTUS_CORE_CAP_SUPPORT_APIS_ENABLED",
@@ -5914,7 +7890,7 @@
         "Operations Support"
       ],
       "summary": "Get operational support overview for a portfolio",
-      "description": "Returns support-oriented operational state for a portfolio, including reprocessing/valuation queue indicators and latest data availability markers.",
+      "description": "What: Return support-oriented operational state for one portfolio.\nHow: Aggregate reprocessing, valuation, and latest-data availability markers for the key.\nWhen: Use during incidents to quickly assess whether portfolio processing is healthy.",
       "naming": {
         "boundedContext": "operations_support",
         "canonicalTerms": [
@@ -6012,7 +7988,7 @@
         "Operations Support"
       ],
       "summary": "List valuation jobs for support workflows",
-      "description": "Returns valuation jobs for a portfolio with pagination and optional status filtering. Designed for operations/support dashboards.",
+      "description": "What: List valuation jobs for a portfolio with support filters.\nHow: Query valuation job records with pagination and optional status filtering.\nWhen: Use to triage stuck valuation workloads and verify drain progress.",
       "naming": {
         "boundedContext": "operations_support",
         "canonicalTerms": [
@@ -6180,7 +8156,7 @@
         "Operations Support"
       ],
       "summary": "List aggregation jobs for support workflows",
-      "description": "Returns aggregation jobs for a portfolio with pagination and optional status filtering. Designed for operations/support dashboards.",
+      "description": "What: List portfolio aggregation jobs for support workflows.\nHow: Query aggregation job records with pagination and optional status filtering.\nWhen: Use when portfolio rollups are stale or downstream timeseries appears delayed.",
       "naming": {
         "boundedContext": "operations_support",
         "canonicalTerms": [
@@ -6348,7 +8324,7 @@
         "Operations Support"
       ],
       "summary": "Get lineage state for a portfolio-security key",
-      "description": "Returns lineage-relevant state (epoch, watermark, latest artifacts) for a specific portfolio-security key.",
+      "description": "What: Return lineage state for one portfolio-security key.\nHow: Read epoch, watermark, and latest artifact pointers from lineage state services.\nWhen: Use during replay/reprocessing investigations for deterministic state validation.",
       "naming": {
         "boundedContext": "operations_support",
         "canonicalTerms": [
@@ -6472,7 +8448,7 @@
         "Operations Support"
       ],
       "summary": "List lineage keys for a portfolio",
-      "description": "Returns current lineage keys (portfolio-security state rows) for a portfolio with pagination and optional status/security filtering.",
+      "description": "What: List lineage keys for a portfolio.\nHow: Query portfolio-security lineage rows with status/security filters and pagination.\nWhen: Use to scope impacted keys before running replay, backfill, or targeted recovery.",
       "naming": {
         "boundedContext": "operations_support",
         "canonicalTerms": [
@@ -8638,30 +10614,47 @@
       "tags": [
         "Portfolios"
       ],
-      "summary": "Ingest Portfolios",
-      "description": "Ingests a list of portfolios and publishes each to a Kafka topic.",
+      "summary": "Ingest portfolios",
+      "description": "What: Accept canonical portfolio master records.\nHow: Validate portfolio schema, enforce idempotency/mode checks, and publish asynchronously for persistence.\nWhen: Use when onboarding or updating portfolio metadata from upstream systems.",
       "naming": {
         "boundedContext": "portfolios",
         "canonicalTerms": [
+          "accepted_count",
           "advisor_id",
           "base_currency",
           "booking_center_code",
           "client_id",
           "close_date",
+          "correlation_id",
           "cost_basis_method",
+          "entity_type",
+          "idempotency_key",
           "investment_time_horizon",
           "is_leverage_allowed",
+          "job_id",
+          "message",
           "objective",
           "open_date",
           "portfolio_id",
           "portfolio_type",
           "portfolios",
+          "request_id",
           "risk_exposure",
-          "status"
+          "status",
+          "trace_id",
+          "x_idempotency_key"
         ]
       },
       "request": {
         "fields": [
+          {
+            "name": "X-Idempotency-Key",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_idempotency_key",
+            "attributeRef": "lotus.x_idempotency_key"
+          },
           {
             "name": "portfolios",
             "location": "body",
@@ -8786,8 +10779,73 @@
       },
       "response": {
         "httpStatus": 202,
-        "model": "object",
-        "fields": []
+        "model": "BatchIngestionAcceptedResponse",
+        "fields": [
+          {
+            "name": "message",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.message",
+            "attributeRef": "lotus.message"
+          },
+          {
+            "name": "entity_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.entity_type",
+            "attributeRef": "lotus.entity_type"
+          },
+          {
+            "name": "accepted_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.accepted_count",
+            "attributeRef": "lotus.accepted_count"
+          },
+          {
+            "name": "correlation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.correlation_id",
+            "attributeRef": "lotus.correlation_id"
+          },
+          {
+            "name": "request_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.request_id",
+            "attributeRef": "lotus.request_id"
+          },
+          {
+            "name": "trace_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.trace_id",
+            "attributeRef": "lotus.trace_id"
+          },
+          {
+            "name": "idempotency_key",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.idempotency_key",
+            "attributeRef": "lotus.idempotency_key"
+          },
+          {
+            "name": "job_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.job_id",
+            "attributeRef": "lotus.job_id"
+          }
+        ]
       }
     },
     {
@@ -8799,34 +10857,50 @@
       "tags": [
         "Transactions"
       ],
-      "summary": "Ingest Transaction",
-      "description": "Ingests a single financial transaction and publishes it to a Kafka topic.",
+      "summary": "Ingest a single transaction",
+      "description": "What: Accept one canonical transaction record for ledger ingestion.\nHow: Validate contract, enforce idempotency/mode controls, then publish asynchronously to Kafka.\nWhen: Use for low-volume operational corrections or single-record onboarding.",
       "naming": {
         "boundedContext": "transactions",
         "canonicalTerms": [
+          "accepted_count",
           "calculation_policy_id",
           "calculation_policy_version",
+          "correlation_id",
           "created_at",
           "currency",
           "economic_event_id",
+          "entity_type",
           "gross_transaction_amount",
+          "idempotency_key",
           "instrument_id",
           "linked_transaction_group_id",
+          "message",
           "portfolio_id",
           "price",
           "quantity",
+          "request_id",
           "security_id",
           "settlement_date",
           "source_system",
+          "trace_id",
           "trade_currency",
           "trade_fee",
           "transaction_date",
           "transaction_id",
-          "transaction_type"
+          "transaction_type",
+          "x_idempotency_key"
         ]
       },
       "request": {
         "fields": [
+          {
+            "name": "X-Idempotency-Key",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_idempotency_key",
+            "attributeRef": "lotus.x_idempotency_key"
+          },
           {
             "name": "transaction_id",
             "location": "body",
@@ -8983,8 +11057,65 @@
       },
       "response": {
         "httpStatus": 202,
-        "model": "object",
-        "fields": []
+        "model": "IngestionAcceptedResponse",
+        "fields": [
+          {
+            "name": "message",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.message",
+            "attributeRef": "lotus.message"
+          },
+          {
+            "name": "entity_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.entity_type",
+            "attributeRef": "lotus.entity_type"
+          },
+          {
+            "name": "accepted_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.accepted_count",
+            "attributeRef": "lotus.accepted_count"
+          },
+          {
+            "name": "correlation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.correlation_id",
+            "attributeRef": "lotus.correlation_id"
+          },
+          {
+            "name": "request_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.request_id",
+            "attributeRef": "lotus.request_id"
+          },
+          {
+            "name": "trace_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.trace_id",
+            "attributeRef": "lotus.trace_id"
+          },
+          {
+            "name": "idempotency_key",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.idempotency_key",
+            "attributeRef": "lotus.idempotency_key"
+          }
+        ]
       }
     },
     {
@@ -8996,35 +11127,52 @@
       "tags": [
         "Transactions"
       ],
-      "summary": "Ingest Transactions",
-      "description": "Ingests a list of financial transactions and publishes each to a Kafka topic.",
+      "summary": "Ingest a transaction batch",
+      "description": "What: Accept a batch of canonical transaction records.\nHow: Persist ingestion job metadata, validate payload, and publish all valid records asynchronously.\nWhen: Use for standard API-driven batch ingestion workflows.",
       "naming": {
         "boundedContext": "transactions",
         "canonicalTerms": [
+          "accepted_count",
           "calculation_policy_id",
           "calculation_policy_version",
+          "correlation_id",
           "created_at",
           "currency",
           "economic_event_id",
+          "entity_type",
           "gross_transaction_amount",
+          "idempotency_key",
           "instrument_id",
+          "job_id",
           "linked_transaction_group_id",
+          "message",
           "portfolio_id",
           "price",
           "quantity",
+          "request_id",
           "security_id",
           "settlement_date",
           "source_system",
+          "trace_id",
           "trade_currency",
           "trade_fee",
           "transaction_date",
           "transaction_id",
           "transaction_type",
-          "transactions"
+          "transactions",
+          "x_idempotency_key"
         ]
       },
       "request": {
         "fields": [
+          {
+            "name": "X-Idempotency-Key",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_idempotency_key",
+            "attributeRef": "lotus.x_idempotency_key"
+          },
           {
             "name": "transactions",
             "location": "body",
@@ -9189,8 +11337,73 @@
       },
       "response": {
         "httpStatus": 202,
-        "model": "object",
-        "fields": []
+        "model": "BatchIngestionAcceptedResponse",
+        "fields": [
+          {
+            "name": "message",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.message",
+            "attributeRef": "lotus.message"
+          },
+          {
+            "name": "entity_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.entity_type",
+            "attributeRef": "lotus.entity_type"
+          },
+          {
+            "name": "accepted_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.accepted_count",
+            "attributeRef": "lotus.accepted_count"
+          },
+          {
+            "name": "correlation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.correlation_id",
+            "attributeRef": "lotus.correlation_id"
+          },
+          {
+            "name": "request_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.request_id",
+            "attributeRef": "lotus.request_id"
+          },
+          {
+            "name": "trace_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.trace_id",
+            "attributeRef": "lotus.trace_id"
+          },
+          {
+            "name": "idempotency_key",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.idempotency_key",
+            "attributeRef": "lotus.idempotency_key"
+          },
+          {
+            "name": "job_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.job_id",
+            "attributeRef": "lotus.job_id"
+          }
+        ]
       }
     },
     {
@@ -9202,30 +11415,47 @@
       "tags": [
         "Instruments"
       ],
-      "summary": "Ingest Instruments",
-      "description": "Ingests a list of financial instruments and publishes each to a Kafka topic.",
+      "summary": "Ingest instruments",
+      "description": "What: Accept canonical instrument/security reference records.\nHow: Validate schema, enforce ingestion mode/idempotency controls, and publish to asynchronous persistence pipeline.\nWhen: Use for security master onboarding and reference data corrections.",
       "naming": {
         "boundedContext": "instruments",
         "canonicalTerms": [
+          "accepted_count",
           "asset_class",
+          "correlation_id",
           "country_of_risk",
           "currency",
+          "entity_type",
+          "idempotency_key",
           "instruments",
           "isin",
           "issuer_id",
           "issuer_name",
+          "job_id",
           "maturity_date",
+          "message",
           "name",
           "product_type",
           "rating",
+          "request_id",
           "sector",
           "security_id",
+          "trace_id",
           "ultimate_parent_issuer_id",
-          "ultimate_parent_issuer_name"
+          "ultimate_parent_issuer_name",
+          "x_idempotency_key"
         ]
       },
       "request": {
         "fields": [
+          {
+            "name": "X-Idempotency-Key",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_idempotency_key",
+            "attributeRef": "lotus.x_idempotency_key"
+          },
           {
             "name": "instruments",
             "location": "body",
@@ -9350,8 +11580,73 @@
       },
       "response": {
         "httpStatus": 202,
-        "model": "object",
-        "fields": []
+        "model": "BatchIngestionAcceptedResponse",
+        "fields": [
+          {
+            "name": "message",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.message",
+            "attributeRef": "lotus.message"
+          },
+          {
+            "name": "entity_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.entity_type",
+            "attributeRef": "lotus.entity_type"
+          },
+          {
+            "name": "accepted_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.accepted_count",
+            "attributeRef": "lotus.accepted_count"
+          },
+          {
+            "name": "correlation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.correlation_id",
+            "attributeRef": "lotus.correlation_id"
+          },
+          {
+            "name": "request_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.request_id",
+            "attributeRef": "lotus.request_id"
+          },
+          {
+            "name": "trace_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.trace_id",
+            "attributeRef": "lotus.trace_id"
+          },
+          {
+            "name": "idempotency_key",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.idempotency_key",
+            "attributeRef": "lotus.idempotency_key"
+          },
+          {
+            "name": "job_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.job_id",
+            "attributeRef": "lotus.job_id"
+          }
+        ]
       }
     },
     {
@@ -9363,20 +11658,37 @@
       "tags": [
         "Market Prices"
       ],
-      "summary": "Ingest Market Prices",
-      "description": "Ingests a list of market prices and publishes each to a Kafka topic.",
+      "summary": "Ingest market prices",
+      "description": "What: Accept canonical market price observations for securities.\nHow: Validate payload, enforce ingestion guardrails, and publish asynchronous events for valuation processing.\nWhen: Use for daily close pricing loads or intraday approved market data updates.",
       "naming": {
         "boundedContext": "market_prices",
         "canonicalTerms": [
+          "accepted_count",
+          "correlation_id",
           "currency",
+          "entity_type",
+          "idempotency_key",
+          "job_id",
           "market_prices",
+          "message",
           "price",
           "price_date",
-          "security_id"
+          "request_id",
+          "security_id",
+          "trace_id",
+          "x_idempotency_key"
         ]
       },
       "request": {
         "fields": [
+          {
+            "name": "X-Idempotency-Key",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_idempotency_key",
+            "attributeRef": "lotus.x_idempotency_key"
+          },
           {
             "name": "market_prices",
             "location": "body",
@@ -9421,8 +11733,73 @@
       },
       "response": {
         "httpStatus": 202,
-        "model": "object",
-        "fields": []
+        "model": "BatchIngestionAcceptedResponse",
+        "fields": [
+          {
+            "name": "message",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.message",
+            "attributeRef": "lotus.message"
+          },
+          {
+            "name": "entity_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.entity_type",
+            "attributeRef": "lotus.entity_type"
+          },
+          {
+            "name": "accepted_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.accepted_count",
+            "attributeRef": "lotus.accepted_count"
+          },
+          {
+            "name": "correlation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.correlation_id",
+            "attributeRef": "lotus.correlation_id"
+          },
+          {
+            "name": "request_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.request_id",
+            "attributeRef": "lotus.request_id"
+          },
+          {
+            "name": "trace_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.trace_id",
+            "attributeRef": "lotus.trace_id"
+          },
+          {
+            "name": "idempotency_key",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.idempotency_key",
+            "attributeRef": "lotus.idempotency_key"
+          },
+          {
+            "name": "job_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.job_id",
+            "attributeRef": "lotus.job_id"
+          }
+        ]
       }
     },
     {
@@ -9434,20 +11811,37 @@
       "tags": [
         "FX Rates"
       ],
-      "summary": "Ingest Fx Rates",
-      "description": "Ingests a list of FX rates and publishes each to a Kafka topic.",
+      "summary": "Ingest FX rates",
+      "description": "What: Accept canonical foreign-exchange rate observations.\nHow: Validate FX rate contract, enforce ingestion controls, and publish asynchronous events for downstream valuation.\nWhen: Use for scheduled FX reference updates and approved manual corrections.",
       "naming": {
         "boundedContext": "fx_rates",
         "canonicalTerms": [
+          "accepted_count",
+          "correlation_id",
+          "entity_type",
           "from_currency",
           "fx_rates",
+          "idempotency_key",
+          "job_id",
+          "message",
           "rate",
           "rate_date",
-          "to_currency"
+          "request_id",
+          "to_currency",
+          "trace_id",
+          "x_idempotency_key"
         ]
       },
       "request": {
         "fields": [
+          {
+            "name": "X-Idempotency-Key",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_idempotency_key",
+            "attributeRef": "lotus.x_idempotency_key"
+          },
           {
             "name": "fx_rates",
             "location": "body",
@@ -9492,8 +11886,73 @@
       },
       "response": {
         "httpStatus": 202,
-        "model": "object",
-        "fields": []
+        "model": "BatchIngestionAcceptedResponse",
+        "fields": [
+          {
+            "name": "message",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.message",
+            "attributeRef": "lotus.message"
+          },
+          {
+            "name": "entity_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.entity_type",
+            "attributeRef": "lotus.entity_type"
+          },
+          {
+            "name": "accepted_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.accepted_count",
+            "attributeRef": "lotus.accepted_count"
+          },
+          {
+            "name": "correlation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.correlation_id",
+            "attributeRef": "lotus.correlation_id"
+          },
+          {
+            "name": "request_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.request_id",
+            "attributeRef": "lotus.request_id"
+          },
+          {
+            "name": "trace_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.trace_id",
+            "attributeRef": "lotus.trace_id"
+          },
+          {
+            "name": "idempotency_key",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.idempotency_key",
+            "attributeRef": "lotus.idempotency_key"
+          },
+          {
+            "name": "job_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.job_id",
+            "attributeRef": "lotus.job_id"
+          }
+        ]
       }
     },
     {
@@ -9505,17 +11964,34 @@
       "tags": [
         "Business Dates"
       ],
-      "summary": "Ingest Business Dates",
-      "description": "Ingests a list of business dates and publishes each to a Kafka topic.",
+      "summary": "Ingest business dates",
+      "description": "What: Accept canonical business calendar dates used by valuation and processing lifecycles.\nHow: Validate date records, apply ingestion controls, and publish asynchronous persistence events.\nWhen: Use for calendar setup, holiday updates, and date-correction operations.",
       "naming": {
         "boundedContext": "business_dates",
         "canonicalTerms": [
+          "accepted_count",
           "business_date",
-          "business_dates"
+          "business_dates",
+          "correlation_id",
+          "entity_type",
+          "idempotency_key",
+          "job_id",
+          "message",
+          "request_id",
+          "trace_id",
+          "x_idempotency_key"
         ]
       },
       "request": {
         "fields": [
+          {
+            "name": "X-Idempotency-Key",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_idempotency_key",
+            "attributeRef": "lotus.x_idempotency_key"
+          },
           {
             "name": "business_dates",
             "location": "body",
@@ -9536,8 +12012,73 @@
       },
       "response": {
         "httpStatus": 202,
-        "model": "object",
-        "fields": []
+        "model": "BatchIngestionAcceptedResponse",
+        "fields": [
+          {
+            "name": "message",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.message",
+            "attributeRef": "lotus.message"
+          },
+          {
+            "name": "entity_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.entity_type",
+            "attributeRef": "lotus.entity_type"
+          },
+          {
+            "name": "accepted_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.accepted_count",
+            "attributeRef": "lotus.accepted_count"
+          },
+          {
+            "name": "correlation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.correlation_id",
+            "attributeRef": "lotus.correlation_id"
+          },
+          {
+            "name": "request_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.request_id",
+            "attributeRef": "lotus.request_id"
+          },
+          {
+            "name": "trace_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.trace_id",
+            "attributeRef": "lotus.trace_id"
+          },
+          {
+            "name": "idempotency_key",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.idempotency_key",
+            "attributeRef": "lotus.idempotency_key"
+          },
+          {
+            "name": "job_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.job_id",
+            "attributeRef": "lotus.job_id"
+          }
+        ]
       }
     },
     {
@@ -9549,16 +12090,33 @@
       "tags": [
         "Reprocessing"
       ],
-      "summary": "Reprocess Transactions",
-      "description": "Accepts a list of transaction IDs and publishes a reprocessing request\nevent for each to a Kafka topic.",
+      "summary": "Request transaction reprocessing",
+      "description": "What: Accept transaction identifiers that require deterministic historical recalculation.\nHow: Validate request, persist ingestion job metadata, and publish reprocessing command events.\nWhen: Use for operational correction workflows after retroactive data changes.",
       "naming": {
         "boundedContext": "reprocessing",
         "canonicalTerms": [
-          "transaction_ids"
+          "accepted_count",
+          "correlation_id",
+          "entity_type",
+          "idempotency_key",
+          "job_id",
+          "message",
+          "request_id",
+          "trace_id",
+          "transaction_ids",
+          "x_idempotency_key"
         ]
       },
       "request": {
         "fields": [
+          {
+            "name": "X-Idempotency-Key",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_idempotency_key",
+            "attributeRef": "lotus.x_idempotency_key"
+          },
           {
             "name": "transaction_ids",
             "location": "body",
@@ -9571,8 +12129,73 @@
       },
       "response": {
         "httpStatus": 202,
-        "model": "object",
-        "fields": []
+        "model": "BatchIngestionAcceptedResponse",
+        "fields": [
+          {
+            "name": "message",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.message",
+            "attributeRef": "lotus.message"
+          },
+          {
+            "name": "entity_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.entity_type",
+            "attributeRef": "lotus.entity_type"
+          },
+          {
+            "name": "accepted_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.accepted_count",
+            "attributeRef": "lotus.accepted_count"
+          },
+          {
+            "name": "correlation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.correlation_id",
+            "attributeRef": "lotus.correlation_id"
+          },
+          {
+            "name": "request_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.request_id",
+            "attributeRef": "lotus.request_id"
+          },
+          {
+            "name": "trace_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.trace_id",
+            "attributeRef": "lotus.trace_id"
+          },
+          {
+            "name": "idempotency_key",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.idempotency_key",
+            "attributeRef": "lotus.idempotency_key"
+          },
+          {
+            "name": "job_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.job_id",
+            "attributeRef": "lotus.job_id"
+          }
+        ]
       }
     },
     {
@@ -9585,10 +12208,11 @@
         "Portfolio Bundle"
       ],
       "summary": "Ingest a complete portfolio bundle",
-      "description": "Accepts a mixed payload (portfolio, instruments, transactions, market prices, FX rates, business dates) for UI/manual/file-based onboarding and publishes to existing lotus-core topics.",
+      "description": "What: Accept a mixed onboarding bundle containing portfolio, instrument, transaction, market-price, FX-rate, and business-date records.\nHow: Validate adapter payload and fan out records into existing canonical ingestion topics.\nWhen: Use for adapter-mode onboarding (UI/manual/file workflows), not primary upstream integration.",
       "naming": {
         "boundedContext": "portfolio_bundle",
         "canonicalTerms": [
+          "accepted_count",
           "advisor_id",
           "asset_class",
           "base_currency",
@@ -9599,14 +12223,17 @@
           "calculation_policy_version",
           "client_id",
           "close_date",
+          "correlation_id",
           "cost_basis_method",
           "country_of_risk",
           "created_at",
           "currency",
           "economic_event_id",
+          "entity_type",
           "from_currency",
           "fx_rates",
           "gross_transaction_amount",
+          "idempotency_key",
           "instrument_id",
           "instruments",
           "investment_time_horizon",
@@ -9614,9 +12241,11 @@
           "isin",
           "issuer_id",
           "issuer_name",
+          "job_id",
           "linked_transaction_group_id",
           "market_prices",
           "maturity_date",
+          "message",
           "mode",
           "name",
           "objective",
@@ -9631,6 +12260,7 @@
           "rate",
           "rate_date",
           "rating",
+          "request_id",
           "risk_exposure",
           "sector",
           "security_id",
@@ -9638,6 +12268,7 @@
           "source_system",
           "status",
           "to_currency",
+          "trace_id",
           "trade_currency",
           "trade_fee",
           "transaction_date",
@@ -9645,11 +12276,20 @@
           "transaction_type",
           "transactions",
           "ultimate_parent_issuer_id",
-          "ultimate_parent_issuer_name"
+          "ultimate_parent_issuer_name",
+          "x_idempotency_key"
         ]
       },
       "request": {
         "fields": [
+          {
+            "name": "X-Idempotency-Key",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_idempotency_key",
+            "attributeRef": "lotus.x_idempotency_key"
+          },
           {
             "name": "source_system",
             "location": "body",
@@ -10166,8 +12806,73 @@
       },
       "response": {
         "httpStatus": 202,
-        "model": "object",
-        "fields": []
+        "model": "BatchIngestionAcceptedResponse",
+        "fields": [
+          {
+            "name": "message",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.message",
+            "attributeRef": "lotus.message"
+          },
+          {
+            "name": "entity_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.entity_type",
+            "attributeRef": "lotus.entity_type"
+          },
+          {
+            "name": "accepted_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.accepted_count",
+            "attributeRef": "lotus.accepted_count"
+          },
+          {
+            "name": "correlation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.correlation_id",
+            "attributeRef": "lotus.correlation_id"
+          },
+          {
+            "name": "request_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.request_id",
+            "attributeRef": "lotus.request_id"
+          },
+          {
+            "name": "trace_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.trace_id",
+            "attributeRef": "lotus.trace_id"
+          },
+          {
+            "name": "idempotency_key",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.idempotency_key",
+            "attributeRef": "lotus.idempotency_key"
+          },
+          {
+            "name": "job_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.job_id",
+            "attributeRef": "lotus.job_id"
+          }
+        ]
       }
     },
     {
@@ -10180,7 +12885,7 @@
         "Bulk Uploads"
       ],
       "summary": "Preview and validate bulk upload data",
-      "description": "Validates CSV/XLSX rows against lotus-core ingestion contracts without publishing events. Returns row-level errors and normalized sample rows for UI correction workflows.",
+      "description": "What: Validate CSV/XLSX ingestion payloads without publishing records.\nHow: Parse file rows, apply entity-specific schema checks, and return row-level validation feedback.\nWhen: Use before commit to catch data-quality issues in bulk adapter uploads.",
       "naming": {
         "boundedContext": "bulk_uploads",
         "canonicalTerms": [
@@ -10287,7 +12992,7 @@
         "Bulk Uploads"
       ],
       "summary": "Commit validated bulk upload data",
-      "description": "Validates CSV/XLSX rows and publishes valid records to existing lotus-core ingestion topics. By default rejects partial uploads; set allowPartial=true to publish valid rows only.",
+      "description": "What: Commit CSV/XLSX data into canonical ingestion topics.\nHow: Validate rows, enforce mode controls, and publish valid records (optionally partial when allowPartial=true).\nWhen: Use after preview passes for adapter-mode bulk ingestion.",
       "naming": {
         "boundedContext": "bulk_uploads",
         "canonicalTerms": [
@@ -10371,6 +13076,2354 @@
             "type": "string",
             "semanticId": "lotus.message",
             "attributeRef": "lotus.message"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_ingestion_job_ingestion_jobs__job_id__get",
+      "method": "GET",
+      "path": "/ingestion/jobs/{job_id}",
+      "domain": "ingestion_operations",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Ingestion Operations"
+      ],
+      "summary": "Get ingestion job status",
+      "description": "What: Return lifecycle state and metadata for one ingestion job.\nHow: Read canonical ingestion-job state by job_id.\nWhen: Use to track asynchronous ingestion completion or failure for a submitted request.",
+      "naming": {
+        "boundedContext": "ingestion_operations",
+        "canonicalTerms": [
+          "accepted_count",
+          "completed_at",
+          "correlation_id",
+          "endpoint",
+          "entity_type",
+          "failure_reason",
+          "idempotency_key",
+          "job_id",
+          "last_retried_at",
+          "request_id",
+          "retry_count",
+          "status",
+          "submitted_at",
+          "trace_id",
+          "x_lotus_ops_token"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "job_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.job_id",
+            "attributeRef": "lotus.job_id"
+          },
+          {
+            "name": "X-Lotus-Ops-Token",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_lotus_ops_token",
+            "attributeRef": "lotus.x_lotus_ops_token"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "IngestionJobResponse",
+        "fields": [
+          {
+            "name": "job_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.job_id",
+            "attributeRef": "lotus.job_id"
+          },
+          {
+            "name": "endpoint",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.endpoint",
+            "attributeRef": "lotus.endpoint"
+          },
+          {
+            "name": "entity_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.entity_type",
+            "attributeRef": "lotus.entity_type"
+          },
+          {
+            "name": "status",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.status",
+            "attributeRef": "lotus.status"
+          },
+          {
+            "name": "accepted_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.accepted_count",
+            "attributeRef": "lotus.accepted_count"
+          },
+          {
+            "name": "idempotency_key",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.idempotency_key",
+            "attributeRef": "lotus.idempotency_key"
+          },
+          {
+            "name": "correlation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.correlation_id",
+            "attributeRef": "lotus.correlation_id"
+          },
+          {
+            "name": "request_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.request_id",
+            "attributeRef": "lotus.request_id"
+          },
+          {
+            "name": "trace_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.trace_id",
+            "attributeRef": "lotus.trace_id"
+          },
+          {
+            "name": "submitted_at",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.submitted_at",
+            "attributeRef": "lotus.submitted_at"
+          },
+          {
+            "name": "completed_at",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.completed_at",
+            "attributeRef": "lotus.completed_at"
+          },
+          {
+            "name": "failure_reason",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.failure_reason",
+            "attributeRef": "lotus.failure_reason"
+          },
+          {
+            "name": "retry_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.retry_count",
+            "attributeRef": "lotus.retry_count"
+          },
+          {
+            "name": "last_retried_at",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.last_retried_at",
+            "attributeRef": "lotus.last_retried_at"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "list_ingestion_jobs_ingestion_jobs_get",
+      "method": "GET",
+      "path": "/ingestion/jobs",
+      "domain": "ingestion_operations",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Ingestion Operations"
+      ],
+      "summary": "List ingestion jobs",
+      "description": "What: List ingestion jobs with operational filtering and pagination.\nHow: Query canonical job records using status/entity/date filters and cursor pagination.\nWhen: Use for runbook dashboards, triage, and service-operations monitoring.",
+      "naming": {
+        "boundedContext": "ingestion_operations",
+        "canonicalTerms": [
+          "accepted_count",
+          "completed_at",
+          "correlation_id",
+          "cursor",
+          "endpoint",
+          "entity_type",
+          "failure_reason",
+          "from",
+          "idempotency_key",
+          "job_id",
+          "jobs",
+          "last_retried_at",
+          "limit",
+          "next_cursor",
+          "request_id",
+          "retry_count",
+          "status",
+          "submitted_at",
+          "to",
+          "total",
+          "trace_id",
+          "x_lotus_ops_token"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "status",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.status",
+            "attributeRef": "lotus.status"
+          },
+          {
+            "name": "entity_type",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.entity_type",
+            "attributeRef": "lotus.entity_type"
+          },
+          {
+            "name": "from",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.from",
+            "attributeRef": "lotus.from"
+          },
+          {
+            "name": "to",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.to",
+            "attributeRef": "lotus.to"
+          },
+          {
+            "name": "cursor",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.cursor",
+            "attributeRef": "lotus.cursor"
+          },
+          {
+            "name": "limit",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.limit",
+            "attributeRef": "lotus.limit"
+          },
+          {
+            "name": "X-Lotus-Ops-Token",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_lotus_ops_token",
+            "attributeRef": "lotus.x_lotus_ops_token"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "IngestionJobListResponse",
+        "fields": [
+          {
+            "name": "jobs",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.jobs",
+            "attributeRef": "lotus.jobs"
+          },
+          {
+            "name": "jobs[].job_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.job_id",
+            "attributeRef": "lotus.job_id"
+          },
+          {
+            "name": "jobs[].endpoint",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.endpoint",
+            "attributeRef": "lotus.endpoint"
+          },
+          {
+            "name": "jobs[].entity_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.entity_type",
+            "attributeRef": "lotus.entity_type"
+          },
+          {
+            "name": "jobs[].status",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.status",
+            "attributeRef": "lotus.status"
+          },
+          {
+            "name": "jobs[].accepted_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.accepted_count",
+            "attributeRef": "lotus.accepted_count"
+          },
+          {
+            "name": "jobs[].idempotency_key",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.idempotency_key",
+            "attributeRef": "lotus.idempotency_key"
+          },
+          {
+            "name": "jobs[].correlation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.correlation_id",
+            "attributeRef": "lotus.correlation_id"
+          },
+          {
+            "name": "jobs[].request_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.request_id",
+            "attributeRef": "lotus.request_id"
+          },
+          {
+            "name": "jobs[].trace_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.trace_id",
+            "attributeRef": "lotus.trace_id"
+          },
+          {
+            "name": "jobs[].submitted_at",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.submitted_at",
+            "attributeRef": "lotus.submitted_at"
+          },
+          {
+            "name": "jobs[].completed_at",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.completed_at",
+            "attributeRef": "lotus.completed_at"
+          },
+          {
+            "name": "jobs[].failure_reason",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.failure_reason",
+            "attributeRef": "lotus.failure_reason"
+          },
+          {
+            "name": "jobs[].retry_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.retry_count",
+            "attributeRef": "lotus.retry_count"
+          },
+          {
+            "name": "jobs[].last_retried_at",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.last_retried_at",
+            "attributeRef": "lotus.last_retried_at"
+          },
+          {
+            "name": "total",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.total",
+            "attributeRef": "lotus.total"
+          },
+          {
+            "name": "next_cursor",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.next_cursor",
+            "attributeRef": "lotus.next_cursor"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "list_ingestion_job_failures_ingestion_jobs__job_id__failures_get",
+      "method": "GET",
+      "path": "/ingestion/jobs/{job_id}/failures",
+      "domain": "ingestion_operations",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Ingestion Operations"
+      ],
+      "summary": "List ingestion job failures",
+      "description": "What: Return failure events recorded for a specific ingestion job.\nHow: Read ingestion job failure history with most-recent-first ordering.\nWhen: Use during incident triage to identify failure phases and impacted record keys.",
+      "naming": {
+        "boundedContext": "ingestion_operations",
+        "canonicalTerms": [
+          "failed_at",
+          "failed_record_keys",
+          "failure_id",
+          "failure_phase",
+          "failure_reason",
+          "failures",
+          "job_id",
+          "limit",
+          "total",
+          "x_lotus_ops_token"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "job_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.job_id",
+            "attributeRef": "lotus.job_id"
+          },
+          {
+            "name": "limit",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.limit",
+            "attributeRef": "lotus.limit"
+          },
+          {
+            "name": "X-Lotus-Ops-Token",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_lotus_ops_token",
+            "attributeRef": "lotus.x_lotus_ops_token"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "IngestionJobFailureListResponse",
+        "fields": [
+          {
+            "name": "failures",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.failures",
+            "attributeRef": "lotus.failures"
+          },
+          {
+            "name": "failures[].failure_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.failure_id",
+            "attributeRef": "lotus.failure_id"
+          },
+          {
+            "name": "failures[].job_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.job_id",
+            "attributeRef": "lotus.job_id"
+          },
+          {
+            "name": "failures[].failure_phase",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.failure_phase",
+            "attributeRef": "lotus.failure_phase"
+          },
+          {
+            "name": "failures[].failure_reason",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.failure_reason",
+            "attributeRef": "lotus.failure_reason"
+          },
+          {
+            "name": "failures[].failed_record_keys",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.failed_record_keys",
+            "attributeRef": "lotus.failed_record_keys"
+          },
+          {
+            "name": "failures[].failed_at",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.failed_at",
+            "attributeRef": "lotus.failed_at"
+          },
+          {
+            "name": "total",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.total",
+            "attributeRef": "lotus.total"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_ingestion_job_records_ingestion_jobs__job_id__records_get",
+      "method": "GET",
+      "path": "/ingestion/jobs/{job_id}/records",
+      "domain": "ingestion_operations",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Ingestion Operations"
+      ],
+      "summary": "Get ingestion job record-level status",
+      "description": "What: Return record-level replayability and failed keys for an ingestion job.\nHow: Derive replayable keys from stored payload and merge with failure history.\nWhen: Use before partial retry operations or to build precise remediation batches.",
+      "naming": {
+        "boundedContext": "ingestion_operations",
+        "canonicalTerms": [
+          "accepted_count",
+          "entity_type",
+          "failed_record_keys",
+          "job_id",
+          "replayable_record_keys",
+          "x_lotus_ops_token"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "job_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.job_id",
+            "attributeRef": "lotus.job_id"
+          },
+          {
+            "name": "X-Lotus-Ops-Token",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_lotus_ops_token",
+            "attributeRef": "lotus.x_lotus_ops_token"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "IngestionJobRecordStatusResponse",
+        "fields": [
+          {
+            "name": "job_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.job_id",
+            "attributeRef": "lotus.job_id"
+          },
+          {
+            "name": "entity_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.entity_type",
+            "attributeRef": "lotus.entity_type"
+          },
+          {
+            "name": "accepted_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.accepted_count",
+            "attributeRef": "lotus.accepted_count"
+          },
+          {
+            "name": "failed_record_keys",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.failed_record_keys",
+            "attributeRef": "lotus.failed_record_keys"
+          },
+          {
+            "name": "replayable_record_keys",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.replayable_record_keys",
+            "attributeRef": "lotus.replayable_record_keys"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "retry_ingestion_job_ingestion_jobs__job_id__retry_post",
+      "method": "POST",
+      "path": "/ingestion/jobs/{job_id}/retry",
+      "domain": "ingestion_operations",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Ingestion Operations"
+      ],
+      "summary": "Retry a failed ingestion job",
+      "description": "What: Retry a failed ingestion job using full or partial payload replay.\nHow: Rehydrate stored request payload, apply optional record-key filtering, and republish asynchronously.\nWhen: Use after root cause remediation to recover failed ingestion without direct DB operations.",
+      "naming": {
+        "boundedContext": "ingestion_operations",
+        "canonicalTerms": [
+          "accepted_count",
+          "completed_at",
+          "correlation_id",
+          "dry_run",
+          "endpoint",
+          "entity_type",
+          "failure_reason",
+          "idempotency_key",
+          "job_id",
+          "last_retried_at",
+          "record_keys",
+          "request_id",
+          "retry_count",
+          "status",
+          "submitted_at",
+          "trace_id",
+          "x_lotus_ops_token"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "job_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.job_id",
+            "attributeRef": "lotus.job_id"
+          },
+          {
+            "name": "X-Lotus-Ops-Token",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_lotus_ops_token",
+            "attributeRef": "lotus.x_lotus_ops_token"
+          },
+          {
+            "name": "record_keys",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.record_keys",
+            "attributeRef": "lotus.record_keys"
+          },
+          {
+            "name": "dry_run",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.dry_run",
+            "attributeRef": "lotus.dry_run"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "IngestionJobResponse",
+        "fields": [
+          {
+            "name": "job_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.job_id",
+            "attributeRef": "lotus.job_id"
+          },
+          {
+            "name": "endpoint",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.endpoint",
+            "attributeRef": "lotus.endpoint"
+          },
+          {
+            "name": "entity_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.entity_type",
+            "attributeRef": "lotus.entity_type"
+          },
+          {
+            "name": "status",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.status",
+            "attributeRef": "lotus.status"
+          },
+          {
+            "name": "accepted_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.accepted_count",
+            "attributeRef": "lotus.accepted_count"
+          },
+          {
+            "name": "idempotency_key",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.idempotency_key",
+            "attributeRef": "lotus.idempotency_key"
+          },
+          {
+            "name": "correlation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.correlation_id",
+            "attributeRef": "lotus.correlation_id"
+          },
+          {
+            "name": "request_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.request_id",
+            "attributeRef": "lotus.request_id"
+          },
+          {
+            "name": "trace_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.trace_id",
+            "attributeRef": "lotus.trace_id"
+          },
+          {
+            "name": "submitted_at",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.submitted_at",
+            "attributeRef": "lotus.submitted_at"
+          },
+          {
+            "name": "completed_at",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.completed_at",
+            "attributeRef": "lotus.completed_at"
+          },
+          {
+            "name": "failure_reason",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.failure_reason",
+            "attributeRef": "lotus.failure_reason"
+          },
+          {
+            "name": "retry_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.retry_count",
+            "attributeRef": "lotus.retry_count"
+          },
+          {
+            "name": "last_retried_at",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.last_retried_at",
+            "attributeRef": "lotus.last_retried_at"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_ingestion_health_summary_ingestion_health_summary_get",
+      "method": "GET",
+      "path": "/ingestion/health/summary",
+      "domain": "ingestion_operations",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Ingestion Operations"
+      ],
+      "summary": "Get ingestion operational health summary",
+      "description": "What: Return aggregate ingestion counters (accepted/queued/failed/backlog).\nHow: Compute summary from canonical ingestion job state.\nWhen: Use for fast operational health checks and dashboards.",
+      "naming": {
+        "boundedContext": "ingestion_operations",
+        "canonicalTerms": [
+          "accepted_jobs",
+          "backlog_jobs",
+          "failed_jobs",
+          "queued_jobs",
+          "total_jobs",
+          "x_lotus_ops_token"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "X-Lotus-Ops-Token",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_lotus_ops_token",
+            "attributeRef": "lotus.x_lotus_ops_token"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "IngestionHealthSummaryResponse",
+        "fields": [
+          {
+            "name": "total_jobs",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.total_jobs",
+            "attributeRef": "lotus.total_jobs"
+          },
+          {
+            "name": "accepted_jobs",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.accepted_jobs",
+            "attributeRef": "lotus.accepted_jobs"
+          },
+          {
+            "name": "queued_jobs",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.queued_jobs",
+            "attributeRef": "lotus.queued_jobs"
+          },
+          {
+            "name": "failed_jobs",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.failed_jobs",
+            "attributeRef": "lotus.failed_jobs"
+          },
+          {
+            "name": "backlog_jobs",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.backlog_jobs",
+            "attributeRef": "lotus.backlog_jobs"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_ingestion_health_lag_ingestion_health_lag_get",
+      "method": "GET",
+      "path": "/ingestion/health/lag",
+      "domain": "ingestion_operations",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Ingestion Operations"
+      ],
+      "summary": "Get ingestion backlog indicators",
+      "description": "What: Return backlog-oriented counters derived from non-terminal jobs.\nHow: Reuse canonical health summary state for lag visibility.\nWhen: Use when operations need a quick backlog signal during ingestion incidents.",
+      "naming": {
+        "boundedContext": "ingestion_operations",
+        "canonicalTerms": [
+          "accepted_jobs",
+          "backlog_jobs",
+          "failed_jobs",
+          "queued_jobs",
+          "total_jobs",
+          "x_lotus_ops_token"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "X-Lotus-Ops-Token",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_lotus_ops_token",
+            "attributeRef": "lotus.x_lotus_ops_token"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "IngestionHealthSummaryResponse",
+        "fields": [
+          {
+            "name": "total_jobs",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.total_jobs",
+            "attributeRef": "lotus.total_jobs"
+          },
+          {
+            "name": "accepted_jobs",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.accepted_jobs",
+            "attributeRef": "lotus.accepted_jobs"
+          },
+          {
+            "name": "queued_jobs",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.queued_jobs",
+            "attributeRef": "lotus.queued_jobs"
+          },
+          {
+            "name": "failed_jobs",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.failed_jobs",
+            "attributeRef": "lotus.failed_jobs"
+          },
+          {
+            "name": "backlog_jobs",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.backlog_jobs",
+            "attributeRef": "lotus.backlog_jobs"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_ingestion_consumer_lag_ingestion_health_consumer_lag_get",
+      "method": "GET",
+      "path": "/ingestion/health/consumer-lag",
+      "domain": "ingestion_operations",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Ingestion Operations"
+      ],
+      "summary": "Get consumer lag diagnostics",
+      "description": "What: Return consumer lag diagnostics derived from DLQ pressure and backlog signals.\nHow: Aggregate consumer dead-letter events by consumer group and original topic.\nWhen: Use to triage downstream consumer lag before replaying ingestion jobs.",
+      "naming": {
+        "boundedContext": "ingestion_operations",
+        "canonicalTerms": [
+          "backlog_jobs",
+          "consumer_group",
+          "dlq_events",
+          "groups",
+          "lag_severity",
+          "last_observed_at",
+          "limit",
+          "lookback_minutes",
+          "original_topic",
+          "total_groups",
+          "x_lotus_ops_token"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "lookback_minutes",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.lookback_minutes",
+            "attributeRef": "lotus.lookback_minutes"
+          },
+          {
+            "name": "limit",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.limit",
+            "attributeRef": "lotus.limit"
+          },
+          {
+            "name": "X-Lotus-Ops-Token",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_lotus_ops_token",
+            "attributeRef": "lotus.x_lotus_ops_token"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "IngestionConsumerLagResponse",
+        "fields": [
+          {
+            "name": "lookback_minutes",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.lookback_minutes",
+            "attributeRef": "lotus.lookback_minutes"
+          },
+          {
+            "name": "backlog_jobs",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.backlog_jobs",
+            "attributeRef": "lotus.backlog_jobs"
+          },
+          {
+            "name": "total_groups",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.total_groups",
+            "attributeRef": "lotus.total_groups"
+          },
+          {
+            "name": "groups",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.groups",
+            "attributeRef": "lotus.groups"
+          },
+          {
+            "name": "groups[].consumer_group",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.consumer_group",
+            "attributeRef": "lotus.consumer_group"
+          },
+          {
+            "name": "groups[].original_topic",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.original_topic",
+            "attributeRef": "lotus.original_topic"
+          },
+          {
+            "name": "groups[].dlq_events",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.dlq_events",
+            "attributeRef": "lotus.dlq_events"
+          },
+          {
+            "name": "groups[].last_observed_at",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.last_observed_at",
+            "attributeRef": "lotus.last_observed_at"
+          },
+          {
+            "name": "groups[].lag_severity",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.lag_severity",
+            "attributeRef": "lotus.lag_severity"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_ingestion_slo_status_ingestion_health_slo_get",
+      "method": "GET",
+      "path": "/ingestion/health/slo",
+      "domain": "ingestion_operations",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Ingestion Operations"
+      ],
+      "summary": "Evaluate ingestion SLO status",
+      "description": "What: Evaluate ingestion SLO signals for failure rate, queue latency, and backlog age.\nHow: Compute lookback-window metrics and compare against caller thresholds.\nWhen: Use for alert evaluation, on-call triage, and operational readiness checks.",
+      "naming": {
+        "boundedContext": "ingestion_operations",
+        "canonicalTerms": [
+          "backlog_age_seconds",
+          "backlog_age_threshold_seconds",
+          "breach_backlog_age",
+          "breach_failure_rate",
+          "breach_queue_latency",
+          "failed_jobs",
+          "failure_rate",
+          "failure_rate_threshold",
+          "lookback_minutes",
+          "p95_queue_latency_seconds",
+          "queue_latency_threshold_seconds",
+          "total_jobs",
+          "x_lotus_ops_token"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "lookback_minutes",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.lookback_minutes",
+            "attributeRef": "lotus.lookback_minutes"
+          },
+          {
+            "name": "failure_rate_threshold",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.failure_rate_threshold",
+            "attributeRef": "lotus.failure_rate_threshold"
+          },
+          {
+            "name": "queue_latency_threshold_seconds",
+            "location": "query",
+            "required": false,
+            "type": "number",
+            "semanticId": "lotus.queue_latency_threshold_seconds",
+            "attributeRef": "lotus.queue_latency_threshold_seconds"
+          },
+          {
+            "name": "backlog_age_threshold_seconds",
+            "location": "query",
+            "required": false,
+            "type": "number",
+            "semanticId": "lotus.backlog_age_threshold_seconds",
+            "attributeRef": "lotus.backlog_age_threshold_seconds"
+          },
+          {
+            "name": "X-Lotus-Ops-Token",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_lotus_ops_token",
+            "attributeRef": "lotus.x_lotus_ops_token"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "IngestionSloStatusResponse",
+        "fields": [
+          {
+            "name": "lookback_minutes",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.lookback_minutes",
+            "attributeRef": "lotus.lookback_minutes"
+          },
+          {
+            "name": "total_jobs",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.total_jobs",
+            "attributeRef": "lotus.total_jobs"
+          },
+          {
+            "name": "failed_jobs",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.failed_jobs",
+            "attributeRef": "lotus.failed_jobs"
+          },
+          {
+            "name": "failure_rate",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.failure_rate",
+            "attributeRef": "lotus.failure_rate"
+          },
+          {
+            "name": "p95_queue_latency_seconds",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.p95_queue_latency_seconds",
+            "attributeRef": "lotus.p95_queue_latency_seconds"
+          },
+          {
+            "name": "backlog_age_seconds",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.backlog_age_seconds",
+            "attributeRef": "lotus.backlog_age_seconds"
+          },
+          {
+            "name": "breach_failure_rate",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.breach_failure_rate",
+            "attributeRef": "lotus.breach_failure_rate"
+          },
+          {
+            "name": "breach_queue_latency",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.breach_queue_latency",
+            "attributeRef": "lotus.breach_queue_latency"
+          },
+          {
+            "name": "breach_backlog_age",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.breach_backlog_age",
+            "attributeRef": "lotus.breach_backlog_age"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_ingestion_error_budget_status_ingestion_health_error_budget_get",
+      "method": "GET",
+      "path": "/ingestion/health/error-budget",
+      "domain": "ingestion_operations",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Ingestion Operations"
+      ],
+      "summary": "Get ingestion error-budget and backlog-growth status",
+      "description": "What: Return current error-budget consumption and backlog growth trend.\nHow: Compare failure/backlog metrics across current and previous lookback windows.\nWhen: Use for SRE-style burn-rate alerts and release-go/no-go operational checks.",
+      "naming": {
+        "boundedContext": "ingestion_operations",
+        "canonicalTerms": [
+          "backlog_growth",
+          "backlog_growth_threshold",
+          "backlog_jobs",
+          "breach_backlog_growth",
+          "breach_failure_rate",
+          "failed_jobs",
+          "failure_rate",
+          "failure_rate_threshold",
+          "lookback_minutes",
+          "previous_backlog_jobs",
+          "previous_lookback_minutes",
+          "remaining_error_budget",
+          "total_jobs",
+          "x_lotus_ops_token"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "lookback_minutes",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.lookback_minutes",
+            "attributeRef": "lotus.lookback_minutes"
+          },
+          {
+            "name": "failure_rate_threshold",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.failure_rate_threshold",
+            "attributeRef": "lotus.failure_rate_threshold"
+          },
+          {
+            "name": "backlog_growth_threshold",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.backlog_growth_threshold",
+            "attributeRef": "lotus.backlog_growth_threshold"
+          },
+          {
+            "name": "X-Lotus-Ops-Token",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_lotus_ops_token",
+            "attributeRef": "lotus.x_lotus_ops_token"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "IngestionErrorBudgetStatusResponse",
+        "fields": [
+          {
+            "name": "lookback_minutes",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.lookback_minutes",
+            "attributeRef": "lotus.lookback_minutes"
+          },
+          {
+            "name": "previous_lookback_minutes",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.previous_lookback_minutes",
+            "attributeRef": "lotus.previous_lookback_minutes"
+          },
+          {
+            "name": "total_jobs",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.total_jobs",
+            "attributeRef": "lotus.total_jobs"
+          },
+          {
+            "name": "failed_jobs",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.failed_jobs",
+            "attributeRef": "lotus.failed_jobs"
+          },
+          {
+            "name": "failure_rate",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.failure_rate",
+            "attributeRef": "lotus.failure_rate"
+          },
+          {
+            "name": "remaining_error_budget",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.remaining_error_budget",
+            "attributeRef": "lotus.remaining_error_budget"
+          },
+          {
+            "name": "backlog_jobs",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.backlog_jobs",
+            "attributeRef": "lotus.backlog_jobs"
+          },
+          {
+            "name": "previous_backlog_jobs",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.previous_backlog_jobs",
+            "attributeRef": "lotus.previous_backlog_jobs"
+          },
+          {
+            "name": "backlog_growth",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.backlog_growth",
+            "attributeRef": "lotus.backlog_growth"
+          },
+          {
+            "name": "breach_failure_rate",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.breach_failure_rate",
+            "attributeRef": "lotus.breach_failure_rate"
+          },
+          {
+            "name": "breach_backlog_growth",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.breach_backlog_growth",
+            "attributeRef": "lotus.breach_backlog_growth"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_ingestion_backlog_breakdown_ingestion_health_backlog_breakdown_get",
+      "method": "GET",
+      "path": "/ingestion/health/backlog-breakdown",
+      "domain": "ingestion_operations",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Ingestion Operations"
+      ],
+      "summary": "Get ingestion backlog breakdown by endpoint and entity",
+      "description": "What: Return grouped backlog/failure-rate metrics by endpoint and entity type.\nHow: Aggregate canonical ingestion jobs into endpoint/entity groups with oldest backlog age.\nWhen: Use to isolate the highest-impact ingestion pipeline segment during incidents.",
+      "naming": {
+        "boundedContext": "ingestion_operations",
+        "canonicalTerms": [
+          "accepted_jobs",
+          "backlog_jobs",
+          "endpoint",
+          "entity_type",
+          "failed_jobs",
+          "failure_rate",
+          "groups",
+          "limit",
+          "lookback_minutes",
+          "oldest_backlog_age_seconds",
+          "oldest_backlog_submitted_at",
+          "queued_jobs",
+          "total_backlog_jobs",
+          "total_jobs",
+          "x_lotus_ops_token"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "lookback_minutes",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.lookback_minutes",
+            "attributeRef": "lotus.lookback_minutes"
+          },
+          {
+            "name": "limit",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.limit",
+            "attributeRef": "lotus.limit"
+          },
+          {
+            "name": "X-Lotus-Ops-Token",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_lotus_ops_token",
+            "attributeRef": "lotus.x_lotus_ops_token"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "IngestionBacklogBreakdownResponse",
+        "fields": [
+          {
+            "name": "lookback_minutes",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.lookback_minutes",
+            "attributeRef": "lotus.lookback_minutes"
+          },
+          {
+            "name": "total_backlog_jobs",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.total_backlog_jobs",
+            "attributeRef": "lotus.total_backlog_jobs"
+          },
+          {
+            "name": "groups",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.groups",
+            "attributeRef": "lotus.groups"
+          },
+          {
+            "name": "groups[].endpoint",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.endpoint",
+            "attributeRef": "lotus.endpoint"
+          },
+          {
+            "name": "groups[].entity_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.entity_type",
+            "attributeRef": "lotus.entity_type"
+          },
+          {
+            "name": "groups[].total_jobs",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.total_jobs",
+            "attributeRef": "lotus.total_jobs"
+          },
+          {
+            "name": "groups[].accepted_jobs",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.accepted_jobs",
+            "attributeRef": "lotus.accepted_jobs"
+          },
+          {
+            "name": "groups[].queued_jobs",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.queued_jobs",
+            "attributeRef": "lotus.queued_jobs"
+          },
+          {
+            "name": "groups[].failed_jobs",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.failed_jobs",
+            "attributeRef": "lotus.failed_jobs"
+          },
+          {
+            "name": "groups[].backlog_jobs",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.backlog_jobs",
+            "attributeRef": "lotus.backlog_jobs"
+          },
+          {
+            "name": "groups[].oldest_backlog_submitted_at",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.oldest_backlog_submitted_at",
+            "attributeRef": "lotus.oldest_backlog_submitted_at"
+          },
+          {
+            "name": "groups[].oldest_backlog_age_seconds",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.oldest_backlog_age_seconds",
+            "attributeRef": "lotus.oldest_backlog_age_seconds"
+          },
+          {
+            "name": "groups[].failure_rate",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.failure_rate",
+            "attributeRef": "lotus.failure_rate"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "list_ingestion_stalled_jobs_ingestion_health_stalled_jobs_get",
+      "method": "GET",
+      "path": "/ingestion/health/stalled-jobs",
+      "domain": "ingestion_operations",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Ingestion Operations"
+      ],
+      "summary": "List stalled ingestion jobs",
+      "description": "What: List ingestion jobs stalled in accepted/queued state beyond threshold.\nHow: Filter canonical jobs by age and status, then attach runbook-oriented suggestions.\nWhen: Use to identify concrete stuck jobs requiring operator intervention.",
+      "naming": {
+        "boundedContext": "ingestion_operations",
+        "canonicalTerms": [
+          "endpoint",
+          "entity_type",
+          "job_id",
+          "jobs",
+          "limit",
+          "queue_age_seconds",
+          "retry_count",
+          "status",
+          "submitted_at",
+          "suggested_action",
+          "threshold_seconds",
+          "total",
+          "x_lotus_ops_token"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "threshold_seconds",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.threshold_seconds",
+            "attributeRef": "lotus.threshold_seconds"
+          },
+          {
+            "name": "limit",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.limit",
+            "attributeRef": "lotus.limit"
+          },
+          {
+            "name": "X-Lotus-Ops-Token",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_lotus_ops_token",
+            "attributeRef": "lotus.x_lotus_ops_token"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "IngestionStalledJobListResponse",
+        "fields": [
+          {
+            "name": "threshold_seconds",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.threshold_seconds",
+            "attributeRef": "lotus.threshold_seconds"
+          },
+          {
+            "name": "total",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.total",
+            "attributeRef": "lotus.total"
+          },
+          {
+            "name": "jobs",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.jobs",
+            "attributeRef": "lotus.jobs"
+          },
+          {
+            "name": "jobs[].job_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.job_id",
+            "attributeRef": "lotus.job_id"
+          },
+          {
+            "name": "jobs[].endpoint",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.endpoint",
+            "attributeRef": "lotus.endpoint"
+          },
+          {
+            "name": "jobs[].entity_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.entity_type",
+            "attributeRef": "lotus.entity_type"
+          },
+          {
+            "name": "jobs[].status",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.status",
+            "attributeRef": "lotus.status"
+          },
+          {
+            "name": "jobs[].submitted_at",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.submitted_at",
+            "attributeRef": "lotus.submitted_at"
+          },
+          {
+            "name": "jobs[].queue_age_seconds",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.queue_age_seconds",
+            "attributeRef": "lotus.queue_age_seconds"
+          },
+          {
+            "name": "jobs[].retry_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.retry_count",
+            "attributeRef": "lotus.retry_count"
+          },
+          {
+            "name": "jobs[].suggested_action",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.suggested_action",
+            "attributeRef": "lotus.suggested_action"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "list_consumer_dlq_events_ingestion_dlq_consumer_events_get",
+      "method": "GET",
+      "path": "/ingestion/dlq/consumer-events",
+      "domain": "ingestion_operations",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Ingestion Operations"
+      ],
+      "summary": "List consumer dead-letter events",
+      "description": "What: Return dead-letter events produced by downstream consumers.\nHow: Query persisted consumer DLQ audit records with optional topic/group filters.\nWhen: Use to investigate consumer-side validation/processing failures without DB access.",
+      "naming": {
+        "boundedContext": "ingestion_operations",
+        "canonicalTerms": [
+          "consumer_group",
+          "correlation_id",
+          "dlq_topic",
+          "error_reason",
+          "event_id",
+          "events",
+          "limit",
+          "observed_at",
+          "original_key",
+          "original_topic",
+          "payload_excerpt",
+          "total",
+          "x_lotus_ops_token"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "limit",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.limit",
+            "attributeRef": "lotus.limit"
+          },
+          {
+            "name": "original_topic",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.original_topic",
+            "attributeRef": "lotus.original_topic"
+          },
+          {
+            "name": "consumer_group",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.consumer_group",
+            "attributeRef": "lotus.consumer_group"
+          },
+          {
+            "name": "X-Lotus-Ops-Token",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_lotus_ops_token",
+            "attributeRef": "lotus.x_lotus_ops_token"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "ConsumerDlqEventListResponse",
+        "fields": [
+          {
+            "name": "events",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.events",
+            "attributeRef": "lotus.events"
+          },
+          {
+            "name": "events[].event_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.event_id",
+            "attributeRef": "lotus.event_id"
+          },
+          {
+            "name": "events[].original_topic",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.original_topic",
+            "attributeRef": "lotus.original_topic"
+          },
+          {
+            "name": "events[].consumer_group",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.consumer_group",
+            "attributeRef": "lotus.consumer_group"
+          },
+          {
+            "name": "events[].dlq_topic",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.dlq_topic",
+            "attributeRef": "lotus.dlq_topic"
+          },
+          {
+            "name": "events[].original_key",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.original_key",
+            "attributeRef": "lotus.original_key"
+          },
+          {
+            "name": "events[].error_reason",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.error_reason",
+            "attributeRef": "lotus.error_reason"
+          },
+          {
+            "name": "events[].correlation_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.correlation_id",
+            "attributeRef": "lotus.correlation_id"
+          },
+          {
+            "name": "events[].payload_excerpt",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.payload_excerpt",
+            "attributeRef": "lotus.payload_excerpt"
+          },
+          {
+            "name": "events[].observed_at",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.observed_at",
+            "attributeRef": "lotus.observed_at"
+          },
+          {
+            "name": "total",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.total",
+            "attributeRef": "lotus.total"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "replay_consumer_dlq_event_ingestion_dlq_consumer_events__event_id__replay_post",
+      "method": "POST",
+      "path": "/ingestion/dlq/consumer-events/{event_id}/replay",
+      "domain": "ingestion_operations",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Ingestion Operations"
+      ],
+      "summary": "Replay ingestion payload for correlated consumer DLQ event",
+      "description": "What: Replay canonical ingestion payload correlated to a consumer DLQ event.\nHow: Resolve DLQ event -> correlation_id -> ingestion job with durable payload, then republish.\nWhen: Use after fixing downstream consumer defects to recover rejected events safely.",
+      "naming": {
+        "boundedContext": "ingestion_operations",
+        "canonicalTerms": [
+          "correlation_id",
+          "dry_run",
+          "event_id",
+          "job_id",
+          "message",
+          "replay_status",
+          "x_lotus_ops_token"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "event_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.event_id",
+            "attributeRef": "lotus.event_id"
+          },
+          {
+            "name": "X-Lotus-Ops-Token",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_lotus_ops_token",
+            "attributeRef": "lotus.x_lotus_ops_token"
+          },
+          {
+            "name": "dry_run",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.dry_run",
+            "attributeRef": "lotus.dry_run"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "ConsumerDlqReplayResponse",
+        "fields": [
+          {
+            "name": "event_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.event_id",
+            "attributeRef": "lotus.event_id"
+          },
+          {
+            "name": "correlation_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.correlation_id",
+            "attributeRef": "lotus.correlation_id"
+          },
+          {
+            "name": "job_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.job_id",
+            "attributeRef": "lotus.job_id"
+          },
+          {
+            "name": "replay_status",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.replay_status",
+            "attributeRef": "lotus.replay_status"
+          },
+          {
+            "name": "message",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.message",
+            "attributeRef": "lotus.message"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_ingestion_ops_control_ingestion_ops_control_get",
+      "method": "GET",
+      "path": "/ingestion/ops/control",
+      "domain": "ingestion_operations",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Ingestion Operations"
+      ],
+      "summary": "Get ingestion operations control mode",
+      "description": "What: Return current ingestion control mode and replay window.\nHow: Read canonical ingestion operations control state.\nWhen: Use before maintenance, pause/drain actions, or controlled replay operations.",
+      "naming": {
+        "boundedContext": "ingestion_operations",
+        "canonicalTerms": [
+          "mode",
+          "replay_window_end",
+          "replay_window_start",
+          "updated_at",
+          "updated_by",
+          "x_lotus_ops_token"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "X-Lotus-Ops-Token",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_lotus_ops_token",
+            "attributeRef": "lotus.x_lotus_ops_token"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "IngestionOpsModeResponse",
+        "fields": [
+          {
+            "name": "mode",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.mode",
+            "attributeRef": "lotus.mode"
+          },
+          {
+            "name": "replay_window_start",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.replay_window_start",
+            "attributeRef": "lotus.replay_window_start"
+          },
+          {
+            "name": "replay_window_end",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.replay_window_end",
+            "attributeRef": "lotus.replay_window_end"
+          },
+          {
+            "name": "updated_by",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.updated_by",
+            "attributeRef": "lotus.updated_by"
+          },
+          {
+            "name": "updated_at",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.updated_at",
+            "attributeRef": "lotus.updated_at"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "update_ingestion_ops_control_ingestion_ops_control_put",
+      "method": "PUT",
+      "path": "/ingestion/ops/control",
+      "domain": "ingestion_operations",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Ingestion Operations"
+      ],
+      "summary": "Update ingestion operations control mode",
+      "description": "What: Update ingestion control mode and optional replay window.\nHow: Persist operational mode transition with validation on replay window boundaries.\nWhen: Use for planned maintenance, controlled drain, or replay governance actions.",
+      "naming": {
+        "boundedContext": "ingestion_operations",
+        "canonicalTerms": [
+          "mode",
+          "replay_window_end",
+          "replay_window_start",
+          "updated_at",
+          "updated_by",
+          "x_lotus_ops_token"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "X-Lotus-Ops-Token",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_lotus_ops_token",
+            "attributeRef": "lotus.x_lotus_ops_token"
+          },
+          {
+            "name": "mode",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.mode",
+            "attributeRef": "lotus.mode"
+          },
+          {
+            "name": "replay_window_start",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.replay_window_start",
+            "attributeRef": "lotus.replay_window_start"
+          },
+          {
+            "name": "replay_window_end",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.replay_window_end",
+            "attributeRef": "lotus.replay_window_end"
+          },
+          {
+            "name": "updated_by",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.updated_by",
+            "attributeRef": "lotus.updated_by"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "IngestionOpsModeResponse",
+        "fields": [
+          {
+            "name": "mode",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.mode",
+            "attributeRef": "lotus.mode"
+          },
+          {
+            "name": "replay_window_start",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.replay_window_start",
+            "attributeRef": "lotus.replay_window_start"
+          },
+          {
+            "name": "replay_window_end",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.replay_window_end",
+            "attributeRef": "lotus.replay_window_end"
+          },
+          {
+            "name": "updated_by",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.updated_by",
+            "attributeRef": "lotus.updated_by"
+          },
+          {
+            "name": "updated_at",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.updated_at",
+            "attributeRef": "lotus.updated_at"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_ingestion_idempotency_diagnostics_ingestion_idempotency_diagnostics_get",
+      "method": "GET",
+      "path": "/ingestion/idempotency/diagnostics",
+      "domain": "ingestion_operations",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Ingestion Operations"
+      ],
+      "summary": "Get idempotency key diagnostics",
+      "description": "What: Return operational diagnostics for ingestion idempotency key reuse and collisions.\nHow: Aggregate ingestion jobs by idempotency key and detect multi-endpoint collisions.\nWhen: Use to detect client integration anti-patterns before they create replay ambiguity.",
+      "naming": {
+        "boundedContext": "ingestion_operations",
+        "canonicalTerms": [
+          "collision_detected",
+          "collisions",
+          "endpoint_count",
+          "endpoints",
+          "first_seen_at",
+          "idempotency_key",
+          "keys",
+          "last_seen_at",
+          "limit",
+          "lookback_minutes",
+          "total_keys",
+          "usage_count",
+          "x_lotus_ops_token"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "lookback_minutes",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.lookback_minutes",
+            "attributeRef": "lotus.lookback_minutes"
+          },
+          {
+            "name": "limit",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.limit",
+            "attributeRef": "lotus.limit"
+          },
+          {
+            "name": "X-Lotus-Ops-Token",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_lotus_ops_token",
+            "attributeRef": "lotus.x_lotus_ops_token"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "IngestionIdempotencyDiagnosticsResponse",
+        "fields": [
+          {
+            "name": "lookback_minutes",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.lookback_minutes",
+            "attributeRef": "lotus.lookback_minutes"
+          },
+          {
+            "name": "total_keys",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.total_keys",
+            "attributeRef": "lotus.total_keys"
+          },
+          {
+            "name": "collisions",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.collisions",
+            "attributeRef": "lotus.collisions"
+          },
+          {
+            "name": "keys",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.keys",
+            "attributeRef": "lotus.keys"
+          },
+          {
+            "name": "keys[].idempotency_key",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.idempotency_key",
+            "attributeRef": "lotus.idempotency_key"
+          },
+          {
+            "name": "keys[].usage_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.usage_count",
+            "attributeRef": "lotus.usage_count"
+          },
+          {
+            "name": "keys[].endpoint_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.endpoint_count",
+            "attributeRef": "lotus.endpoint_count"
+          },
+          {
+            "name": "keys[].endpoints",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.endpoints",
+            "attributeRef": "lotus.endpoints"
+          },
+          {
+            "name": "keys[].first_seen_at",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.first_seen_at",
+            "attributeRef": "lotus.first_seen_at"
+          },
+          {
+            "name": "keys[].last_seen_at",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.last_seen_at",
+            "attributeRef": "lotus.last_seen_at"
+          },
+          {
+            "name": "keys[].collision_detected",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.collision_detected",
+            "attributeRef": "lotus.collision_detected"
           }
         ]
       }

--- a/scripts/docker_endpoint_smoke.py
+++ b/scripts/docker_endpoint_smoke.py
@@ -267,6 +267,7 @@ def main() -> int:
     results: list[CheckResult] = []
     ingest = args.ingestion_base_url
     query = args.query_base_url
+    ops_headers = {"X-Lotus-Ops-Token": "lotus-core-ops-local"}
 
     _call(results, name="ing live", method="GET", url=f"{ingest}/health/live", expected={200})
     _call(results, name="ing ready", method="GET", url=f"{ingest}/health/ready", expected={200})
@@ -277,6 +278,7 @@ def main() -> int:
         method="PUT",
         url=f"{ingest}/ingestion/ops/control",
         expected={200},
+        headers=ops_headers,
         json={"mode": "normal", "updated_by": "deterministic_smoke"},
     )
 
@@ -501,6 +503,7 @@ def main() -> int:
         method="GET",
         url=f"{ingest}/ingestion/jobs?limit=10",
         expected={200},
+        headers=ops_headers,
     )
     job_id: str | None = None
     if jobs_response is not None and jobs_response.status_code == 200:
@@ -515,6 +518,7 @@ def main() -> int:
             method="GET",
             url=f"{ingest}/ingestion/jobs/{job_id}",
             expected={200},
+            headers=ops_headers,
         )
         _call(
             results,
@@ -522,6 +526,15 @@ def main() -> int:
             method="GET",
             url=f"{ingest}/ingestion/jobs/{job_id}/failures",
             expected={200},
+            headers=ops_headers,
+        )
+        _call(
+            results,
+            name="job record status",
+            method="GET",
+            url=f"{ingest}/ingestion/jobs/{job_id}/records",
+            expected={200},
+            headers=ops_headers,
         )
         _call(
             results,
@@ -529,6 +542,7 @@ def main() -> int:
             method="POST",
             url=f"{ingest}/ingestion/jobs/{job_id}/retry",
             expected={200},
+            headers=ops_headers,
             json={"dry_run": True, "record_keys": []},
         )
     else:
@@ -550,6 +564,7 @@ def main() -> int:
         method="GET",
         url=f"{ingest}/ingestion/health/summary",
         expected={200},
+        headers=ops_headers,
     )
     _call(
         results,
@@ -557,6 +572,7 @@ def main() -> int:
         method="GET",
         url=f"{ingest}/ingestion/health/lag",
         expected={200},
+        headers=ops_headers,
     )
     _call(
         results,
@@ -564,6 +580,23 @@ def main() -> int:
         method="GET",
         url=f"{ingest}/ingestion/health/slo",
         expected={200},
+        headers=ops_headers,
+    )
+    _call(
+        results,
+        name="health consumer lag",
+        method="GET",
+        url=f"{ingest}/ingestion/health/consumer-lag",
+        expected={200},
+        headers=ops_headers,
+    )
+    _call(
+        results,
+        name="health error budget",
+        method="GET",
+        url=f"{ingest}/ingestion/health/error-budget",
+        expected={200},
+        headers=ops_headers,
     )
     _call(
         results,
@@ -571,6 +604,15 @@ def main() -> int:
         method="GET",
         url=f"{ingest}/ingestion/dlq/consumer-events?limit=10",
         expected={200},
+        headers=ops_headers,
+    )
+    _call(
+        results,
+        name="idempotency diagnostics",
+        method="GET",
+        url=f"{ingest}/ingestion/idempotency/diagnostics?limit=10",
+        expected={200},
+        headers=ops_headers,
     )
     _call(
         results,

--- a/src/services/ingestion_service/app/ops_controls.py
+++ b/src/services/ingestion_service/app/ops_controls.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import os
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from threading import Lock
+from typing import Annotated
+
+from fastapi import Header, HTTPException, Request, status
+
+
+def _as_bool(value: str | None, default: bool) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+OPS_TOKEN_REQUIRED = _as_bool(os.getenv("LOTUS_CORE_INGEST_OPS_TOKEN_REQUIRED"), True)
+OPS_TOKEN_VALUE = os.getenv("LOTUS_CORE_INGEST_OPS_TOKEN", "lotus-core-ops-local")
+
+RATE_LIMIT_ENABLED = _as_bool(os.getenv("LOTUS_CORE_INGEST_RATE_LIMIT_ENABLED"), True)
+RATE_LIMIT_WINDOW_SECONDS = int(os.getenv("LOTUS_CORE_INGEST_RATE_LIMIT_WINDOW_SECONDS", "60"))
+RATE_LIMIT_MAX_REQUESTS = int(os.getenv("LOTUS_CORE_INGEST_RATE_LIMIT_MAX_REQUESTS", "120"))
+RATE_LIMIT_MAX_RECORDS = int(os.getenv("LOTUS_CORE_INGEST_RATE_LIMIT_MAX_RECORDS", "10000"))
+
+OpsTokenHeader = Annotated[
+    str | None,
+    Header(
+        alias="X-Lotus-Ops-Token",
+        description=(
+            "Operations token for privileged ingestion runbook APIs "
+            "(health controls, retry, DLQ triage, idempotency diagnostics)."
+        ),
+    ),
+]
+
+
+@dataclass(slots=True)
+class _WriteEvent:
+    observed_at: datetime
+    record_count: int
+
+
+_write_events: dict[str, deque[_WriteEvent]] = defaultdict(deque)
+_rate_limit_lock = Lock()
+
+
+def _evict_expired(events: deque[_WriteEvent], now_utc: datetime) -> None:
+    cutoff = now_utc - timedelta(seconds=RATE_LIMIT_WINDOW_SECONDS)
+    while events and events[0].observed_at < cutoff:
+        events.popleft()
+
+
+def enforce_ingestion_write_rate_limit(*, endpoint: str, record_count: int) -> None:
+    if not RATE_LIMIT_ENABLED:
+        return
+    if record_count < 1:
+        record_count = 1
+
+    now_utc = datetime.now(UTC)
+    with _rate_limit_lock:
+        events = _write_events[endpoint]
+        _evict_expired(events, now_utc)
+        current_requests = len(events)
+        current_records = sum(item.record_count for item in events)
+        projected_requests = current_requests + 1
+        projected_records = current_records + record_count
+        if (
+            projected_requests > RATE_LIMIT_MAX_REQUESTS
+            or projected_records > RATE_LIMIT_MAX_RECORDS
+        ):
+            raise PermissionError(
+                "Ingestion write rate limit exceeded. "
+                f"window_seconds={RATE_LIMIT_WINDOW_SECONDS}, "
+                f"max_requests={RATE_LIMIT_MAX_REQUESTS}, "
+                f"max_records={RATE_LIMIT_MAX_RECORDS}."
+            )
+        events.append(_WriteEvent(observed_at=now_utc, record_count=record_count))
+
+
+async def require_ops_token(
+    request: Request,
+    ops_token: OpsTokenHeader = None,
+) -> str:
+    if not OPS_TOKEN_REQUIRED:
+        return "ops-token-not-required"
+    if not ops_token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={
+                "code": "INGESTION_OPS_TOKEN_REQUIRED",
+                "message": (
+                    "Missing X-Lotus-Ops-Token header for privileged ingestion operations API."
+                ),
+            },
+        )
+    if ops_token != OPS_TOKEN_VALUE:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "code": "INGESTION_OPS_TOKEN_INVALID",
+                "message": "Invalid X-Lotus-Ops-Token.",
+            },
+        )
+    return request.headers.get("X-Principal", "ops-token")

--- a/src/services/ingestion_service/app/routers/business_dates.py
+++ b/src/services/ingestion_service/app/routers/business_dates.py
@@ -4,6 +4,7 @@ import logging
 from app.ack_response import build_batch_ack
 from app.DTOs.business_date_dto import BusinessDateIngestionRequest
 from app.DTOs.ingestion_ack_dto import BatchIngestionAcceptedResponse
+from app.ops_controls import enforce_ingestion_write_rate_limit
 from app.request_metadata import (
     IdempotencyKeyHeader,
     create_ingestion_job_id,
@@ -48,6 +49,15 @@ async def ingest_business_dates(
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail={"code": "INGESTION_MODE_BLOCKS_WRITES", "message": str(exc)},
+        ) from exc
+    try:
+        enforce_ingestion_write_rate_limit(
+            endpoint="/ingest/business-dates", record_count=len(request.business_dates)
+        )
+    except PermissionError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail={"code": "INGESTION_RATE_LIMIT_EXCEEDED", "message": str(exc)},
         ) from exc
     num_dates = len(request.business_dates)
     job_id = create_ingestion_job_id()

--- a/src/services/ingestion_service/app/routers/instruments.py
+++ b/src/services/ingestion_service/app/routers/instruments.py
@@ -4,6 +4,7 @@ import logging
 from app.ack_response import build_batch_ack
 from app.DTOs.ingestion_ack_dto import BatchIngestionAcceptedResponse
 from app.DTOs.instrument_dto import InstrumentIngestionRequest
+from app.ops_controls import enforce_ingestion_write_rate_limit
 from app.request_metadata import (
     IdempotencyKeyHeader,
     create_ingestion_job_id,
@@ -48,6 +49,15 @@ async def ingest_instruments(
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail={"code": "INGESTION_MODE_BLOCKS_WRITES", "message": str(exc)},
+        ) from exc
+    try:
+        enforce_ingestion_write_rate_limit(
+            endpoint="/ingest/instruments", record_count=len(request.instruments)
+        )
+    except PermissionError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail={"code": "INGESTION_RATE_LIMIT_EXCEEDED", "message": str(exc)},
         ) from exc
     num_instruments = len(request.instruments)
     job_id = create_ingestion_job_id()

--- a/src/services/ingestion_service/app/routers/market_prices.py
+++ b/src/services/ingestion_service/app/routers/market_prices.py
@@ -4,6 +4,7 @@ import logging
 from app.ack_response import build_batch_ack
 from app.DTOs.ingestion_ack_dto import BatchIngestionAcceptedResponse
 from app.DTOs.market_price_dto import MarketPriceIngestionRequest
+from app.ops_controls import enforce_ingestion_write_rate_limit
 from app.request_metadata import (
     IdempotencyKeyHeader,
     create_ingestion_job_id,
@@ -48,6 +49,15 @@ async def ingest_market_prices(
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail={"code": "INGESTION_MODE_BLOCKS_WRITES", "message": str(exc)},
+        ) from exc
+    try:
+        enforce_ingestion_write_rate_limit(
+            endpoint="/ingest/market-prices", record_count=len(request.market_prices)
+        )
+    except PermissionError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail={"code": "INGESTION_RATE_LIMIT_EXCEEDED", "message": str(exc)},
         ) from exc
     num_prices = len(request.market_prices)
     job_id = create_ingestion_job_id()

--- a/src/services/query_service/app/routers/operations.py
+++ b/src/services/query_service/app/routers/operations.py
@@ -30,8 +30,9 @@ def get_operations_service(
     responses={status.HTTP_404_NOT_FOUND: {"description": "Portfolio not found."}},
     summary="Get operational support overview for a portfolio",
     description=(
-        "Returns support-oriented operational state for a portfolio, including "
-        "reprocessing/valuation queue indicators and latest data availability markers."
+        "What: Return support-oriented operational state for one portfolio.\n"
+        "How: Aggregate reprocessing, valuation, and latest-data availability markers for the key.\n"
+        "When: Use during incidents to quickly assess whether portfolio processing is healthy."
     ),
 )
 async def get_support_overview(
@@ -55,8 +56,9 @@ async def get_support_overview(
     responses={status.HTTP_404_NOT_FOUND: {"description": "Portfolio not found."}},
     summary="List valuation jobs for support workflows",
     description=(
-        "Returns valuation jobs for a portfolio with pagination and optional status filtering. "
-        "Designed for operations/support dashboards."
+        "What: List valuation jobs for a portfolio with support filters.\n"
+        "How: Query valuation job records with pagination and optional status filtering.\n"
+        "When: Use to triage stuck valuation workloads and verify drain progress."
     ),
 )
 async def get_valuation_jobs(
@@ -88,8 +90,9 @@ async def get_valuation_jobs(
     responses={status.HTTP_404_NOT_FOUND: {"description": "Portfolio not found."}},
     summary="List aggregation jobs for support workflows",
     description=(
-        "Returns aggregation jobs for a portfolio with pagination and optional status filtering. "
-        "Designed for operations/support dashboards."
+        "What: List portfolio aggregation jobs for support workflows.\n"
+        "How: Query aggregation job records with pagination and optional status filtering.\n"
+        "When: Use when portfolio rollups are stale or downstream timeseries appears delayed."
     ),
 )
 async def get_aggregation_jobs(
@@ -121,8 +124,9 @@ async def get_aggregation_jobs(
     responses={status.HTTP_404_NOT_FOUND: {"description": "Portfolio/security lineage not found."}},
     summary="Get lineage state for a portfolio-security key",
     description=(
-        "Returns lineage-relevant state (epoch, watermark, latest artifacts) "
-        "for a specific portfolio-security key."
+        "What: Return lineage state for one portfolio-security key.\n"
+        "How: Read epoch, watermark, and latest artifact pointers from lineage state services.\n"
+        "When: Use during replay/reprocessing investigations for deterministic state validation."
     ),
 )
 async def get_lineage(
@@ -150,8 +154,9 @@ async def get_lineage(
     responses={status.HTTP_404_NOT_FOUND: {"description": "Portfolio not found."}},
     summary="List lineage keys for a portfolio",
     description=(
-        "Returns current lineage keys (portfolio-security state rows) for a portfolio with "
-        "pagination and optional status/security filtering."
+        "What: List lineage keys for a portfolio.\n"
+        "How: Query portfolio-security lineage rows with status/security filters and pagination.\n"
+        "When: Use to scope impacted keys before running replay, backfill, or targeted recovery."
     ),
 )
 async def get_lineage_keys(
@@ -182,4 +187,3 @@ async def get_lineage_keys(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An unexpected server error occurred while listing lineage keys.",
         )
-


### PR DESCRIPTION
## Summary\n- add privileged ingestion ops auth token and write rate limiting\n- add consumer-lag, error-budget, idempotency diagnostics, record-status, and DLQ replay APIs\n- improve query operations docs with What/How/When descriptions\n- update deterministic docker smoke to cover new protected ops endpoints\n- add CI docker smoke contract job with artifact upload retention\n- regenerate lotus-core API vocabulary inventory\n\n## Validation\n- make lint\n- make typecheck\n- python -m pytest tests/integration/services/ingestion_service/test_ingestion_routers.py -q\n- python scripts/openapi_quality_gate.py\n- python scripts/api_vocabulary_inventory.py --validate-only\n- python scripts/ingestion_endpoint_contract_gate.py