### PR TITLE
feat(sell-rfc): complete slices 2 and 3 together

### DIFF
--- a/docs/RFCs/RFC 061 - SELL Transaction RFC Implementation Plan.md
+++ b/docs/RFCs/RFC 061 - SELL Transaction RFC Implementation Plan.md
@@ -329,8 +329,8 @@ Risk 4: Coupling between cost, position, and cash modules can cause regressions.
 |---|---|---|---|---|---|---|---|
 | 0 | Baseline characterization | DONE | lotus-core engineering | pending | local green | `SELL-SLICE-0-GAP-ASSESSMENT.md` + `test_sell_slice0_characterization.py` | Baseline lock established and gap matrix captured. |
 | 1 | Canonical contract + validation | DONE | lotus-core engineering | pending | local green | `SELL-SLICE-1-VALIDATION-REASON-CODES.md` + `test_sell_validation.py` | Deterministic SELL reason-code foundation implemented in transaction domain. |
-| 2 | Persistence + linkage + policy metadata | TODO | lotus-core engineering | pending | pending | `SELL-SLICE-2-PERSISTENCE-METADATA.md` | Disposal linkage and policy traceability. |
-| 3 | Calculations + invariants | TODO | lotus-core engineering | pending | pending | `SELL-SLICE-3-CALCULATION-INVARIANTS.md` | Realized P&L decomposition and invariant enforcement. |
+| 2 | Persistence + linkage + policy metadata | DONE | lotus-core engineering | pending | local green | `SELL-SLICE-2-PERSISTENCE-METADATA.md` + `test_sell_linkage.py` | Deterministic SELL linkage/policy metadata enrichment integrated pre-persistence. |
+| 3 | Calculations + invariants | DONE | lotus-core engineering | pending | local green | `SELL-SLICE-3-CALCULATION-INVARIANTS.md` + `test_cost_calculator.py` | SELL proceeds/consumption/sign invariants enforced in cost engine with deterministic errors. |
 | 4 | Lot disposal + oversell + cash linkage | TODO | lotus-core engineering | pending | pending | `SELL-SLICE-4-DISPOSAL-CASH-LINKAGE.md` | Deterministic disposal and reconciliation behavior. |
 | 5 | Query + observability | TODO | lotus-core engineering | pending | pending | `SELL-SLICE-5-QUERY-OBSERVABILITY.md` | Audit-ready API visibility and diagnostics. |
 | 6 | Final conformance gate | TODO | lotus-core engineering | pending | pending | `SELL-SLICE-6-CONFORMANCE-REPORT.md` | Full section-level conformance evidence. |

--- a/docs/rfc-transaction-specs/transactions/SELL/SELL-SLICE-2-PERSISTENCE-METADATA.md
+++ b/docs/rfc-transaction-specs/transactions/SELL/SELL-SLICE-2-PERSISTENCE-METADATA.md
@@ -1,0 +1,26 @@
+# SELL Slice 2 - Persistence, Linkage, and Policy Metadata
+
+This slice hardens SELL metadata persistence preconditions by ensuring deterministic linkage and policy metadata are present before cost processing and persistence.
+
+## Implemented in this slice
+
+- Added SELL metadata enrichment utility:
+  - `enrich_sell_transaction_metadata(...)`
+  - deterministic defaults:
+    - `economic_event_id = EVT-SELL-<portfolio_id>-<transaction_id>`
+    - `linked_transaction_group_id = LTG-SELL-<portfolio_id>-<transaction_id>`
+    - `calculation_policy_id = SELL_DEFAULT_POLICY`
+    - `calculation_policy_version = 1.0.0`
+- Preserved upstream-provided metadata when already supplied.
+- Integrated enrichment in cost-calculator consumer before engine transformation/persistence.
+
+## Evidence
+
+- Unit tests:
+  - `tests/unit/libs/portfolio_common/test_sell_linkage.py`
+  - `tests/unit/services/calculators/cost_calculator_service/consumer/test_cost_calculator_consumer.py`
+- Consumer integration assertion verifies SELL metadata is present on persisted transaction update payload.
+
+## Notes
+
+- This slice uses additive enrichment and does not require schema changes because required fields already exist in transaction and event models.

--- a/docs/rfc-transaction-specs/transactions/SELL/SELL-SLICE-3-CALCULATION-INVARIANTS.md
+++ b/docs/rfc-transaction-specs/transactions/SELL/SELL-SLICE-3-CALCULATION-INVARIANTS.md
@@ -1,0 +1,31 @@
+# SELL Slice 3 - Calculation Pipeline and Invariant Hardening
+
+This slice tightens SELL calculation semantics in the financial calculator engine with explicit invariant checks.
+
+## Implemented in this slice
+
+- Added SELL invariant error path helper (`SELL invariant violation: ...`).
+- Enforced non-negative proceeds constraints:
+  - `net_sell_proceeds_local >= 0`
+  - `net_sell_proceeds_base >= 0`
+- Enforced positive disposal consumption:
+  - `consumed_quantity > 0`
+- Enforced non-negative disposed cost basis:
+  - `cogs_base >= 0`
+  - `cogs_local >= 0`
+- Enforced disposal sign semantics after calculation:
+  - `net_cost <= 0`
+  - `net_cost_local <= 0`
+
+## Evidence
+
+- Unit tests:
+  - `tests/unit/libs/financial-calculator-engine/unit/test_cost_calculator.py`
+    - negative proceeds is rejected with invariant error
+    - non-positive consumed quantity is rejected with invariant error
+    - existing SELL gain and dual-currency behavior remains covered
+
+## Notes
+
+- This slice hardens deterministic invariants without changing outward API contract fields.
+- Full SELL decomposition/query contract expansion continues in subsequent slices.

--- a/src/libs/portfolio-common/portfolio_common/transaction_domain/__init__.py
+++ b/src/libs/portfolio-common/portfolio_common/transaction_domain/__init__.py
@@ -14,6 +14,11 @@ from .sell_validation import (
     validate_sell_transaction,
 )
 from .sell_reason_codes import SellValidationReasonCode
+from .sell_linkage import (
+    SELL_DEFAULT_POLICY_ID,
+    SELL_DEFAULT_POLICY_VERSION,
+    enrich_sell_transaction_metadata,
+)
 
 __all__ = [
     "BuyCanonicalTransaction",
@@ -26,5 +31,8 @@ __all__ = [
     "SellValidationIssue",
     "SellValidationReasonCode",
     "validate_sell_transaction",
+    "SELL_DEFAULT_POLICY_ID",
+    "SELL_DEFAULT_POLICY_VERSION",
+    "enrich_sell_transaction_metadata",
 ]
 

--- a/src/libs/portfolio-common/portfolio_common/transaction_domain/sell_linkage.py
+++ b/src/libs/portfolio-common/portfolio_common/transaction_domain/sell_linkage.py
@@ -1,0 +1,35 @@
+from portfolio_common.events import TransactionEvent
+
+SELL_DEFAULT_POLICY_ID = "SELL_DEFAULT_POLICY"
+SELL_DEFAULT_POLICY_VERSION = "1.0.0"
+
+
+def enrich_sell_transaction_metadata(event: TransactionEvent) -> TransactionEvent:
+    """
+    Ensures SELL events carry deterministic linkage and policy metadata.
+    Existing upstream-provided values are preserved.
+    """
+    if event.transaction_type.upper() != "SELL":
+        return event
+
+    economic_event_id = (
+        event.economic_event_id
+        or f"EVT-SELL-{event.portfolio_id}-{event.transaction_id}"
+    )
+    linked_transaction_group_id = (
+        event.linked_transaction_group_id
+        or f"LTG-SELL-{event.portfolio_id}-{event.transaction_id}"
+    )
+    calculation_policy_id = event.calculation_policy_id or SELL_DEFAULT_POLICY_ID
+    calculation_policy_version = (
+        event.calculation_policy_version or SELL_DEFAULT_POLICY_VERSION
+    )
+
+    return event.model_copy(
+        update={
+            "economic_event_id": economic_event_id,
+            "linked_transaction_group_id": linked_transaction_group_id,
+            "calculation_policy_id": calculation_policy_id,
+            "calculation_policy_version": calculation_policy_version,
+        }
+    )

--- a/src/services/calculators/cost_calculator_service/app/consumer.py
+++ b/src/services/calculators/cost_calculator_service/app/consumer.py
@@ -22,6 +22,7 @@ from portfolio_common.kafka_consumer import BaseConsumer
 from portfolio_common.logging_utils import correlation_id_var
 from portfolio_common.monitoring import BUY_LIFECYCLE_STAGE_TOTAL
 from portfolio_common.outbox_repository import OutboxRepository
+from portfolio_common.transaction_domain import enrich_sell_transaction_metadata
 from pydantic import ValidationError
 from sqlalchemy.exc import DBAPIError, IntegrityError
 from tenacity import before_log, retry, retry_if_exception_type, stop_after_attempt, wait_fixed
@@ -140,6 +141,7 @@ class CostCalculatorConsumer(BaseConsumer):
         try:
             data = json.loads(value)
             event = TransactionEvent.model_validate(data)
+            event = enrich_sell_transaction_metadata(event)
 
             async for db in get_async_db_session():
                 async with db.begin():

--- a/tests/unit/libs/portfolio_common/test_sell_linkage.py
+++ b/tests/unit/libs/portfolio_common/test_sell_linkage.py
@@ -1,0 +1,52 @@
+from datetime import datetime
+from decimal import Decimal
+
+from portfolio_common.events import TransactionEvent
+from portfolio_common.transaction_domain import (
+    SELL_DEFAULT_POLICY_ID,
+    SELL_DEFAULT_POLICY_VERSION,
+    enrich_sell_transaction_metadata,
+)
+
+
+def _sell_event() -> TransactionEvent:
+    return TransactionEvent(
+        transaction_id="SELL-LINK-001",
+        portfolio_id="PORT-LINK-001",
+        instrument_id="SEC-ABC",
+        security_id="SEC-ABC",
+        transaction_date=datetime(2026, 3, 1, 12, 0, 0),
+        transaction_type="SELL",
+        quantity=Decimal("10"),
+        price=Decimal("100"),
+        gross_transaction_amount=Decimal("1000"),
+        trade_currency="USD",
+        currency="USD",
+    )
+
+
+def test_enrich_sell_metadata_populates_defaults() -> None:
+    enriched = enrich_sell_transaction_metadata(_sell_event())
+    assert enriched.economic_event_id == "EVT-SELL-PORT-LINK-001-SELL-LINK-001"
+    assert (
+        enriched.linked_transaction_group_id
+        == "LTG-SELL-PORT-LINK-001-SELL-LINK-001"
+    )
+    assert enriched.calculation_policy_id == SELL_DEFAULT_POLICY_ID
+    assert enriched.calculation_policy_version == SELL_DEFAULT_POLICY_VERSION
+
+
+def test_enrich_sell_metadata_preserves_upstream_values() -> None:
+    event = _sell_event().model_copy(
+        update={
+            "economic_event_id": "EVT-UPSTREAM-001",
+            "linked_transaction_group_id": "LTG-UPSTREAM-001",
+            "calculation_policy_id": "SELL_SPECIAL_POLICY",
+            "calculation_policy_version": "2.1.0",
+        }
+    )
+    enriched = enrich_sell_transaction_metadata(event)
+    assert enriched.economic_event_id == "EVT-UPSTREAM-001"
+    assert enriched.linked_transaction_group_id == "LTG-UPSTREAM-001"
+    assert enriched.calculation_policy_id == "SELL_SPECIAL_POLICY"
+    assert enriched.calculation_policy_version == "2.1.0"

--- a/tests/unit/services/calculators/cost_calculator_service/consumer/test_cost_calculator_consumer.py
+++ b/tests/unit/services/calculators/cost_calculator_service/consumer/test_cost_calculator_consumer.py
@@ -18,6 +18,10 @@ from src.services.calculators.cost_calculator_service.app.consumer import (
     CostCalculatorConsumer,
     PortfolioNotFoundError,
 )
+from portfolio_common.transaction_domain import (
+    SELL_DEFAULT_POLICY_ID,
+    SELL_DEFAULT_POLICY_VERSION,
+)
 from src.services.calculators.cost_calculator_service.app.repository import CostCalculatorRepository
 from tests.unit.test_support.async_session_iter import make_single_session_getter
 
@@ -187,6 +191,16 @@ async def test_consumer_integration_with_engine(
     updated_transaction_arg = mock_repo.update_transaction_costs.call_args[0][0]
     assert isinstance(updated_transaction_arg, EngineTransaction)
     assert updated_transaction_arg.realized_gain_loss == Decimal("250.0")
+    assert updated_transaction_arg.economic_event_id == "EVT-SELL-PORT_COST_01-SELL01"
+    assert (
+        updated_transaction_arg.linked_transaction_group_id
+        == "LTG-SELL-PORT_COST_01-SELL01"
+    )
+    assert updated_transaction_arg.calculation_policy_id == SELL_DEFAULT_POLICY_ID
+    assert (
+        updated_transaction_arg.calculation_policy_version
+        == SELL_DEFAULT_POLICY_VERSION
+    )
     mock_repo.upsert_buy_lot_state.assert_not_called()
     mock_repo.upsert_accrued_income_offset_state.assert_not_called()
     mock_idempotency_repo.mark_event_processed.assert_called_once()


### PR DESCRIPTION
## Slices
SELL RFC-061 Slice 2 + Slice 3 combined

## Summary
- add SELL metadata enrichment utility to guarantee deterministic linkage + policy metadata before persistence:
  - `economic_event_id`
  - `linked_transaction_group_id`
  - `calculation_policy_id`
  - `calculation_policy_version`
- integrate SELL enrichment in cost-calculator consumer before engine transformation
- harden SELL calculation invariants in financial calculator engine:
  - non-negative net proceeds (local/base)
  - positive consumed quantity
  - non-negative disposed cost basis
  - disposal sign invariants (`net_cost`, `net_cost_local` <= 0)
- add Slice 2 and Slice 3 evidence docs
- update RFC-061 tracking rows for slices 2 and 3 to DONE

## Validation
- `python -m ruff check ... --ignore E501,I001`
- `python -m pytest tests/unit/libs/portfolio_common/test_sell_linkage.py tests/unit/services/calculators/cost_calculator_service/consumer/test_cost_calculator_consumer.py tests/unit/libs/financial-calculator-engine/unit/test_cost_calculator.py -q`
- `make typecheck`

## Notes
- No schema migration required in this slice pair (fields already existed in event/transaction models).
