### PR TITLE
feat(query): align integration capabilities contract and docs

### DIFF
--- a/docs/RFCs/RFC 063 - Stateful Analytics Input Contracts for lotus-performance APIs.md
+++ b/docs/RFCs/RFC 063 - Stateful Analytics Input Contracts for lotus-performance APIs.md
@@ -1,0 +1,259 @@
+# RFC 063 - Stateful Analytics Input Contracts for lotus-performance APIs
+
+## Status
+Proposed
+
+## Date
+2026-03-01
+
+## Owners
+- lotus-core (authoritative stateful data provider)
+- lotus-performance (analytics computation owner)
+- lotus-platform (contract governance)
+
+## 1. Problem Statement
+`lotus-performance` exposes analytics APIs (`/performance/twr`, `/performance/mwr`, `/performance/attribution`, `/contribution`, `/analytics/positions`, `/integration/returns/series`) that are fully computable in stateless mode today but not fully backed by stable lotus-core stateful input contracts.
+
+Observed contract gaps on `lotus-core` `main`:
+1. `POST /integration/portfolios/{portfolio_id}/performance-input` is not present.
+2. `POST /portfolios/{portfolio_id}/positions-analytics` is not present.
+
+As a result, stateful-mode enablement across all lotus-performance APIs is inconsistent and integration behavior is fragile.
+
+## 2. Decision
+Define and implement a dedicated stateful-input contract suite in lotus-core for lotus-performance analytics, while preserving ownership boundaries:
+1. lotus-core owns canonical source data and integration input payloads.
+2. lotus-performance owns all analytics calculations and response semantics.
+
+## 3. Scope
+This RFC defines required lotus-core query contracts and their required data points for:
+1. TWR
+2. MWR
+3. Attribution
+4. Contribution
+5. Positions analytics feed
+6. Returns-series feed (portfolio + benchmark + risk-free)
+
+Out of scope:
+1. Changes to lotus-performance formulas or scoring methodology.
+2. UI/gateway response contracts.
+3. Data ingestion mechanics (covered in ingestion RFCs).
+
+## 4. API-to-Data Requirements Matrix
+
+### 4.1 `lotus-performance` API: `POST /performance/twr` (stateful mode)
+Required lotus-core endpoint:
+1. `POST /integration/portfolios/{portfolio_id}/performance-input`
+
+Required response data points:
+1. `portfolio_id`
+2. `performance_start_date`
+3. `valuation_points[]` with each row containing:
+   - `day`
+   - `perf_date`
+   - `begin_mv`
+   - `bod_cf`
+   - `eod_cf`
+   - `mgmt_fees`
+   - `end_mv`
+4. `pas_contract_version`
+5. `consumer_system`
+
+### 4.2 `lotus-performance` API: `POST /performance/mwr` (stateful mode)
+Required lotus-core endpoint:
+1. `POST /integration/portfolios/{portfolio_id}/mwr-input`
+
+Required response data points:
+1. `portfolio_id`
+2. `as_of_date`
+3. `start_date`
+4. `end_date`
+5. `begin_mv`
+6. `end_mv`
+7. `cash_flows[]`:
+   - `date`
+   - `amount`
+   - optional: `type` (`external_flow`, `fee`, `tax`, etc.)
+8. `currency`
+9. `contract_version`
+
+### 4.3 `lotus-performance` API: `POST /performance/attribution` (stateful mode)
+Required lotus-core endpoint:
+1. `POST /integration/portfolios/{portfolio_id}/attribution-input`
+
+Required response data points:
+1. `portfolio_id`
+2. `report_start_date`
+3. `report_end_date`
+4. `group_by_dimensions[]` (requested dimensions resolved)
+5. `portfolio_data`:
+   - `metric_basis`
+   - `valuation_points[]` (`day`, `perf_date`, `begin_mv`, `bod_cf`, `eod_cf`, `mgmt_fees`, `end_mv`)
+6. `instruments_data[]`:
+   - `instrument_id`
+   - `meta{}` (must contain all requested `group_by` dimensions)
+   - `valuation_points[]` with same fields as portfolio
+7. `benchmark_groups_data[]`:
+   - `key{}` (dimension map)
+   - `observations[]`:
+     - `date`
+     - `weight_bop`
+     - `return_base`
+     - optional: `return_local`
+     - optional: `return_fx`
+8. `currency_context`:
+   - `portfolio_currency`
+   - `reporting_currency`
+9. `contract_version`
+
+### 4.4 `lotus-performance` API: `POST /contribution` (stateful mode)
+Required lotus-core endpoint:
+1. `POST /integration/portfolios/{portfolio_id}/contribution-input`
+
+Required response data points:
+1. `portfolio_id`
+2. `report_start_date`
+3. `report_end_date`
+4. `portfolio_data`:
+   - `metric_basis`
+   - `valuation_points[]` (`day`, `perf_date`, `begin_mv`, `bod_cf`, `eod_cf`, `mgmt_fees`, `end_mv`)
+5. `positions_data[]`:
+   - `position_id`
+   - `meta{}`
+   - `valuation_points[]` with same fields
+6. optional hierarchy hints:
+   - `supported_hierarchy_dimensions[]`
+7. `currency_context`
+8. `contract_version`
+
+### 4.5 `lotus-performance` API: `POST /analytics/positions` (stateful mode)
+Required lotus-core endpoint:
+1. `POST /integration/portfolios/{portfolio_id}/positions-analytics-input`
+
+Required response data points:
+1. `portfolio_id`
+2. `as_of_date`
+3. `total_market_value`
+4. `positions[]` (normalized row payload sufficient for lotus-performance passthrough and downstream consumers)
+5. `contract_version`
+
+### 4.6 `lotus-performance` API: `POST /integration/returns/series` (`core_api_ref`)
+Required lotus-core endpoints:
+1. `POST /integration/portfolios/{portfolio_id}/performance-input`
+2. `POST /integration/portfolios/{portfolio_id}/benchmark-assignment` (already present)
+3. `POST /integration/benchmarks/{benchmark_id}/return-series` (already present)
+4. `POST /integration/reference/risk-free-series` (already present)
+
+Required response data points:
+1. Portfolio leg from `performance-input`:
+   - `performance_start_date`
+   - `valuation_points[]` (`day`, `perf_date`, `begin_mv`, `bod_cf`, `eod_cf`, `mgmt_fees`, `end_mv`)
+2. Benchmark leg:
+   - assignment: `benchmark_id`
+   - series points: `series_date`, `benchmark_return`
+3. Risk-free leg:
+   - series points: `series_date`, `value`
+   - `series_mode` (`return_series` or `annualized_rate_series`)
+   - rate conventions (when applicable)
+
+## 5. Contract Definitions (Normative)
+
+### 5.1 `POST /integration/portfolios/{portfolio_id}/performance-input`
+Request:
+1. `as_of_date`
+2. `lookback_days`
+3. `consumer_system`
+
+Response:
+1. `portfolio_id`
+2. `performance_start_date`
+3. `valuation_points[]` with required daily valuation fields
+4. `pas_contract_version`
+5. `consumer_system`
+6. `lineage`
+
+### 5.2 `POST /integration/portfolios/{portfolio_id}/mwr-input`
+Request:
+1. `as_of_date`
+2. `window` (`start_date`, `end_date`) or `period`
+3. `consumer_system`
+
+Response:
+1. `portfolio_id`
+2. `as_of_date`
+3. `start_date`
+4. `end_date`
+5. `begin_mv`
+6. `end_mv`
+7. `cash_flows[]` (`date`, `amount`, optional `type`)
+8. `currency`
+9. `contract_version`
+10. `lineage`
+
+### 5.3 `POST /integration/portfolios/{portfolio_id}/attribution-input`
+Request:
+1. `report_start_date`
+2. `report_end_date`
+3. `group_by_dimensions[]`
+4. `consumer_system`
+5. optional `reporting_currency`
+
+Response:
+1. Full payload listed in section 4.3
+
+### 5.4 `POST /integration/portfolios/{portfolio_id}/contribution-input`
+Request:
+1. `report_start_date`
+2. `report_end_date`
+3. optional `hierarchy[]`
+4. `consumer_system`
+5. optional `reporting_currency`
+
+Response:
+1. Full payload listed in section 4.4
+
+### 5.5 `POST /integration/portfolios/{portfolio_id}/positions-analytics-input`
+Request:
+1. `as_of_date`
+2. `sections[]`
+3. optional `performance_periods[]`
+4. `consumer_system`
+
+Response:
+1. Full payload listed in section 4.5
+
+## 6. Error Contract
+All endpoints in this RFC must use deterministic lotus-core integration error mapping:
+1. `INVALID_REQUEST`
+2. `RESOURCE_NOT_FOUND`
+3. `INSUFFICIENT_DATA`
+4. `SOURCE_UNAVAILABLE`
+5. `CONTRACT_VIOLATION_UPSTREAM`
+6. `UNSUPPORTED_CONFIGURATION`
+
+## 7. Non-Functional Requirements
+1. Deterministic ordering for all time-series arrays.
+2. No duplicate dates per series.
+3. Effective-dated determinism (same inputs and as-of context produce replay-equivalent payloads).
+4. Correlation/request/trace propagation headers must be accepted and echoed.
+5. OpenAPI + API vocabulary inventory compliance per RFC-0067.
+
+## 8. Compatibility and Migration
+1. Existing RFC-062 endpoints remain authoritative for benchmark/risk-free contracts.
+2. `performance-input` and `positions-analytics-input` are required to unblock full stateful mode across all lotus-performance APIs.
+3. lotus-performance will keep stateless request modes as fallback until all stateful contracts are available in production.
+
+## 9. Test Requirements
+1. Unit tests for all new request/response validators and policy branches.
+2. Integration tests for each endpoint covering:
+   - happy path
+   - missing data
+   - unsupported configuration
+   - deterministic ordering and uniqueness
+3. Contract smoke tests proving lotus-performance can run each stateful API path against lotus-core contracts.
+
+## 10. Acceptance Criteria
+1. All endpoints in section 5 are implemented in lotus-core query service.
+2. `lotus-performance` runs stateful mode for TWR, MWR, attribution, contribution, positions, and returns-series without direct DB coupling.
+3. RFC-0067 gates pass for lotus-core contract surfaces.
+4. Cross-repo CI contract tests between lotus-core and lotus-performance are green.

--- a/docs/standards/api-vocabulary/lotus-core-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-core-api-vocabulary.v1.json
@@ -13,7 +13,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-03-01T10:32:54.339174+00:00",
+  "generatedAt": "2026-03-01T11:47:14.666402+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.accepted_count",
@@ -103,7 +103,7 @@
       "semanticId": "lotus.allowed_sections",
       "canonicalTerm": "allowed_sections",
       "preferredName": "allowed_sections",
-      "description": "effective integration policy response field: allowed sections.",
+      "description": "Section allow-list resolved for this consumer and tenant.",
       "example": [
         "example_allowed_sections_item"
       ],
@@ -1027,7 +1027,7 @@
       "semanticId": "lotus.contract_version",
       "canonicalTerm": "contract_version",
       "preferredName": "contract_version",
-      "description": "effective integration policy response field: contract version.",
+      "description": "Version of the integration policy response contract.",
       "example": "v1",
       "type": "string",
       "locations": [
@@ -1739,7 +1739,7 @@
       "semanticId": "lotus.features",
       "canonicalTerm": "features",
       "preferredName": "features",
-      "description": "integration capabilities response field: features.",
+      "description": "Feature-level capability flags and ownership metadata.",
       "example": [
         "features_item_example"
       ],
@@ -1842,7 +1842,7 @@
       "semanticId": "lotus.generated_at",
       "canonicalTerm": "generated_at",
       "preferredName": "generated_at",
-      "description": "Timestamp for generated at.",
+      "description": "UTC timestamp when the policy response was generated.",
       "example": "2026-02-27T10:30:00Z",
       "type": "string",
       "locations": [
@@ -2691,7 +2691,7 @@
       "semanticId": "lotus.matched_rule_id",
       "canonicalTerm": "matched_rule_id",
       "preferredName": "matched_rule_id",
-      "description": "Unique matched rule identifier.",
+      "description": "Deterministic identifier of the matched policy rule.",
       "example": "MATCHED_RULE_001",
       "type": "string",
       "locations": [
@@ -3203,7 +3203,7 @@
       "semanticId": "lotus.policy_provenance",
       "canonicalTerm": "policy_provenance",
       "preferredName": "policy_provenance",
-      "description": "effective integration policy response field: policy provenance.",
+      "description": "Policy lineage metadata showing how the effective policy was resolved.",
       "example": "policy_provenance_example",
       "type": "string",
       "locations": [
@@ -3217,7 +3217,7 @@
       "semanticId": "lotus.policy_source",
       "canonicalTerm": "policy_source",
       "preferredName": "policy_source",
-      "description": "policy provenance metadata field: policy source.",
+      "description": "Policy source level used for resolution.",
       "example": "example_policy_source",
       "type": "string",
       "locations": [
@@ -3231,7 +3231,7 @@
       "semanticId": "lotus.policy_version",
       "canonicalTerm": "policy_version",
       "preferredName": "policy_version",
-      "description": "policy provenance metadata field: policy version.",
+      "description": "Version label for the resolved integration policy.",
       "example": "tenant-default-v1",
       "type": "string",
       "locations": [
@@ -4519,7 +4519,7 @@
       "semanticId": "lotus.source_service",
       "canonicalTerm": "source_service",
       "preferredName": "source_service",
-      "description": "effective integration policy response field: source service.",
+      "description": "Service producing the policy response.",
       "example": "lotus-core",
       "type": "string",
       "locations": [
@@ -4635,7 +4635,7 @@
       "semanticId": "lotus.strict_mode",
       "canonicalTerm": "strict_mode",
       "preferredName": "strict_mode",
-      "description": "policy provenance metadata field: strict mode.",
+      "description": "Whether strict section gating is enforced for this policy context.",
       "example": true,
       "type": "boolean",
       "locations": [
@@ -4709,7 +4709,7 @@
       "semanticId": "lotus.supported_input_modes",
       "canonicalTerm": "supported_input_modes",
       "preferredName": "supported_input_modes",
-      "description": "integration capabilities response field: supported input modes.",
+      "description": "Supported integration input modes for the consumer context.",
       "example": [
         "example_supported_input_modes_item"
       ],
@@ -5241,7 +5241,7 @@
       "semanticId": "lotus.warnings",
       "canonicalTerm": "warnings",
       "preferredName": "warnings",
-      "description": "effective integration policy response field: warnings.",
+      "description": "Non-fatal policy diagnostics relevant to consumer behavior.",
       "example": [
         "example_warnings_item"
       ],
@@ -5327,7 +5327,7 @@
       "semanticId": "lotus.workflows",
       "canonicalTerm": "workflows",
       "preferredName": "workflows",
-      "description": "integration capabilities response field: workflows.",
+      "description": "Workflow-level capability flags derived from feature dependencies.",
       "example": [
         "workflows_item_example"
       ],
@@ -13181,15 +13181,15 @@
       "operationId": "get_integration_capabilities_integration_capabilities_get",
       "method": "GET",
       "path": "/integration/capabilities",
-      "domain": "integration",
+      "domain": "integration_contracts",
       "serviceGroup": "query",
       "tags": [
-        "Integration"
+        "Integration Contracts"
       ],
       "summary": "Get lotus-core Integration Capabilities",
-      "description": "Returns backend-governed lotus-core capability and workflow flags for a consumer system and tenant context. Intended for lotus-gateway/UI and lotus-manage feature control.",
+      "description": "What: Return policy-resolved integration capabilities for a consumer and tenant context.\nHow: Applies environment and tenant-policy overrides, then derives workflow states from canonical feature dependencies.\nWhen: Used by downstream services and UI clients to enable only supported lotus-core integration paths.",
       "naming": {
-        "boundedContext": "integration",
+        "boundedContext": "integration_contracts",
         "canonicalTerms": [
           "as_of_date",
           "consumer_system",

--- a/src/services/query_service/app/dtos/capabilities_dto.py
+++ b/src/services/query_service/app/dtos/capabilities_dto.py
@@ -23,16 +23,54 @@ class WorkflowCapability(BaseModel):
 
 
 class IntegrationCapabilitiesResponse(BaseModel):
-    contract_version: str = Field(...)
-    source_service: str = Field(...)
-    consumer_system: ConsumerSystem = Field(...)
-    tenant_id: str = Field(...)
-    generated_at: datetime = Field(...)
-    as_of_date: date = Field(...)
-    policy_version: str = Field(...)
-    supported_input_modes: list[str] = Field(...)
-    features: list[FeatureCapability]
-    workflows: list[WorkflowCapability]
+    contract_version: str = Field(
+        ...,
+        description="Version of the capabilities response contract.",
+        examples=["v1"],
+    )
+    source_service: str = Field(
+        ...,
+        description="Service emitting capability metadata.",
+        examples=["lotus-core"],
+    )
+    consumer_system: ConsumerSystem = Field(
+        ...,
+        description="Canonical consumer system receiving capabilities.",
+        examples=["lotus-performance"],
+    )
+    tenant_id: str = Field(
+        ...,
+        description="Tenant identifier used for capability policy resolution.",
+        examples=["tenant_sg_pb"],
+    )
+    generated_at: datetime = Field(
+        ...,
+        description="UTC timestamp when capability payload was generated.",
+        examples=["2026-03-01T12:00:00Z"],
+    )
+    as_of_date: date = Field(
+        ...,
+        description="Business date at which capability policy is effective.",
+        examples=["2026-03-01"],
+    )
+    policy_version: str = Field(
+        ...,
+        description="Resolved policy version for tenant capability controls.",
+        examples=["tenant-default-v1"],
+    )
+    supported_input_modes: list[str] = Field(
+        ...,
+        description="Supported integration input modes for the consumer context.",
+        examples=[["lotus_core_ref", "inline_bundle", "file_upload"]],
+    )
+    features: list[FeatureCapability] = Field(
+        ...,
+        description="Feature-level capability flags and ownership metadata.",
+    )
+    workflows: list[WorkflowCapability] = Field(
+        ...,
+        description="Workflow-level capability flags derived from feature dependencies.",
+    )
 
     model_config = {
         "json_schema_extra": {
@@ -66,4 +104,3 @@ class IntegrationCapabilitiesResponse(BaseModel):
             }
         },
     }
-

--- a/src/services/query_service/app/dtos/integration_dto.py
+++ b/src/services/query_service/app/dtos/integration_dto.py
@@ -4,23 +4,70 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class PolicyProvenanceMetadata(BaseModel):
-    policy_version: str = Field(...)
-    policy_source: str = Field(...)
-    matched_rule_id: str = Field(...)
-    strict_mode: bool = Field(...)
+    policy_version: str = Field(
+        ...,
+        description="Version label for the resolved integration policy.",
+        examples=["tenant-default-v1"],
+    )
+    policy_source: str = Field(
+        ...,
+        description="Policy source level used for resolution.",
+        examples=["tenant"],
+    )
+    matched_rule_id: str = Field(
+        ...,
+        description="Deterministic identifier of the matched policy rule.",
+        examples=["tenant.tenant_sg_pb.consumers.lotus-performance"],
+    )
+    strict_mode: bool = Field(
+        ...,
+        description="Whether strict section gating is enforced for this policy context.",
+        examples=[True],
+    )
 
     model_config = ConfigDict()
 
 
 class EffectiveIntegrationPolicyResponse(BaseModel):
-    contract_version: str = Field("v1")
-    source_service: str = Field("lotus-core")
-    consumer_system: str = Field(...)
-    tenant_id: str = Field(...)
-    generated_at: datetime = Field(...)
-    policy_provenance: PolicyProvenanceMetadata = Field(...)
-    allowed_sections: list[str] = Field(default_factory=list)
-    warnings: list[str] = Field(default_factory=list)
+    contract_version: str = Field(
+        "v1",
+        description="Version of the integration policy response contract.",
+        examples=["v1"],
+    )
+    source_service: str = Field(
+        "lotus-core",
+        description="Service producing the policy response.",
+        examples=["lotus-core"],
+    )
+    consumer_system: str = Field(
+        ...,
+        description="Canonical downstream consumer system identifier.",
+        examples=["lotus-performance"],
+    )
+    tenant_id: str = Field(
+        ...,
+        description="Tenant identifier used for policy resolution.",
+        examples=["tenant_sg_pb"],
+    )
+    generated_at: datetime = Field(
+        ...,
+        description="UTC timestamp when the policy response was generated.",
+        examples=["2026-03-01T12:00:00Z"],
+    )
+    policy_provenance: PolicyProvenanceMetadata = Field(
+        ...,
+        description="Policy lineage metadata showing how the effective policy was resolved.",
+    )
+    allowed_sections: list[str] = Field(
+        default_factory=list,
+        description="Section allow-list resolved for this consumer and tenant.",
+        examples=[["OVERVIEW", "HOLDINGS"]],
+    )
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="Non-fatal policy diagnostics relevant to consumer behavior.",
+        examples=[["NO_ALLOWED_SECTION_RESTRICTION"]],
+    )
 
     model_config = ConfigDict()
 

--- a/src/services/query_service/app/routers/capabilities.py
+++ b/src/services/query_service/app/routers/capabilities.py
@@ -1,10 +1,11 @@
-from fastapi import APIRouter, Depends, Query
 from typing import cast
+
+from fastapi import APIRouter, Depends, Query
 
 from ..dtos.capabilities_dto import ConsumerSystem, IntegrationCapabilitiesResponse
 from ..services.capabilities_service import CapabilitiesService
 
-router = APIRouter(prefix="/integration", tags=["Integration"])
+router = APIRouter(prefix="/integration", tags=["Integration Contracts"])
 
 
 def get_capabilities_service() -> CapabilitiesService:
@@ -16,8 +17,11 @@ def get_capabilities_service() -> CapabilitiesService:
     response_model=IntegrationCapabilitiesResponse,
     summary="Get lotus-core Integration Capabilities",
     description=(
-        "Returns backend-governed lotus-core capability and workflow flags for a consumer system "
-        "and tenant context. Intended for lotus-gateway/UI and lotus-manage feature control."
+        "What: Return policy-resolved integration capabilities for a consumer and tenant context.\n"
+        "How: Applies environment and tenant-policy overrides, then derives workflow states from "
+        "canonical feature dependencies.\n"
+        "When: Used by downstream services and UI clients to enable only supported lotus-core "
+        "integration paths."
     ),
 )
 async def get_integration_capabilities(
@@ -37,4 +41,3 @@ async def get_integration_capabilities(
         tenant_id=tenant_id,
     )
     return cast(IntegrationCapabilitiesResponse, response)
-

--- a/src/services/query_service/app/services/capabilities_service.py
+++ b/src/services/query_service/app/services/capabilities_service.py
@@ -98,7 +98,9 @@ class CapabilitiesService:
                 mode for mode in supported_input_modes if mode != "inline_bundle"
             ]
         if not feature_states["lotus_core.ingestion.bulk_upload_adapter"]:
-            supported_input_modes = [mode for mode in supported_input_modes if mode != "file_upload"]
+            supported_input_modes = [
+                mode for mode in supported_input_modes if mode != "file_upload"
+            ]
 
         tenant_policy = self._load_tenant_overrides().get(tenant_id)
         if tenant_policy:
@@ -178,7 +180,7 @@ class CapabilitiesService:
                         for key in _WORKFLOW_DEPENDENCIES["advisor_workbench_overview"]
                     ),
                 ),
-                required_features=["lotus_core.support.overview_api"],
+                required_features=list(_WORKFLOW_DEPENDENCIES["advisor_workbench_overview"]),
             ),
             WorkflowCapability(
                 workflow_key="portfolio_bulk_onboarding",
@@ -189,7 +191,7 @@ class CapabilitiesService:
                         for key in _WORKFLOW_DEPENDENCIES["portfolio_bulk_onboarding"]
                     ),
                 ),
-                required_features=["lotus_core.ingestion.bulk_upload"],
+                required_features=list(_WORKFLOW_DEPENDENCIES["portfolio_bulk_onboarding"]),
             ),
             WorkflowCapability(
                 workflow_key="portfolio_what_if_simulation",
@@ -200,7 +202,7 @@ class CapabilitiesService:
                         for key in _WORKFLOW_DEPENDENCIES["portfolio_what_if_simulation"]
                     ),
                 ),
-                required_features=["lotus_core.simulation.what_if"],
+                required_features=list(_WORKFLOW_DEPENDENCIES["portfolio_what_if_simulation"]),
             ),
         ]
 

--- a/tests/unit/services/query_service/services/test_capabilities_service.py
+++ b/tests/unit/services/query_service/services/test_capabilities_service.py
@@ -113,3 +113,16 @@ def test_capabilities_ignores_invalid_tenant_entries_and_non_dict_workflow_overr
     workflow_map = {workflow.workflow_key: workflow.enabled for workflow in response.workflows}
     assert response.policy_version == "tenant-x-v1"
     assert workflow_map["portfolio_bulk_onboarding"] is True
+
+
+def test_capabilities_workflow_required_features_are_canonical() -> None:
+    service = CapabilitiesService()
+    response = service.get_integration_capabilities(
+        consumer_system="lotus-gateway",
+        tenant_id="default",
+    )
+
+    feature_keys = {feature.key for feature in response.features}
+    for workflow in response.workflows:
+        assert workflow.required_features
+        assert set(workflow.required_features).issubset(feature_keys)


### PR DESCRIPTION
## Summary
- fix integration capabilities contract consistency by using canonical workflow dependency keys
- improve query-service capability/policy DTO field descriptions and realistic examples
- standardize capabilities router metadata and integration contract tagging
- add regression test asserting workflow required_features are always canonical feature keys
- regenerate lotus-core API vocabulary inventory
- include RFC 063 document in this change set

## Validation
- make ci-local
- python scripts/openapi_quality_gate.py
- python scripts/api_vocabulary_inventory.py --validate-only
- python -m pytest tests/unit/services/query_service/services/test_capabilities_service.py tests/integration/services/query_service/test_capabilities_router_dependency.py -q
