### PR TITLE
feat(rfc-063): add analytics export job contracts and durable result retrieval

### DIFF
--- a/alembic/versions/e1f2a3b4c6d7_feat_add_analytics_export_jobs_table.py
+++ b/alembic/versions/e1f2a3b4c6d7_feat_add_analytics_export_jobs_table.py
@@ -1,0 +1,60 @@
+"""feat: add analytics export jobs table
+
+Revision ID: e1f2a3b4c6d7
+Revises: d0e1f2a3b4c5
+Create Date: 2026-03-01 21:30:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "e1f2a3b4c6d7"
+down_revision: Union[str, None] = "d0e1f2a3b4c5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "analytics_export_jobs",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("job_id", sa.String(), nullable=False),
+        sa.Column("dataset_type", sa.String(), nullable=False),
+        sa.Column("portfolio_id", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), server_default="accepted", nullable=False),
+        sa.Column("request_fingerprint", sa.String(), nullable=False),
+        sa.Column("request_payload", sa.JSON(), nullable=False),
+        sa.Column("result_payload", sa.JSON(), nullable=True),
+        sa.Column("result_row_count", sa.Integer(), nullable=True),
+        sa.Column("result_format", sa.String(), server_default="json", nullable=False),
+        sa.Column("compression", sa.String(), server_default="none", nullable=False),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_analytics_export_jobs_dataset_type"), "analytics_export_jobs", ["dataset_type"], unique=False)
+    op.create_index(op.f("ix_analytics_export_jobs_job_id"), "analytics_export_jobs", ["job_id"], unique=True)
+    op.create_index(op.f("ix_analytics_export_jobs_portfolio_id"), "analytics_export_jobs", ["portfolio_id"], unique=False)
+    op.create_index(
+        op.f("ix_analytics_export_jobs_request_fingerprint"),
+        "analytics_export_jobs",
+        ["request_fingerprint"],
+        unique=False,
+    )
+    op.create_index(op.f("ix_analytics_export_jobs_status"), "analytics_export_jobs", ["status"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_analytics_export_jobs_status"), table_name="analytics_export_jobs")
+    op.drop_index(op.f("ix_analytics_export_jobs_request_fingerprint"), table_name="analytics_export_jobs")
+    op.drop_index(op.f("ix_analytics_export_jobs_portfolio_id"), table_name="analytics_export_jobs")
+    op.drop_index(op.f("ix_analytics_export_jobs_job_id"), table_name="analytics_export_jobs")
+    op.drop_index(op.f("ix_analytics_export_jobs_dataset_type"), table_name="analytics_export_jobs")
+    op.drop_table("analytics_export_jobs")

--- a/src/libs/portfolio-common/portfolio_common/database_models.py
+++ b/src/libs/portfolio-common/portfolio_common/database_models.py
@@ -872,6 +872,28 @@ class ReprocessingJob(Base):
     )
 
 
+class AnalyticsExportJob(Base):
+    __tablename__ = "analytics_export_jobs"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    job_id = Column(String, unique=True, index=True, nullable=False)
+    dataset_type = Column(String, index=True, nullable=False)
+    portfolio_id = Column(String, index=True, nullable=False)
+    status = Column(String, index=True, nullable=False, server_default="accepted")
+    request_fingerprint = Column(String, index=True, nullable=False)
+    request_payload = Column(JSON, nullable=False)
+    result_payload = Column(JSON, nullable=True)
+    result_row_count = Column(Integer, nullable=True)
+    result_format = Column(String, nullable=False, server_default="json")
+    compression = Column(String, nullable=False, server_default="none")
+    error_message = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    started_at = Column(DateTime(timezone=True), nullable=True)
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
 class CashflowRule(Base):
     """
     Defines the business rules for generating a cashflow from a transaction type.

--- a/src/libs/portfolio-common/portfolio_common/monitoring.py
+++ b/src/libs/portfolio-common/portfolio_common/monitoring.py
@@ -261,6 +261,33 @@ INGESTION_REPLAY_FAILURE_TOTAL = Counter(
     ["recovery_path", "replay_status"],
 )
 
+ANALYTICS_EXPORT_JOBS_TOTAL = Counter(
+    "analytics_export_jobs_total",
+    "Number of analytics export jobs by dataset_type and terminal status.",
+    ["dataset_type", "status"],
+)
+
+ANALYTICS_EXPORT_JOB_DURATION_SECONDS = Histogram(
+    "analytics_export_job_duration_seconds",
+    "Duration of analytics export job execution in seconds.",
+    labelnames=("dataset_type",),
+    buckets=(0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 60),
+)
+
+ANALYTICS_EXPORT_RESULT_BYTES = Histogram(
+    "analytics_export_result_bytes",
+    "Serialized payload size for analytics export results.",
+    labelnames=("result_format", "compression"),
+    buckets=(1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216),
+)
+
+ANALYTICS_EXPORT_PAGE_DEPTH = Histogram(
+    "analytics_export_page_depth",
+    "Number of source pages traversed while building analytics export result.",
+    labelnames=("dataset_type",),
+    buckets=(1, 2, 5, 10, 20, 50, 100, 200),
+)
+
 # --------------------------------------------------------------------------------------
 # Optional generic HTTP metrics (use across services if helpful)
 # --------------------------------------------------------------------------------------

--- a/src/services/query_service/app/repositories/analytics_export_repository.py
+++ b/src/services/query_service/app/repositories/analytics_export_repository.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from portfolio_common.database_models import AnalyticsExportJob
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class AnalyticsExportRepository:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def create_job(
+        self,
+        *,
+        job_id: str,
+        dataset_type: str,
+        portfolio_id: str,
+        request_fingerprint: str,
+        request_payload: dict,
+        result_format: str,
+        compression: str,
+    ) -> AnalyticsExportJob:
+        row = AnalyticsExportJob(
+            job_id=job_id,
+            dataset_type=dataset_type,
+            portfolio_id=portfolio_id,
+            status="accepted",
+            request_fingerprint=request_fingerprint,
+            request_payload=request_payload,
+            result_format=result_format,
+            compression=compression,
+        )
+        self.db.add(row)
+        await self.db.flush()
+        return row
+
+    async def get_job(self, job_id: str) -> AnalyticsExportJob | None:
+        result = await self.db.execute(
+            select(AnalyticsExportJob).where(AnalyticsExportJob.job_id == job_id).limit(1)
+        )
+        return result.scalars().first()
+
+    async def get_latest_by_fingerprint(
+        self, *, request_fingerprint: str, dataset_type: str
+    ) -> AnalyticsExportJob | None:
+        result = await self.db.execute(
+            select(AnalyticsExportJob)
+            .where(
+                AnalyticsExportJob.request_fingerprint == request_fingerprint,
+                AnalyticsExportJob.dataset_type == dataset_type,
+            )
+            .order_by(AnalyticsExportJob.id.desc())
+            .limit(1)
+        )
+        return result.scalars().first()
+
+    async def mark_running(self, row: AnalyticsExportJob) -> None:
+        row.status = "running"
+        row.started_at = datetime.now(UTC)
+        await self.db.flush()
+
+    async def mark_completed(
+        self, row: AnalyticsExportJob, *, result_payload: dict, result_row_count: int
+    ) -> None:
+        row.status = "completed"
+        row.result_payload = result_payload
+        row.result_row_count = result_row_count
+        row.completed_at = datetime.now(UTC)
+        await self.db.flush()
+
+    async def mark_failed(self, row: AnalyticsExportJob, *, error_message: str) -> None:
+        row.status = "failed"
+        row.error_message = error_message
+        row.completed_at = datetime.now(UTC)
+        await self.db.flush()

--- a/tests/unit/services/query_service/dtos/test_analytics_input_dto.py
+++ b/tests/unit/services/query_service/dtos/test_analytics_input_dto.py
@@ -4,6 +4,7 @@ import pytest
 from pydantic import ValidationError
 
 from src.services.query_service.app.dtos.analytics_input_dto import (
+    AnalyticsExportCreateRequest,
     PortfolioAnalyticsTimeseriesRequest,
     PositionAnalyticsTimeseriesRequest,
 )
@@ -17,3 +18,55 @@ def test_portfolio_timeseries_request_requires_window_or_period() -> None:
 def test_position_timeseries_request_requires_window_or_period() -> None:
     with pytest.raises(ValidationError):
         PositionAnalyticsTimeseriesRequest(as_of_date="2025-12-31")
+
+
+def test_export_request_requires_portfolio_payload_for_portfolio_dataset() -> None:
+    with pytest.raises(ValidationError):
+        AnalyticsExportCreateRequest(
+            dataset_type="portfolio_timeseries",
+            portfolio_id="P1",
+            result_format="json",
+            compression="none",
+        )
+
+
+def test_export_request_rejects_cross_payload_for_portfolio_dataset() -> None:
+    with pytest.raises(ValidationError):
+        AnalyticsExportCreateRequest(
+            dataset_type="portfolio_timeseries",
+            portfolio_id="P1",
+            portfolio_timeseries_request=PortfolioAnalyticsTimeseriesRequest(
+                as_of_date="2025-12-31",
+                period="one_month",
+            ),
+            position_timeseries_request=PositionAnalyticsTimeseriesRequest(
+                as_of_date="2025-12-31",
+                period="one_month",
+            ),
+        )
+
+
+def test_export_request_requires_position_payload_for_position_dataset() -> None:
+    with pytest.raises(ValidationError):
+        AnalyticsExportCreateRequest(
+            dataset_type="position_timeseries",
+            portfolio_id="P1",
+            result_format="ndjson",
+            compression="gzip",
+        )
+
+
+def test_export_request_rejects_cross_payload_for_position_dataset() -> None:
+    with pytest.raises(ValidationError):
+        AnalyticsExportCreateRequest(
+            dataset_type="position_timeseries",
+            portfolio_id="P1",
+            position_timeseries_request=PositionAnalyticsTimeseriesRequest(
+                as_of_date="2025-12-31",
+                period="one_month",
+            ),
+            portfolio_timeseries_request=PortfolioAnalyticsTimeseriesRequest(
+                as_of_date="2025-12-31",
+                period="one_month",
+            ),
+        )

--- a/tests/unit/services/query_service/repositories/test_analytics_export_repository.py
+++ b/tests/unit/services/query_service/repositories/test_analytics_export_repository.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.services.query_service.app.repositories.analytics_export_repository import (
+    AnalyticsExportRepository,
+)
+
+
+class _FakeExecuteResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalars(self):
+        return self
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+
+@pytest.mark.asyncio
+async def test_analytics_export_repository_create_get_and_markers() -> None:
+    db = AsyncMock(spec=AsyncSession)
+    repo = AnalyticsExportRepository(db)
+
+    await repo.create_job(
+        job_id="aexp_1",
+        dataset_type="portfolio_timeseries",
+        portfolio_id="P1",
+        request_fingerprint="fp1",
+        request_payload={"x": 1},
+        result_format="json",
+        compression="none",
+    )
+    assert db.add.call_count == 1
+    assert db.flush.await_count == 1
+
+    row = SimpleNamespace(
+        status="accepted",
+        started_at=None,
+        completed_at=None,
+        result_payload=None,
+        result_row_count=None,
+        error_message=None,
+    )
+    await repo.mark_running(row)
+    assert row.status == "running"
+    await repo.mark_completed(row, result_payload={"a": 1}, result_row_count=2)
+    assert row.status == "completed"
+    await repo.mark_failed(row, error_message="failed")
+    assert row.status == "failed"
+
+    db.execute.return_value = _FakeExecuteResult([SimpleNamespace(job_id="aexp_1")])
+    got = await repo.get_job("aexp_1")
+    assert got is not None
+
+    db.execute.return_value = _FakeExecuteResult([SimpleNamespace(job_id="aexp_2")])
+    got_fp = await repo.get_latest_by_fingerprint(request_fingerprint="fp", dataset_type="x")
+    assert got_fp is not None

--- a/tests/unit/services/query_service/services/test_analytics_timeseries_service.py
+++ b/tests/unit/services/query_service/services/test_analytics_timeseries_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date
+from datetime import UTC, date, datetime
 from decimal import Decimal
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from unittest.mock import MagicMock
 
 from src.services.query_service.app.dtos.analytics_input_dto import (
+    AnalyticsExportCreateRequest,
     AnalyticsWindow,
     PageRequest,
     PortfolioAnalyticsReferenceRequest,
@@ -400,3 +401,288 @@ async def test_get_position_timeseries_missing_fx_rate() -> None:
             ),
         )
     assert exc_info.value.code == "INSUFFICIENT_DATA"
+
+
+@pytest.mark.asyncio
+async def test_create_export_job_completed() -> None:
+    service = make_service()
+    row = SimpleNamespace(
+        job_id="aexp_1",
+        dataset_type="portfolio_timeseries",
+        portfolio_id="P1",
+        status="accepted",
+        request_fingerprint="fp1",
+        result_format="json",
+        compression="none",
+        result_row_count=None,
+        error_message=None,
+        created_at=datetime(2025, 1, 1, tzinfo=UTC),
+        started_at=None,
+        completed_at=None,
+    )
+    service.export_repo = SimpleNamespace(
+        get_latest_by_fingerprint=AsyncMock(return_value=None),
+        create_job=AsyncMock(return_value=row),
+        mark_running=AsyncMock(side_effect=lambda *_args, **_kwargs: setattr(row, "status", "running")),
+        mark_completed=AsyncMock(
+            side_effect=lambda *_args, **_kwargs: setattr(row, "status", "completed")
+        ),
+        mark_failed=AsyncMock(),
+    )
+    service._collect_portfolio_timeseries_for_export = AsyncMock(  # pylint: disable=protected-access
+        return_value=([{"valuation_date": "2025-01-01"}], 1)
+    )
+
+    response = await service.create_export_job(
+        AnalyticsExportCreateRequest(
+            dataset_type="portfolio_timeseries",
+            portfolio_id="P1",
+            portfolio_timeseries_request=PortfolioAnalyticsTimeseriesRequest(
+                as_of_date="2025-12-31",
+                period="one_month",
+            ),
+            result_format="json",
+            compression="none",
+        )
+    )
+    assert response.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_get_export_job_not_found() -> None:
+    service = make_service()
+    service.export_repo = SimpleNamespace(get_job=AsyncMock(return_value=None))
+    with pytest.raises(AnalyticsInputError) as exc_info:
+        await service.get_export_job("missing")
+    assert exc_info.value.code == "RESOURCE_NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_get_export_result_ndjson_gzip() -> None:
+    service = make_service()
+    row = SimpleNamespace(
+        job_id="aexp_1",
+        dataset_type="portfolio_timeseries",
+        status="completed",
+        result_payload={
+            "job_id": "aexp_1",
+            "dataset_type": "portfolio_timeseries",
+            "generated_at": "2026-03-01T12:00:00Z",
+            "contract_version": "rfc_063_v1",
+            "data": [{"valuation_date": "2025-01-01"}],
+        },
+    )
+    service.export_repo = SimpleNamespace(get_job=AsyncMock(return_value=row))
+    payload, media_type, encoding = await service.get_export_result_ndjson(
+        "aexp_1", compression="gzip"
+    )
+    assert media_type == "application/x-ndjson"
+    assert encoding == "gzip"
+    assert len(payload) > 0
+
+
+def test_jsonable_converts_decimal_and_date() -> None:
+    service = make_service()
+    converted = service._jsonable(  # pylint: disable=protected-access
+        {"amount": Decimal("1.23"), "as_of_date": date(2025, 1, 1), "nested": [Decimal("2.00")]}
+    )
+    assert converted == {
+        "amount": "1.23",
+        "as_of_date": "2025-01-01",
+        "nested": ["2.00"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_export_job_reuses_existing() -> None:
+    service = make_service()
+    existing = SimpleNamespace(
+        job_id="aexp_existing",
+        dataset_type="portfolio_timeseries",
+        portfolio_id="P1",
+        status="completed",
+        request_fingerprint="fp",
+        result_format="json",
+        compression="none",
+        result_row_count=1,
+        error_message=None,
+        created_at=datetime(2026, 3, 1, tzinfo=UTC),
+        started_at=datetime(2026, 3, 1, tzinfo=UTC),
+        completed_at=datetime(2026, 3, 1, tzinfo=UTC),
+    )
+    service.export_repo = SimpleNamespace(
+        get_latest_by_fingerprint=AsyncMock(return_value=existing),
+    )
+    response = await service.create_export_job(
+        AnalyticsExportCreateRequest(
+            dataset_type="portfolio_timeseries",
+            portfolio_id="P1",
+            portfolio_timeseries_request=PortfolioAnalyticsTimeseriesRequest(
+                as_of_date="2025-12-31",
+                period="one_month",
+            ),
+        )
+    )
+    assert response.job_id == "aexp_existing"
+
+
+@pytest.mark.asyncio
+async def test_create_export_job_marks_failed_on_input_error() -> None:
+    service = make_service()
+    row = SimpleNamespace(
+        job_id="aexp_2",
+        dataset_type="position_timeseries",
+        portfolio_id="P1",
+        status="accepted",
+        request_fingerprint="fp1",
+        result_format="json",
+        compression="none",
+        result_row_count=None,
+        error_message=None,
+        created_at=datetime(2026, 3, 1, tzinfo=UTC),
+        started_at=None,
+        completed_at=None,
+    )
+    service.export_repo = SimpleNamespace(
+        get_latest_by_fingerprint=AsyncMock(return_value=None),
+        create_job=AsyncMock(return_value=row),
+        mark_running=AsyncMock(),
+        mark_completed=AsyncMock(),
+        mark_failed=AsyncMock(side_effect=lambda *_a, **_k: setattr(row, "status", "failed")),
+    )
+    service._collect_position_timeseries_for_export = AsyncMock(  # pylint: disable=protected-access
+        side_effect=AnalyticsInputError("INSUFFICIENT_DATA", "missing")
+    )
+    response = await service.create_export_job(
+        AnalyticsExportCreateRequest(
+            dataset_type="position_timeseries",
+            portfolio_id="P1",
+            position_timeseries_request=PositionAnalyticsTimeseriesRequest(
+                as_of_date="2025-12-31",
+                period="one_month",
+            ),
+        )
+    )
+    assert response.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_get_export_result_json_error_branches() -> None:
+    service = make_service()
+    service.export_repo = SimpleNamespace(get_job=AsyncMock(return_value=None))
+    with pytest.raises(AnalyticsInputError):
+        await service.get_export_result_json("missing")
+
+    service.export_repo = SimpleNamespace(
+        get_job=AsyncMock(return_value=SimpleNamespace(status="running", result_payload={}))
+    )
+    with pytest.raises(AnalyticsInputError):
+        await service.get_export_result_json("running")
+
+    service.export_repo = SimpleNamespace(
+        get_job=AsyncMock(return_value=SimpleNamespace(status="completed", result_payload="bad"))
+    )
+    with pytest.raises(AnalyticsInputError):
+        await service.get_export_result_json("bad")
+
+
+@pytest.mark.asyncio
+async def test_get_export_result_ndjson_error_and_plain_branches() -> None:
+    service = make_service()
+    service.export_repo = SimpleNamespace(get_job=AsyncMock(return_value=None))
+    with pytest.raises(AnalyticsInputError):
+        await service.get_export_result_ndjson("missing", compression="none")
+
+    service.export_repo = SimpleNamespace(
+        get_job=AsyncMock(return_value=SimpleNamespace(status="running", result_payload={}))
+    )
+    with pytest.raises(AnalyticsInputError):
+        await service.get_export_result_ndjson("running", compression="none")
+
+    service.export_repo = SimpleNamespace(
+        get_job=AsyncMock(return_value=SimpleNamespace(status="completed", result_payload="bad"))
+    )
+    with pytest.raises(AnalyticsInputError):
+        await service.get_export_result_ndjson("bad", compression="none")
+
+    service.export_repo = SimpleNamespace(
+        get_job=AsyncMock(
+            return_value=SimpleNamespace(
+                status="completed",
+                job_id="aexp_ok",
+                dataset_type="portfolio_timeseries",
+                result_payload={"generated_at": "2026-03-01T00:00:00Z", "contract_version": "rfc_063_v1", "data": "bad"},
+            )
+        )
+    )
+    with pytest.raises(AnalyticsInputError):
+        await service.get_export_result_ndjson("malformed", compression="none")
+
+    service.export_repo = SimpleNamespace(
+        get_job=AsyncMock(
+            return_value=SimpleNamespace(
+                status="completed",
+                job_id="aexp_ok",
+                dataset_type="portfolio_timeseries",
+                result_payload={
+                    "generated_at": "2026-03-01T00:00:00Z",
+                    "contract_version": "rfc_063_v1",
+                    "data": [{"valuation_date": "2025-01-01"}],
+                },
+            )
+        )
+    )
+    payload, media_type, encoding = await service.get_export_result_ndjson(
+        "aexp_ok", compression="none"
+    )
+    assert media_type == "application/x-ndjson"
+    assert encoding == "none"
+    assert b'"record_type":"metadata"' in payload
+
+
+@pytest.mark.asyncio
+async def test_collect_export_helpers_page_through_all_tokens() -> None:
+    service = make_service()
+    service.get_portfolio_timeseries = AsyncMock(
+        side_effect=[
+            SimpleNamespace(
+                observations=[SimpleNamespace(model_dump=lambda mode="json": {"d": "1"})],
+                page=SimpleNamespace(next_page_token="n1"),
+            ),
+            SimpleNamespace(
+                observations=[SimpleNamespace(model_dump=lambda mode="json": {"d": "2"})],
+                page=SimpleNamespace(next_page_token=None),
+            ),
+        ]
+    )
+    rows, depth = await service._collect_portfolio_timeseries_for_export(  # pylint: disable=protected-access
+        portfolio_id="P1",
+        request=PortfolioAnalyticsTimeseriesRequest(
+            as_of_date="2025-12-31",
+            period="one_month",
+        ),
+    )
+    assert rows == [{"d": "1"}, {"d": "2"}]
+    assert depth == 2
+
+    service.get_position_timeseries = AsyncMock(
+        side_effect=[
+            SimpleNamespace(
+                rows=[SimpleNamespace(model_dump=lambda mode="json": {"p": "1"})],
+                page=SimpleNamespace(next_page_token="n1"),
+            ),
+            SimpleNamespace(
+                rows=[SimpleNamespace(model_dump=lambda mode="json": {"p": "2"})],
+                page=SimpleNamespace(next_page_token=None),
+            ),
+        ]
+    )
+    rows_pos, depth_pos = await service._collect_position_timeseries_for_export(  # pylint: disable=protected-access
+        portfolio_id="P1",
+        request=PositionAnalyticsTimeseriesRequest(
+            as_of_date="2025-12-31",
+            period="one_month",
+        ),
+    )
+    assert rows_pos == [{"p": "1"}, {"p": "2"}]
+    assert depth_pos == 2


### PR DESCRIPTION
## Summary
- add durable analytics export job model and migration (nalytics_export_jobs)
- implement RFC-063 export contracts:
  - POST /integration/exports/analytics-timeseries/jobs
  - GET /integration/exports/analytics-timeseries/jobs/{job_id}
  - GET /integration/exports/analytics-timeseries/jobs/{job_id}/result
- support result retrieval in json and 
djson with optional gzip
- add export observability metrics for job outcomes, duration, payload bytes, and page depth
- add repository/service/router coverage and integration dependency tests

## Validation
- make ci-local
- make migration-smoke
- make openapi-gate
- make api-vocabulary-gate
