### PR TITLE
docs: finalize transaction RFC metadata and tracking wording

### DIFF
--- a/docs/RFCs/RFC 059 - BUY Transaction RFC Implementation Plan.md
+++ b/docs/RFCs/RFC 059 - BUY Transaction RFC Implementation Plan.md
@@ -383,7 +383,7 @@ Use the following board in PR descriptions and weekly status updates:
 | 3 | Calculations + invariants | DONE | lotus-core engineering | merged | local + CI green | `BUY-SLICE-3-CALCULATION-INVARIANTS.md` + financial engine tests | Canonical BUY invariants and explicit realized P&L zero behavior enforced. |
 | 4 | Position/lot/cash/offset | DONE | lotus-core engineering | merged | local + CI green | `BUY-SLICE-4-LOT-CASH-OFFSET.md` + integration tests | Durable lot and accrued-offset state added with linkage propagation. |
 | 5 | Query + observability | DONE | lotus-core engineering | merged | local + CI green | `BUY-SLICE-5-QUERY-OBSERVABILITY.md` + query tests | BUY lot/offset/cash-linkage endpoints and lifecycle telemetry implemented. |
-| 6 | Final conformance gate | DONE | lotus-core engineering | pending | local green | `BUY-SLICE-6-CONFORMANCE-REPORT.md` + `buy-rfc` suite | Final section-level conformance map and dedicated CI regression suite added. |
+| 6 | Final conformance gate | DONE | lotus-core engineering | merged | local + CI green | `BUY-SLICE-6-CONFORMANCE-REPORT.md` + `buy-rfc` suite | Final section-level conformance map and dedicated CI regression suite added. |
 
 Status values:
 

--- a/docs/rfc-transaction-specs/transactions/BUY/RFC-BUY-01.md
+++ b/docs/rfc-transaction-specs/transactions/BUY/RFC-BUY-01.md
@@ -6,17 +6,17 @@
 * **Title:** Canonical BUY Transaction Specification
 * **Version:** 1.0.0
 * **Status:** Draft
-* **Owner:** *TBD*
-* **Reviewers:** *TBD*
-* **Approvers:** *TBD*
-* **Last Updated:** *TBD*
-* **Effective Date:** *TBD*
+* **Owner:** lotus-core engineering
+* **Reviewers:** Platform Architecture, lotus-risk engineering
+* **Approvers:** lotus-core maintainers
+* **Last Updated:** 2026-03-01
+* **Effective Date:** 2026-03-01 (pending formal approval)
 
 ### 1.1 Change Log
 
 | Version | Date  | Author | Summary                             |
 | ------- | ----- | ------ | ----------------------------------- |
-| 1.0.0   | *TBD* | *TBD*  | Initial canonical BUY specification |
+| 1.0.0   | 2026-03-01 | lotus-core engineering  | Initial canonical BUY specification |
 
 ### 1.2 Purpose
 

--- a/docs/rfc-transaction-specs/transactions/SELL/RFC-SELL-01.md
+++ b/docs/rfc-transaction-specs/transactions/SELL/RFC-SELL-01.md
@@ -6,17 +6,17 @@
 * **Title:** Canonical SELL Transaction Specification
 * **Version:** 1.0.0
 * **Status:** Draft
-* **Owner:** *TBD*
-* **Reviewers:** *TBD*
-* **Approvers:** *TBD*
-* **Last Updated:** *TBD*
-* **Effective Date:** *TBD*
+* **Owner:** lotus-core engineering
+* **Reviewers:** Platform Architecture, lotus-risk engineering
+* **Approvers:** lotus-core maintainers
+* **Last Updated:** 2026-03-01
+* **Effective Date:** 2026-03-01 (pending formal approval)
 
 ### 1.1 Change Log
 
 | Version | Date  | Author | Summary                              |
 | ------- | ----- | ------ | ------------------------------------ |
-| 1.0.0   | *TBD* | *TBD*  | Initial canonical SELL specification |
+| 1.0.0   | 2026-03-01 | lotus-core engineering  | Initial canonical SELL specification |
 
 ### 1.2 Purpose
 


### PR DESCRIPTION
## Summary
- update BUY and SELL canonical RFC metadata from placeholder values to concrete owner/reviewer/approver/date information
- align BUY implementation plan tracking row for Slice 6 from stale `pending` wording to `merged`

## Scope
- docs only
- no runtime code changes
