### PR TITLE
ci(core): start docker smoke earlier in pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
 
   docker-build:
     name: Validate Docker Build
-    needs: [quality, coverage-gate]
+    needs: [quality]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
## Summary\n- change docker-smoke-contract job dependency from [quality, coverage-gate] to [quality]\n\n## Why\n- allows Docker smoke to run in parallel with coverage gate\n- reduces end-to-end CI wall-clock time\n- keeps quality gates intact (coverage still required as independent check)\n\n## Quality\n- no checks removed\n- no thresholds lowered\n- no test scope reduced