### PR TITLE
test(sell-rfc): complete slice 0 baseline characterization

### DIFF
--- a/docs/RFCs/RFC 061 - SELL Transaction RFC Implementation Plan.md
+++ b/docs/RFCs/RFC 061 - SELL Transaction RFC Implementation Plan.md
@@ -327,7 +327,7 @@ Risk 4: Coupling between cost, position, and cash modules can cause regressions.
 
 | Slice | Name | Status | Owner | PRs | Test Gate | Evidence | Notes |
 |---|---|---|---|---|---|---|---|
-| 0 | Baseline characterization | TODO | lotus-core engineering | pending | pending | `SELL-SLICE-0-GAP-ASSESSMENT.md` | Establish baseline lock and approved gap matrix. |
+| 0 | Baseline characterization | DONE | lotus-core engineering | pending | local green | `SELL-SLICE-0-GAP-ASSESSMENT.md` + `test_sell_slice0_characterization.py` | Baseline lock established and gap matrix captured. |
 | 1 | Canonical contract + validation | TODO | lotus-core engineering | pending | pending | `SELL-SLICE-1-VALIDATION-REASON-CODES.md` | Deterministic SELL reason-code foundation. |
 | 2 | Persistence + linkage + policy metadata | TODO | lotus-core engineering | pending | pending | `SELL-SLICE-2-PERSISTENCE-METADATA.md` | Disposal linkage and policy traceability. |
 | 3 | Calculations + invariants | TODO | lotus-core engineering | pending | pending | `SELL-SLICE-3-CALCULATION-INVARIANTS.md` | Realized P&L decomposition and invariant enforcement. |

--- a/docs/rfc-transaction-specs/transactions/SELL/SELL-SLICE-0-GAP-ASSESSMENT.md
+++ b/docs/rfc-transaction-specs/transactions/SELL/SELL-SLICE-0-GAP-ASSESSMENT.md
@@ -1,0 +1,51 @@
+# SELL Slice 0 Gap Assessment
+
+## Scope
+
+This assessment captures the baseline gap between current `lotus-core` SELL behavior and `RFC-SELL-01` before functional SELL implementation changes.
+
+Status labels:
+
+- `COVERED`
+- `PARTIALLY_COVERED`
+- `NOT_COVERED`
+
+Behavior labels:
+
+- `MATCHES`
+- `PARTIALLY_MATCHES`
+- `DOES_NOT_MATCH`
+
+## Requirement Matrix
+
+| Requirement | Implementation Status | Behavior Match | Current Observed Behavior | Target Behavior | Risk if Unchanged | Proposed Action | Blocking |
+|---|---|---|---|---|---|---|---|
+| Lifecycle stage order (receive -> validate -> normalize -> policy -> calculate -> effects -> persist -> publish -> observability) | PARTIALLY_COVERED | PARTIALLY_MATCHES | Core stages exist across ingestion, persistence, and calculators but are not represented as explicit, queryable stage state per SELL. | Deterministic, diagnosable lifecycle stage model for every SELL. | Incident triage and reconciliation remain slower and less deterministic. | Add stage-state persistence and support visibility in Slice 5. | Yes |
+| SELL semantic invariant: reduces quantity/exposure | COVERED | MATCHES | Position calculator reduces quantity for `SELL` and `TRANSFER_OUT`. | Same behavior with explicit SELL invariants. | Regression risk during canonical refactor if not locked. | Keep under characterization; enforce explicit invariants in Slice 3. | Yes |
+| SELL cost basis disposal and realized P&L calculation | COVERED | PARTIALLY_MATCHES | Cost engine computes disposal and realized gain/loss; decomposition and policy-trace semantics are not yet explicit at canonical contract level. | Canonical deterministic disposal + realized capital/FX/total decomposition with policy traceability. | Accounting transparency gaps under audit/replay scenarios. | Harden in Slices 2-3. | Yes |
+| Canonical linkage (`economic_event_id`, `linked_transaction_group_id`) | PARTIALLY_COVERED | PARTIALLY_MATCHES | Linkage infrastructure exists in core transaction metadata, but SELL disposal/cash reconciliation linkage is not yet complete end-to-end per RFC surface. | SELL effects and linked cash are fully reconcilable by stable linkage ids. | Cash/security reconciliation ambiguity for support and audit. | Complete linkage semantics in Slices 2 and 4. | Yes |
+| Lot disposal traceability (per-lot effects and disposal method) | PARTIALLY_COVERED | PARTIALLY_MATCHES | Disposal strategy exists in cost engine but explicit canonical disposal state/query contract is incomplete. | Deterministic lot-disposal evidence and method visibility for each SELL. | Harder post-trade audit and tax-lot explainability. | Implement disposal persistence/query surfaces in Slices 3-5. | Yes |
+| Oversell/short policy behavior | PARTIALLY_COVERED | PARTIALLY_MATCHES | Engine-side insufficient quantity handling exists, but RFC-level deterministic policy matrix and reason-code surface are incomplete. | Policy-driven oversell behavior with deterministic reason codes. | Inconsistent behavior under edge cases and weak support diagnostics. | Define policy matrix and reason codes in Slice 1; enforce in Slice 4. | Yes |
+| Accrued-interest received separation for fixed-income SELL | NOT_COVERED | DOES_NOT_MATCH | SELL handling does not yet expose canonical accrued-interest-received separation and reporting shape required by RFC. | Accrued-interest received separated from capital P&L and queryable for fixed income flows. | Misclassification risk in income/capital analytics and reporting. | Add in Slices 3-5. | Yes |
+| Failure reason taxonomy with deterministic reason codes | PARTIALLY_COVERED | PARTIALLY_MATCHES | Existing validation/runtime failures exist but SELL-specific deterministic reason-code taxonomy is not complete. | Canonical SELL reason-code catalog for validation and processing failures. | Inconsistent QA/support handling. | Introduce in Slice 1. | Yes |
+| Query surfaces: SELL disposal + realized breakdown + linkage + policy trace | PARTIALLY_COVERED | PARTIALLY_MATCHES | Baseline transaction query exposes realized fields and core metadata; disposal-level and full lifecycle/audit surfaces are incomplete. | Full canonical SELL query visibility and support payloads. | Downstream consumers cannot rely on complete canonical surface. | Extend in Slice 5. | Yes |
+| Idempotency/replay safety for SELL side effects | COVERED | PARTIALLY_MATCHES | Core idempotency/replay protections exist platform-wide, but SELL-specific disposal/linkage invariants are not fully asserted. | Replay-safe canonical SELL with deterministic disposal and linkage effects. | Duplicate/disputed disposal outcomes under advanced recovery flows. | Expand SELL replay coverage in Slices 2-4. | Yes |
+| Observability diagnosability per SELL lifecycle stage | PARTIALLY_COVERED | PARTIALLY_MATCHES | Structured logs and metrics exist at service level; lifecycle stage observability for SELL is not yet exposed as first-class state. | Stage-aware SELL observability and support diagnostics payloads. | Slow root-cause analysis in production incidents. | Complete in Slice 5. | No |
+
+## Characterization Coverage Added in Slice 0
+
+- SELL ingestion DTO baseline behavior lock (`trade_fee` defaulting).
+- SELL fee transformation lock from ingestion event to cost engine payload.
+- SELL position quantity/cost-basis baseline progression lock using current `net_cost` semantics.
+- SELL query record mapping lock for transaction-level realized/net-cost fields.
+
+### Important transition rule
+
+Slice 0 characterization locks current behavior only for refactoring safety.
+As implementation slices progress, these tests must be promoted to canonical assertions aligned to `RFC-SELL-01` final semantics.
+No legacy assertion should remain if it conflicts with approved RFC behavior.
+
+## Notes
+
+- This assessment records current behavior; it does not modify SELL logic.
+- Functional conformance to `RFC-SELL-01` begins in Slice 1 onward.

--- a/tests/unit/transaction_specs/test_sell_slice0_characterization.py
+++ b/tests/unit/transaction_specs/test_sell_slice0_characterization.py
@@ -1,0 +1,108 @@
+from datetime import datetime
+from decimal import Decimal
+
+from portfolio_common.database_models import Transaction as DBTransaction
+from portfolio_common.events import TransactionEvent
+from services.ingestion_service.app.DTOs.transaction_dto import Transaction
+from src.services.calculators.cost_calculator_service.app.consumer import CostCalculatorConsumer
+from src.services.calculators.position_calculator.app.core.position_logic import PositionCalculator
+from src.services.calculators.position_calculator.app.core.position_models import (
+    PositionState as PositionStateDTO,
+)
+from src.services.query_service.app.dtos.transaction_dto import TransactionRecord
+
+
+def test_sell_ingestion_transaction_defaults_trade_fee_to_zero() -> None:
+    payload = {
+        "transaction_id": "SELL_SLICE0_001",
+        "portfolio_id": "PORT_SLICE0",
+        "instrument_id": "SEC_EQ_US_001",
+        "security_id": "SEC_EQ_US_001",
+        "transaction_date": "2026-01-20T00:00:00Z",
+        "transaction_type": "SELL",
+        "quantity": "5",
+        "price": "120.50",
+        "gross_transaction_amount": "602.5",
+        "trade_currency": "USD",
+        "currency": "USD",
+    }
+
+    model = Transaction(**payload)
+    assert model.transaction_type == "SELL"
+    assert model.trade_fee == Decimal("0")
+
+
+def test_sell_fee_transformation_to_engine_fees_structure() -> None:
+    consumer = CostCalculatorConsumer(
+        bootstrap_servers="test",
+        topic="raw_transactions_completed",
+        group_id="slice0",
+    )
+    event = TransactionEvent(
+        transaction_id="SELL_SLICE0_002",
+        portfolio_id="PORT_SLICE0",
+        instrument_id="SEC_EQ_US_001",
+        security_id="SEC_EQ_US_001",
+        transaction_date=datetime(2026, 1, 20),
+        transaction_type="SELL",
+        quantity=Decimal("5"),
+        price=Decimal("120.50"),
+        gross_transaction_amount=Decimal("602.5"),
+        trade_currency="USD",
+        currency="USD",
+        trade_fee=Decimal("3.25"),
+    )
+
+    transformed = consumer._transform_event_for_engine(event)
+    assert transformed["transaction_type"] == "SELL"
+    assert transformed["fees"] == {"brokerage": "3.25"}
+
+
+def test_sell_position_calculation_reduces_quantity_and_cost_basis() -> None:
+    state = PositionStateDTO(
+        quantity=Decimal("10"),
+        cost_basis=Decimal("1000"),
+        cost_basis_local=Decimal("1000"),
+    )
+    event = TransactionEvent(
+        transaction_id="SELL_SLICE0_003",
+        portfolio_id="PORT_SLICE0",
+        instrument_id="SEC_EQ_US_001",
+        security_id="SEC_EQ_US_001",
+        transaction_date=datetime(2026, 1, 20),
+        transaction_type="SELL",
+        quantity=Decimal("5"),
+        price=Decimal("120.50"),
+        gross_transaction_amount=Decimal("602.5"),
+        trade_currency="USD",
+        currency="USD",
+        net_cost=Decimal("-500"),
+        net_cost_local=Decimal("-500"),
+    )
+
+    next_state = PositionCalculator.calculate_next_position(state, event)
+    assert next_state.quantity == Decimal("5")
+    assert next_state.cost_basis == Decimal("500")
+    assert next_state.cost_basis_local == Decimal("500")
+
+
+def test_sell_query_record_mapping_preserves_current_fields() -> None:
+    db_txn = DBTransaction(
+        transaction_id="SELL_SLICE0_004",
+        transaction_date=datetime(2026, 1, 20),
+        transaction_type="SELL",
+        instrument_id="SEC_EQ_US_001",
+        security_id="SEC_EQ_US_001",
+        quantity=Decimal("5"),
+        price=Decimal("120.50"),
+        gross_transaction_amount=Decimal("602.5"),
+        currency="USD",
+        net_cost=Decimal("-500"),
+        realized_gain_loss=Decimal("102.5"),
+    )
+
+    record = TransactionRecord.model_validate(db_txn)
+    assert record.transaction_type == "SELL"
+    assert record.quantity == 5.0
+    assert record.net_cost == -500.0
+    assert record.realized_gain_loss == 102.5


### PR DESCRIPTION
## Slice
SELL RFC-061 Slice 0: baseline characterization and gap assessment

## Summary
- add `SELL-SLICE-0-GAP-ASSESSMENT.md` with requirement matrix against `RFC-SELL-01`
- add baseline characterization tests to lock current SELL behavior before canonical changes:
  - ingestion DTO trade-fee default
  - fee transformation to cost engine payload
  - position quantity/cost basis progression using current net-cost semantics
  - query record mapping for current realized/net-cost fields
- update RFC-061 tracking table: Slice 0 marked DONE with evidence references

## Validation
- `python -m ruff check tests/unit/transaction_specs/test_sell_slice0_characterization.py docs/rfc-transaction-specs/transactions/SELL/SELL-SLICE-0-GAP-ASSESSMENT.md "docs/RFCs/RFC 061 - SELL Transaction RFC Implementation Plan.md" --ignore E501,I001`
- `python -m pytest tests/unit/transaction_specs/test_sell_slice0_characterization.py -q`
