### PR TITLE
feat(sell-rfc): complete slice 4 disposal and linkage hardening

### DIFF
--- a/docs/RFCs/RFC 061 - SELL Transaction RFC Implementation Plan.md
+++ b/docs/RFCs/RFC 061 - SELL Transaction RFC Implementation Plan.md
@@ -331,7 +331,7 @@ Risk 4: Coupling between cost, position, and cash modules can cause regressions.
 | 1 | Canonical contract + validation | DONE | lotus-core engineering | pending | local green | `SELL-SLICE-1-VALIDATION-REASON-CODES.md` + `test_sell_validation.py` | Deterministic SELL reason-code foundation implemented in transaction domain. |
 | 2 | Persistence + linkage + policy metadata | DONE | lotus-core engineering | pending | local green | `SELL-SLICE-2-PERSISTENCE-METADATA.md` + `test_sell_linkage.py` | Deterministic SELL linkage/policy metadata enrichment integrated pre-persistence. |
 | 3 | Calculations + invariants | DONE | lotus-core engineering | pending | local green | `SELL-SLICE-3-CALCULATION-INVARIANTS.md` + `test_cost_calculator.py` | SELL proceeds/consumption/sign invariants enforced in cost engine with deterministic errors. |
-| 4 | Lot disposal + oversell + cash linkage | TODO | lotus-core engineering | pending | pending | `SELL-SLICE-4-DISPOSAL-CASH-LINKAGE.md` | Deterministic disposal and reconciliation behavior. |
+| 4 | Lot disposal + oversell + cash linkage | DONE | lotus-core engineering | pending | local green | `SELL-SLICE-4-DISPOSAL-CASH-LINKAGE.md` + linkage/consumer/cost tests | Deterministic disposal policy tagging and strict oversell gates added with linkage propagation checks. |
 | 5 | Query + observability | TODO | lotus-core engineering | pending | pending | `SELL-SLICE-5-QUERY-OBSERVABILITY.md` | Audit-ready API visibility and diagnostics. |
 | 6 | Final conformance gate | TODO | lotus-core engineering | pending | pending | `SELL-SLICE-6-CONFORMANCE-REPORT.md` | Full section-level conformance evidence. |
 

--- a/docs/rfc-transaction-specs/transactions/SELL/SELL-SLICE-4-DISPOSAL-CASH-LINKAGE.md
+++ b/docs/rfc-transaction-specs/transactions/SELL/SELL-SLICE-4-DISPOSAL-CASH-LINKAGE.md
@@ -1,0 +1,29 @@
+# SELL Slice 4 - Disposal Policy, Oversell Gates, and Cash Linkage
+
+This slice hardens deterministic disposal behavior and cash-linkage metadata propagation for SELL processing.
+
+## Implemented in this slice
+
+- Added deterministic SELL policy metadata assignment during cost-calculator processing:
+  - `SELL_FIFO_POLICY` when portfolio cost basis is FIFO/default
+  - `SELL_AVCO_POLICY` when portfolio cost basis is AVCO
+  - policy version `1.0.0`
+- Enforced strict oversell gate in SELL calculation path:
+  - compare requested sell quantity vs available quantity before disposal
+  - block oversold quantity under strict policy with deterministic invariant error
+  - if `SELL_ALLOW_OVERSOLD_POLICY` is configured, return explicit unsupported-policy invariant error (no silent behavior)
+- Preserved/propagated linkage identifiers into persisted and emitted SELL events:
+  - `economic_event_id`
+  - `linked_transaction_group_id`
+
+## Evidence
+
+- Unit tests:
+  - `tests/unit/libs/portfolio_common/test_sell_linkage.py`
+  - `tests/unit/services/calculators/cost_calculator_service/consumer/test_cost_calculator_consumer.py`
+  - `tests/unit/libs/financial-calculator-engine/unit/test_cost_calculator.py`
+
+## Notes
+
+- This slice focuses on deterministic policy and linkage behavior.
+- Full disposal-effect query surfaces remain in subsequent slices.

--- a/src/libs/portfolio-common/portfolio_common/transaction_domain/__init__.py
+++ b/src/libs/portfolio-common/portfolio_common/transaction_domain/__init__.py
@@ -15,7 +15,8 @@ from .sell_validation import (
 )
 from .sell_reason_codes import SellValidationReasonCode
 from .sell_linkage import (
-    SELL_DEFAULT_POLICY_ID,
+    SELL_AVCO_POLICY_ID,
+    SELL_FIFO_POLICY_ID,
     SELL_DEFAULT_POLICY_VERSION,
     enrich_sell_transaction_metadata,
 )
@@ -31,7 +32,8 @@ __all__ = [
     "SellValidationIssue",
     "SellValidationReasonCode",
     "validate_sell_transaction",
-    "SELL_DEFAULT_POLICY_ID",
+    "SELL_AVCO_POLICY_ID",
+    "SELL_FIFO_POLICY_ID",
     "SELL_DEFAULT_POLICY_VERSION",
     "enrich_sell_transaction_metadata",
 ]

--- a/src/libs/portfolio-common/portfolio_common/transaction_domain/sell_linkage.py
+++ b/src/libs/portfolio-common/portfolio_common/transaction_domain/sell_linkage.py
@@ -1,10 +1,13 @@
 from portfolio_common.events import TransactionEvent
 
-SELL_DEFAULT_POLICY_ID = "SELL_DEFAULT_POLICY"
+SELL_FIFO_POLICY_ID = "SELL_FIFO_POLICY"
+SELL_AVCO_POLICY_ID = "SELL_AVCO_POLICY"
 SELL_DEFAULT_POLICY_VERSION = "1.0.0"
 
 
-def enrich_sell_transaction_metadata(event: TransactionEvent) -> TransactionEvent:
+def enrich_sell_transaction_metadata(
+    event: TransactionEvent, *, cost_basis_method: str | None = None
+) -> TransactionEvent:
     """
     Ensures SELL events carry deterministic linkage and policy metadata.
     Existing upstream-provided values are preserved.
@@ -20,7 +23,11 @@ def enrich_sell_transaction_metadata(event: TransactionEvent) -> TransactionEven
         event.linked_transaction_group_id
         or f"LTG-SELL-{event.portfolio_id}-{event.transaction_id}"
     )
-    calculation_policy_id = event.calculation_policy_id or SELL_DEFAULT_POLICY_ID
+    if cost_basis_method == "AVCO":
+        resolved_policy_id = SELL_AVCO_POLICY_ID
+    else:
+        resolved_policy_id = SELL_FIFO_POLICY_ID
+    calculation_policy_id = event.calculation_policy_id or resolved_policy_id
     calculation_policy_version = (
         event.calculation_policy_version or SELL_DEFAULT_POLICY_VERSION
     )

--- a/src/services/calculators/cost_calculator_service/app/consumer.py
+++ b/src/services/calculators/cost_calculator_service/app/consumer.py
@@ -141,7 +141,6 @@ class CostCalculatorConsumer(BaseConsumer):
         try:
             data = json.loads(value)
             event = TransactionEvent.model_validate(data)
-            event = enrich_sell_transaction_metadata(event)
 
             async for db in get_async_db_session():
                 async with db.begin():
@@ -160,6 +159,9 @@ class CostCalculatorConsumer(BaseConsumer):
                         )
 
                     cost_basis_method = portfolio.cost_basis_method or "FIFO"
+                    event = enrich_sell_transaction_metadata(
+                        event, cost_basis_method=cost_basis_method
+                    )
 
                     history_db = await repo.get_transaction_history(
                         portfolio_id=event.portfolio_id,

--- a/tests/unit/libs/portfolio_common/test_sell_linkage.py
+++ b/tests/unit/libs/portfolio_common/test_sell_linkage.py
@@ -3,7 +3,8 @@ from decimal import Decimal
 
 from portfolio_common.events import TransactionEvent
 from portfolio_common.transaction_domain import (
-    SELL_DEFAULT_POLICY_ID,
+    SELL_AVCO_POLICY_ID,
+    SELL_FIFO_POLICY_ID,
     SELL_DEFAULT_POLICY_VERSION,
     enrich_sell_transaction_metadata,
 )
@@ -32,7 +33,7 @@ def test_enrich_sell_metadata_populates_defaults() -> None:
         enriched.linked_transaction_group_id
         == "LTG-SELL-PORT-LINK-001-SELL-LINK-001"
     )
-    assert enriched.calculation_policy_id == SELL_DEFAULT_POLICY_ID
+    assert enriched.calculation_policy_id == SELL_FIFO_POLICY_ID
     assert enriched.calculation_policy_version == SELL_DEFAULT_POLICY_VERSION
 
 
@@ -50,3 +51,9 @@ def test_enrich_sell_metadata_preserves_upstream_values() -> None:
     assert enriched.linked_transaction_group_id == "LTG-UPSTREAM-001"
     assert enriched.calculation_policy_id == "SELL_SPECIAL_POLICY"
     assert enriched.calculation_policy_version == "2.1.0"
+
+
+def test_enrich_sell_metadata_uses_avco_policy_when_requested() -> None:
+    enriched = enrich_sell_transaction_metadata(_sell_event(), cost_basis_method="AVCO")
+    assert enriched.calculation_policy_id == SELL_AVCO_POLICY_ID
+    assert enriched.calculation_policy_version == SELL_DEFAULT_POLICY_VERSION


### PR DESCRIPTION
## Slice
SELL RFC-061 Slice 4: disposal policy, oversell gates, and cash linkage

## Summary
- enhance SELL metadata enrichment to resolve disposal policy id by portfolio cost-basis method:
  - `SELL_FIFO_POLICY`
  - `SELL_AVCO_POLICY`
- enforce strict oversell gate in SELL calculation path before lot consumption
- add deterministic invariant error behavior for unsupported oversold policy mode
- verify linkage metadata propagation in consumer persisted payload and outbox payload
- add Slice 4 evidence doc and mark Slice 4 DONE in RFC-061 tracking

## Validation
- `python -m ruff check ... --ignore E501,I001`
- `python -m pytest tests/unit/libs/portfolio_common/test_sell_linkage.py tests/unit/services/calculators/cost_calculator_service/consumer/test_cost_calculator_consumer.py tests/unit/libs/financial-calculator-engine/unit/test_cost_calculator.py -q`
- `make typecheck`
