### PR TITLE
feat(ingestion): require docker smoke and harden DLQ replay auditing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
     if: >
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-docker-smoke'))
+      github.event_name == 'pull_request'
     needs: [quality, coverage-gate]
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/alembic/versions/b2c3d4e5f6a7_feat_add_consumer_dlq_replay_audit_table.py
+++ b/alembic/versions/b2c3d4e5f6a7_feat_add_consumer_dlq_replay_audit_table.py
@@ -1,0 +1,86 @@
+"""feat: add consumer dlq replay audit table
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-03-01 10:35:00
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b2c3d4e5f6a7"
+down_revision: Union[str, None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "consumer_dlq_replay_audit",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("replay_id", sa.String(), nullable=False),
+        sa.Column("event_id", sa.String(), nullable=False),
+        sa.Column("replay_fingerprint", sa.String(), nullable=False),
+        sa.Column("correlation_id", sa.String(), nullable=True),
+        sa.Column("job_id", sa.String(), nullable=True),
+        sa.Column("endpoint", sa.String(), nullable=True),
+        sa.Column("replay_status", sa.String(), nullable=False),
+        sa.Column("dry_run", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.Column("replay_reason", sa.Text(), nullable=False),
+        sa.Column("requested_by", sa.String(), nullable=True),
+        sa.Column(
+            "requested_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_consumer_dlq_replay_audit_replay_id",
+        "consumer_dlq_replay_audit",
+        ["replay_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_consumer_dlq_replay_audit_event_id",
+        "consumer_dlq_replay_audit",
+        ["event_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_consumer_dlq_replay_audit_replay_fingerprint",
+        "consumer_dlq_replay_audit",
+        ["replay_fingerprint"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_consumer_dlq_replay_audit_replay_status",
+        "consumer_dlq_replay_audit",
+        ["replay_status"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_consumer_dlq_replay_audit_job_id",
+        "consumer_dlq_replay_audit",
+        ["job_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_consumer_dlq_replay_audit_job_id", table_name="consumer_dlq_replay_audit")
+    op.drop_index(
+        "ix_consumer_dlq_replay_audit_replay_status", table_name="consumer_dlq_replay_audit"
+    )
+    op.drop_index(
+        "ix_consumer_dlq_replay_audit_replay_fingerprint", table_name="consumer_dlq_replay_audit"
+    )
+    op.drop_index("ix_consumer_dlq_replay_audit_event_id", table_name="consumer_dlq_replay_audit")
+    op.drop_index("ix_consumer_dlq_replay_audit_replay_id", table_name="consumer_dlq_replay_audit")
+    op.drop_table("consumer_dlq_replay_audit")

--- a/docs/standards/api-vocabulary/lotus-core-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-core-api-vocabulary.v1.json
@@ -13,7 +13,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-03-01T02:11:43.652261+00:00",
+  "generatedAt": "2026-03-01T02:28:27.332756+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.accepted_count",
@@ -2854,6 +2854,34 @@
       ],
       "observedTypes": [
         "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.replay_audit_id",
+      "canonicalTerm": "replay_audit_id",
+      "preferredName": "replay_audit_id",
+      "description": "Durable replay audit identifier for this replay attempt.",
+      "example": "REPLAY_AUDIT_001",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.replay_fingerprint",
+      "canonicalTerm": "replay_fingerprint",
+      "preferredName": "replay_fingerprint",
+      "description": "Deterministic fingerprint for this replay mapping and payload.",
+      "example": "replay_fingerprint_example",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
       ]
     },
     {
@@ -15003,6 +15031,8 @@
           "event_id",
           "job_id",
           "message",
+          "replay_audit_id",
+          "replay_fingerprint",
           "replay_status",
           "x_lotus_ops_token"
         ]
@@ -15070,6 +15100,22 @@
             "type": "string",
             "semanticId": "lotus.replay_status",
             "attributeRef": "lotus.replay_status"
+          },
+          {
+            "name": "replay_audit_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.replay_audit_id",
+            "attributeRef": "lotus.replay_audit_id"
+          },
+          {
+            "name": "replay_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.replay_fingerprint",
+            "attributeRef": "lotus.replay_fingerprint"
           },
           {
             "name": "message",

--- a/src/libs/portfolio-common/portfolio_common/database_models.py
+++ b/src/libs/portfolio-common/portfolio_common/database_models.py
@@ -12,7 +12,6 @@ from sqlalchemy import (
     Boolean,
     JSON,
     Index,
-    PrimaryKeyConstraint,
     Text,
 )
 from sqlalchemy.orm import relationship
@@ -529,6 +528,24 @@ class ConsumerDlqEvent(Base):
     correlation_id = Column(String, nullable=True)
     payload_excerpt = Column(Text, nullable=True)
     observed_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+
+class ConsumerDlqReplayAudit(Base):
+    __tablename__ = "consumer_dlq_replay_audit"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    replay_id = Column(String, unique=True, index=True, nullable=False)
+    event_id = Column(String, index=True, nullable=False)
+    replay_fingerprint = Column(String, index=True, nullable=False)
+    correlation_id = Column(String, nullable=True)
+    job_id = Column(String, nullable=True, index=True)
+    endpoint = Column(String, nullable=True)
+    replay_status = Column(String, nullable=False, index=True)
+    dry_run = Column(Boolean, nullable=False, server_default="f")
+    replay_reason = Column(Text, nullable=False)
+    requested_by = Column(String, nullable=True)
+    requested_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    completed_at = Column(DateTime(timezone=True), nullable=True)
 
 
 class PositionState(Base):

--- a/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
+++ b/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
@@ -507,9 +507,24 @@ class ConsumerDlqReplayResponse(BaseModel):
         description="Correlated ingestion job replayed from durable payload.",
         examples=["job_01J5S0J6D3BAVMK2E1V0WQ7MCC"],
     )
-    replay_status: Literal["dry_run", "replayed", "not_replayable"] = Field(
+    replay_status: Literal[
+        "dry_run",
+        "replayed",
+        "not_replayable",
+        "duplicate_blocked",
+    ] = Field(
         description="Replay execution result.",
         examples=["replayed"],
+    )
+    replay_audit_id: str | None = Field(
+        default=None,
+        description="Durable replay audit identifier for this replay attempt.",
+        examples=["replay_01J5WK1G7S3HBQ7Q3M0E3TMT0P"],
+    )
+    replay_fingerprint: str | None = Field(
+        default=None,
+        description="Deterministic fingerprint for this replay mapping and payload.",
+        examples=["c5b0faeb7de60bc111f109624e58d0ad6206634be5fef4d4455cdac629df4f3f"],
     )
     message: str = Field(
         description="Human-readable replay outcome for runbook workflows.",


### PR DESCRIPTION
## Summary\n- make Docker Smoke Contract run on every PR so it can be branch-protection required\n- harden DLQ replay mapping with deterministic replay fingerprinting\n- add durable replay audit table (consumer_dlq_replay_audit) and persistence service methods\n- block duplicate replay for already-successful deterministic fingerprints\n- extend replay response with eplay_audit_id and eplay_fingerprint\n- regenerate lotus-core API vocabulary inventory\n\n## Validation\n- python -m pytest tests/integration/services/ingestion_service/test_ingestion_routers.py -q\n- python scripts/migration_contract_check.py --mode alembic-sql\n- make typecheck\n- python scripts/openapi_quality_gate.py\n- python scripts/api_vocabulary_inventory.py --validate-only