### PR TITLE
RFC 065 Phase 0: calculator SLO baseline and operations runbook

### DIFF
--- a/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
+++ b/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
@@ -1,0 +1,167 @@
+# RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap
+
+## Status
+Proposed (Needs Approval)
+
+## Date
+2026-03-03
+
+## Owners
+- lotus-core: calculator pipeline and canonical processing contracts
+- lotus-platform: governance and operational standards
+
+## 1. Summary
+This RFC defines a structured, incremental plan to scale lotus-core calculators for high processing load while preserving financial correctness, determinism, and operational reliability.
+
+The design leverages event-driven architecture as the primary scaling model: partitioned workload distribution, independent consumer-group scaling per calculator, idempotent processing, backlog-aware autoscaling, and robust replay/operations controls.
+
+## 2. Goals
+1. Support materially higher ingestion and calculation throughput without correctness regressions.
+2. Maintain deterministic ordering where financially required.
+3. Scale each calculator independently based on its own backlog and latency profile.
+4. Improve failure isolation, replay safety, and operational visibility.
+5. Deliver improvements in controlled phases with measurable acceptance criteria.
+
+## 3. Non-Goals
+1. Re-architect all calculators in a single release.
+2. Move performance/risk analytics calculations into lotus-core.
+3. Introduce non-canonical naming or cross-service vocabulary drift.
+
+## 4. Partitioning Strategy (Decision)
+
+### 4.1 Approved default model
+Your proposal is directionally correct and should be the baseline:
+
+1. Transaction processing partition key: `portfolio_id`
+2. Position-level derived processing partition key: `portfolio_id + instrument_id`
+3. Portfolio rollups partition key: `portfolio_id`
+
+### 4.2 Why this is correct
+1. Portfolio-level transaction ordering preserves accounting integrity for related events:
+- buys/sells and associated cash
+- corporate actions affecting lots/cost basis
+- transfers and ledger-linked adjustments
+2. Position-level fan-out enables high parallelism after transaction-state consistency is established.
+3. Rollup-by-portfolio aligns naturally with NAV/exposure aggregation outputs.
+
+### 4.3 Required refinements
+1. Define deterministic tie-break order inside a partition:
+- business date/effective timestamp
+- transaction timestamp
+- ingestion sequence/event id
+2. Add skew controls for very large portfolios:
+- backlog-aware worker autoscaling
+- optional sub-partition strategy for replay-only flows if needed
+3. Preserve strict per-key ordering only where required; allow wider parallelism for stateless enrichment tasks.
+
+## 5. Target Operating Model
+
+### 5.1 Topic and consumer-group boundaries
+1. Isolate calculators in separate consumer groups:
+- position
+- cost
+- valuation
+- cashflow
+- timeseries
+2. Keep domain-event topics immutable/canonical; introduce dedicated derived topics when needed for heavy stages.
+
+### 5.2 Idempotency and write safety
+1. Every consumer must be idempotent by event identity + version.
+2. State writes must be compare-and-set/upsert safe.
+3. Job transitions must be atomic and epoch/version fenced.
+
+### 5.3 Backpressure and workload classes
+1. Split hot path vs heavy path:
+- hot path: transaction-to-state correctness updates
+- heavy path: historical rebuild/recompute
+2. Introduce explicit backlog controls and prioritization.
+
+### 5.4 Replay and failure management
+1. Standard dead-letter queues with deterministic failure codes.
+2. Replay tools by key/date range with auditable execution metadata.
+
+## 6. Incremental Delivery Plan
+
+### Phase 0 - Baseline instrumentation and SLOs
+1. Establish per-calculator SLOs:
+- consumer lag
+- lag age seconds
+- end-to-end processing latency
+- failure/retry rate
+2. Add dashboards and alert thresholds.
+
+Acceptance:
+1. SLO dashboard exists for each calculator.
+2. On-call runbook includes lag spike and stuck-partition handling.
+
+### Phase 1 - Partitioning and ordering hardening
+1. Enforce partition-key standards in producer and consumer contracts.
+2. Implement deterministic in-partition ordering tie-breaks.
+3. Validate no ordering regressions via characterization tests.
+
+Acceptance:
+1. Deterministic outcomes under shuffled ingestion order.
+2. No duplicate accounting side-effects in replay tests.
+
+### Phase 2 - Independent scaling controls
+1. Configure autoscaling per calculator group using lag/latency metrics.
+2. Apply min replicas and burst profile per workload class.
+3. Tune fetch/batch/commit settings per calculator.
+
+Acceptance:
+1. Sustained high-load run meets SLOs.
+2. No cross-calculator starvation.
+
+### Phase 3 - Backpressure, DLQ, and replay reliability
+1. Add standardized DLQ policy with reason-code taxonomy.
+2. Add replay controls with rate limiting and blast-radius guardrails.
+3. Add backlog-threshold controls for non-critical workloads.
+
+Acceptance:
+1. Poison events isolated without pipeline collapse.
+2. Replay completion is deterministic and auditable.
+
+### Phase 4 - Throughput optimization
+1. Introduce safe micro-batching for heavy writes.
+2. Tune DB indexes and query plans for bottleneck paths.
+3. Reduce job-table contention with optimized claim/update patterns.
+
+Acceptance:
+1. Measured throughput uplift versus Phase 0 baseline.
+2. No correctness drift under concurrency stress tests.
+
+### Phase 5 - Production hardening and governance closeout
+1. Document operating envelopes and scaling playbooks.
+2. Add CI smoke/load checks for key contracts.
+3. Final architecture review and governance sign-off.
+
+Acceptance:
+1. All required checks green.
+2. Operations team runbook approved.
+
+## 7. Test Strategy
+1. Unit tests for idempotency and ordering logic.
+2. Integration tests for end-to-end event flow across calculators.
+3. Concurrency and replay tests (duplicate, delayed, out-of-order events).
+4. Load tests by workload profile (steady-state and burst).
+
+## 8. Risks and Mitigations
+1. Hot-key skew on large portfolios
+- Mitigation: autoscaling + backlog controls + replay-specific partition strategy
+2. Hidden ordering dependencies across calculators
+- Mitigation: explicit contracts and characterization tests
+3. Retry storms
+- Mitigation: bounded retries, DLQ policies, exponential backoff
+4. Job-table contention
+- Mitigation: claim strategy tuning, index optimization, batch updates
+
+## 9. Open Decisions
+1. Maximum acceptable lag age by calculator under peak load.
+2. Replay isolation policy (shared workers vs dedicated workers).
+3. Partition count growth strategy and rebalancing procedure.
+
+## 10. Definition of Done
+1. All phases completed or formally deferred with rationale.
+2. SLOs consistently met in load and replay scenarios.
+3. No financial correctness regressions in characterization suites.
+4. Full operational runbook and monitoring coverage in place.

--- a/docs/operations/Calculator-SLO-Baseline-Runbook.md
+++ b/docs/operations/Calculator-SLO-Baseline-Runbook.md
@@ -1,0 +1,77 @@
+# Calculator SLO Baseline Runbook (RFC 065 Phase 0)
+
+## Purpose
+Define the minimum operational baseline for calculator throughput and reliability before scaling changes in RFC 065.
+
+## Scope
+Per-portfolio operational SLO snapshot for:
+1. Valuation calculator
+2. Portfolio aggregation (timeseries rollup)
+3. Reprocessing key activity
+
+Endpoint:
+- `GET /support/portfolios/{portfolio_id}/calculator-slos`
+
+## Response Interpretation
+`valuation` and `aggregation` include:
+1. `pending_jobs`: queued work not started
+2. `processing_jobs`: active work in progress
+3. `stale_processing_jobs`: jobs in processing beyond stale threshold
+4. `failed_jobs`: terminal failed jobs currently present
+5. `failed_jobs_last_24h`: recent fail velocity indicator
+6. `oldest_open_job_date`: oldest open job business date
+7. `backlog_age_days`: age of backlog against `business_date`
+
+`reprocessing` includes:
+1. `active_reprocessing_keys`: number of keys under replay/reprocessing
+
+## Initial SLO Targets (Phase 0 Baseline)
+These are baseline targets and should be tuned from production observations.
+
+### Valuation
+1. `stale_processing_jobs == 0`
+2. `backlog_age_days <= 1` under normal daily flow
+3. `failed_jobs_last_24h == 0` for stable periods
+
+### Aggregation
+1. `stale_processing_jobs == 0`
+2. `backlog_age_days <= 1` under normal daily flow
+3. `failed_jobs_last_24h == 0` for stable periods
+
+### Reprocessing
+1. `active_reprocessing_keys == 0` outside planned replay windows
+2. During replay windows, key count should trend down monotonically
+
+## Alert Thresholds
+Set warning/critical thresholds:
+
+1. Warning:
+- `valuation.backlog_age_days >= 2`
+- `aggregation.backlog_age_days >= 2`
+- any `failed_jobs_last_24h > 0`
+2. Critical:
+- any `stale_processing_jobs > 0`
+- `backlog_age_days >= 5`
+- `active_reprocessing_keys` increasing for consecutive checks
+
+## Incident Triage Flow
+1. Call `/support/portfolios/{portfolio_id}/calculator-slos`.
+2. If stale processing > 0:
+- inspect `/support/portfolios/{portfolio_id}/valuation-jobs?status=PROCESSING`
+- inspect `/support/portfolios/{portfolio_id}/aggregation-jobs?status=PROCESSING`
+3. If fail velocity > 0:
+- inspect `.../valuation-jobs?status=FAILED` and latest failure reason
+- inspect `.../aggregation-jobs?status=FAILED`
+4. If backlog age rises:
+- verify business date progression
+- verify worker availability and consumer lag
+- verify no blocking reprocessing floods
+
+## Review Cadence
+1. Daily: check critical portfolios
+2. Weekly: trend `backlog_age_days` and `failed_jobs_last_24h`
+3. Monthly: recalibrate thresholds based on observed load profile
+
+## Notes
+1. This runbook is intentionally portfolio-scoped to support targeted investigation.
+2. Platform-wide SLO dashboards should aggregate these metrics across portfolios in later RFC 065 phases.

--- a/src/services/query_service/app/dtos/operations_dto.py
+++ b/src/services/query_service/app/dtos/operations_dto.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, datetime
 from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
@@ -93,6 +93,86 @@ class SupportOverviewResponse(BaseModel):
             "daily_position_snapshot exists for the same portfolio/security/epoch."
         ),
         examples=[0],
+    )
+
+
+class CalculatorSloBucket(BaseModel):
+    pending_jobs: int = Field(
+        ...,
+        description="Count of jobs currently waiting in PENDING state.",
+        examples=[12],
+    )
+    processing_jobs: int = Field(
+        ...,
+        description="Count of jobs actively processing.",
+        examples=[3],
+    )
+    stale_processing_jobs: int = Field(
+        ...,
+        description="Count of PROCESSING jobs older than stale threshold (15 minutes).",
+        examples=[1],
+    )
+    failed_jobs: int = Field(
+        ...,
+        description="Count of jobs currently in FAILED terminal state.",
+        examples=[0],
+    )
+    failed_jobs_last_24h: int = Field(
+        ...,
+        description="Count of jobs that moved to FAILED state in the last 24 hours.",
+        examples=[2],
+    )
+    oldest_open_job_date: Optional[date] = Field(
+        None,
+        description="Oldest business date among open jobs (PENDING/PROCESSING).",
+        examples=["2026-02-25"],
+    )
+    backlog_age_days: Optional[int] = Field(
+        None,
+        description=(
+            "Age in days from oldest_open_job_date to business_date "
+            "(or current UTC date when business_date is unavailable)."
+        ),
+        examples=[7],
+    )
+
+
+class ReprocessingSloBucket(BaseModel):
+    active_reprocessing_keys: int = Field(
+        ...,
+        description="Number of position keys currently in REPROCESSING state.",
+        examples=[4],
+    )
+
+
+class CalculatorSloResponse(BaseModel):
+    portfolio_id: str = Field(..., description="Unique portfolio identifier.", examples=["PF-001"])
+    business_date: Optional[date] = Field(
+        None,
+        description="Latest business date from default business calendar.",
+        examples=["2026-03-02"],
+    )
+    stale_threshold_minutes: int = Field(
+        ...,
+        description="Threshold used to classify stale processing jobs.",
+        examples=[15],
+    )
+    generated_at_utc: datetime = Field(
+        ...,
+        description="UTC timestamp when this SLO snapshot was generated.",
+        examples=["2026-03-03T10:05:11Z"],
+    )
+    valuation: CalculatorSloBucket = Field(
+        ...,
+        description="Valuation calculator SLO snapshot for this portfolio.",
+    )
+    aggregation: CalculatorSloBucket = Field(
+        ...,
+        description="Timeseries aggregation SLO snapshot for this portfolio.",
+    )
+    reprocessing: ReprocessingSloBucket = Field(
+        ...,
+        description="Reprocessing SLO snapshot for this portfolio.",
     )
 
 

--- a/src/services/query_service/app/repositories/operations_repository.py
+++ b/src/services/query_service/app/repositories/operations_repository.py
@@ -96,6 +96,91 @@ class OperationsRepository:
         )
         return int((await self.db.execute(stmt)).scalar_one() or 0)
 
+    async def get_processing_aggregation_jobs_count(self, portfolio_id: str) -> int:
+        stmt = (
+            select(func.count())
+            .select_from(PortfolioAggregationJob)
+            .where(
+                PortfolioAggregationJob.portfolio_id == portfolio_id,
+                PortfolioAggregationJob.status == "PROCESSING",
+            )
+        )
+        return int((await self.db.execute(stmt)).scalar_one() or 0)
+
+    async def get_stale_processing_aggregation_jobs_count(
+        self, portfolio_id: str, stale_minutes: int
+    ) -> int:
+        stale_threshold = datetime.now(timezone.utc) - timedelta(minutes=stale_minutes)
+        stmt = (
+            select(func.count())
+            .select_from(PortfolioAggregationJob)
+            .where(
+                PortfolioAggregationJob.portfolio_id == portfolio_id,
+                PortfolioAggregationJob.status == "PROCESSING",
+                PortfolioAggregationJob.updated_at < stale_threshold,
+            )
+        )
+        return int((await self.db.execute(stmt)).scalar_one() or 0)
+
+    async def get_valuation_failed_jobs_count(self, portfolio_id: str) -> int:
+        stmt = (
+            select(func.count())
+            .select_from(PortfolioValuationJob)
+            .where(
+                PortfolioValuationJob.portfolio_id == portfolio_id,
+                PortfolioValuationJob.status == "FAILED",
+            )
+        )
+        return int((await self.db.execute(stmt)).scalar_one() or 0)
+
+    async def get_valuation_failed_jobs_last_hours(
+        self, portfolio_id: str, hours: int
+    ) -> int:
+        since = datetime.now(timezone.utc) - timedelta(hours=hours)
+        stmt = (
+            select(func.count())
+            .select_from(PortfolioValuationJob)
+            .where(
+                PortfolioValuationJob.portfolio_id == portfolio_id,
+                PortfolioValuationJob.status == "FAILED",
+                PortfolioValuationJob.updated_at >= since,
+            )
+        )
+        return int((await self.db.execute(stmt)).scalar_one() or 0)
+
+    async def get_aggregation_failed_jobs_count(self, portfolio_id: str) -> int:
+        stmt = (
+            select(func.count())
+            .select_from(PortfolioAggregationJob)
+            .where(
+                PortfolioAggregationJob.portfolio_id == portfolio_id,
+                PortfolioAggregationJob.status == "FAILED",
+            )
+        )
+        return int((await self.db.execute(stmt)).scalar_one() or 0)
+
+    async def get_aggregation_failed_jobs_last_hours(
+        self, portfolio_id: str, hours: int
+    ) -> int:
+        since = datetime.now(timezone.utc) - timedelta(hours=hours)
+        stmt = (
+            select(func.count())
+            .select_from(PortfolioAggregationJob)
+            .where(
+                PortfolioAggregationJob.portfolio_id == portfolio_id,
+                PortfolioAggregationJob.status == "FAILED",
+                PortfolioAggregationJob.updated_at >= since,
+            )
+        )
+        return int((await self.db.execute(stmt)).scalar_one() or 0)
+
+    async def get_oldest_pending_aggregation_date(self, portfolio_id: str) -> Optional[date]:
+        stmt = select(func.min(PortfolioAggregationJob.aggregation_date)).where(
+            PortfolioAggregationJob.portfolio_id == portfolio_id,
+            PortfolioAggregationJob.status.in_(("PENDING", "PROCESSING")),
+        )
+        return (await self.db.execute(stmt)).scalar_one_or_none()
+
     async def get_latest_transaction_date(self, portfolio_id: str) -> Optional[date]:
         stmt = select(func.max(func.date(Transaction.transaction_date))).where(
             Transaction.portfolio_id == portfolio_id

--- a/src/services/query_service/app/routers/operations.py
+++ b/src/services/query_service/app/routers/operations.py
@@ -6,6 +6,7 @@ from portfolio_common.db import get_async_db_session
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..dtos.operations_dto import (
+    CalculatorSloResponse,
     LineageKeyListResponse,
     LineageResponse,
     SupportJobListResponse,
@@ -49,6 +50,43 @@ async def get_support_overview(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An unexpected server error occurred while building support overview.",
+        )
+
+
+@router.get(
+    "/support/portfolios/{portfolio_id}/calculator-slos",
+    response_model=CalculatorSloResponse,
+    responses={status.HTTP_404_NOT_FOUND: {"description": "Portfolio not found."}},
+    summary="Get calculator SLO baseline snapshot for a portfolio",
+    description=(
+        "What: Return calculator backlog, stale-processing, and failed-job baselines for one "
+        "portfolio.\n"
+        "How: Aggregate valuation/aggregation job states and reprocessing key counts in a single "
+        "support payload.\n"
+        "When: Use before scaling actions, during incidents, and for daily operational SLO checks."
+    ),
+)
+async def get_calculator_slos(
+    portfolio_id: str = Path(..., description="Portfolio identifier."),
+    stale_threshold_minutes: int = Query(
+        15,
+        ge=1,
+        le=1440,
+        description="Threshold in minutes used to classify stale PROCESSING jobs.",
+    ),
+    service: OperationsService = Depends(get_operations_service),
+):
+    try:
+        return await service.get_calculator_slos(
+            portfolio_id=portfolio_id, stale_threshold_minutes=stale_threshold_minutes
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    except Exception:
+        logger.exception("Failed to build calculator SLO snapshot for portfolio %s", portfolio_id)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An unexpected server error occurred while building calculator SLO snapshot.",
         )
 
 

--- a/src/services/query_service/app/services/operations_service.py
+++ b/src/services/query_service/app/services/operations_service.py
@@ -4,9 +4,12 @@ from datetime import datetime, timezone
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..dtos.operations_dto import (
+    CalculatorSloBucket,
+    CalculatorSloResponse,
     LineageKeyListResponse,
     LineageKeyRecord,
     LineageResponse,
+    ReprocessingSloBucket,
     SupportJobListResponse,
     SupportJobRecord,
     SupportOverviewResponse,
@@ -88,6 +91,84 @@ class OperationsService:
             latest_position_snapshot_date=latest_position_snapshot_date_unbounded,
             latest_booked_position_snapshot_date=latest_booked_position_snapshot_date,
             position_snapshot_history_mismatch_count=position_snapshot_history_mismatch_count,
+        )
+
+    async def get_calculator_slos(
+        self, portfolio_id: str, stale_threshold_minutes: int = 15
+    ) -> CalculatorSloResponse:
+        await self._ensure_portfolio_exists(portfolio_id)
+        (
+            latest_business_date,
+            active_reprocessing_keys,
+            valuation_pending,
+            valuation_processing,
+            valuation_stale_processing,
+            valuation_failed,
+            valuation_failed_last_24h,
+            valuation_oldest_open,
+            aggregation_pending,
+            aggregation_processing,
+            aggregation_stale_processing,
+            aggregation_failed,
+            aggregation_failed_last_24h,
+            aggregation_oldest_open,
+        ) = await asyncio.gather(
+            self.repo.get_latest_business_date(),
+            self.repo.get_active_reprocessing_keys_count(portfolio_id),
+            self.repo.get_pending_valuation_jobs_count(portfolio_id),
+            self.repo.get_processing_valuation_jobs_count(portfolio_id),
+            self.repo.get_stale_processing_valuation_jobs_count(
+                portfolio_id, stale_minutes=stale_threshold_minutes
+            ),
+            self.repo.get_valuation_failed_jobs_count(portfolio_id),
+            self.repo.get_valuation_failed_jobs_last_hours(portfolio_id, hours=24),
+            self.repo.get_oldest_pending_valuation_date(portfolio_id),
+            self.repo.get_pending_aggregation_jobs_count(portfolio_id),
+            self.repo.get_processing_aggregation_jobs_count(portfolio_id),
+            self.repo.get_stale_processing_aggregation_jobs_count(
+                portfolio_id, stale_minutes=stale_threshold_minutes
+            ),
+            self.repo.get_aggregation_failed_jobs_count(portfolio_id),
+            self.repo.get_aggregation_failed_jobs_last_hours(portfolio_id, hours=24),
+            self.repo.get_oldest_pending_aggregation_date(portfolio_id),
+        )
+
+        reference_date = latest_business_date or datetime.now(timezone.utc).date()
+        valuation_backlog_age_days = (
+            max(0, (reference_date - valuation_oldest_open).days)
+            if valuation_oldest_open is not None
+            else None
+        )
+        aggregation_backlog_age_days = (
+            max(0, (reference_date - aggregation_oldest_open).days)
+            if aggregation_oldest_open is not None
+            else None
+        )
+
+        return CalculatorSloResponse(
+            portfolio_id=portfolio_id,
+            business_date=latest_business_date,
+            stale_threshold_minutes=stale_threshold_minutes,
+            generated_at_utc=datetime.now(timezone.utc),
+            valuation=CalculatorSloBucket(
+                pending_jobs=valuation_pending,
+                processing_jobs=valuation_processing,
+                stale_processing_jobs=valuation_stale_processing,
+                failed_jobs=valuation_failed,
+                failed_jobs_last_24h=valuation_failed_last_24h,
+                oldest_open_job_date=valuation_oldest_open,
+                backlog_age_days=valuation_backlog_age_days,
+            ),
+            aggregation=CalculatorSloBucket(
+                pending_jobs=aggregation_pending,
+                processing_jobs=aggregation_processing,
+                stale_processing_jobs=aggregation_stale_processing,
+                failed_jobs=aggregation_failed,
+                failed_jobs_last_24h=aggregation_failed_last_24h,
+                oldest_open_job_date=aggregation_oldest_open,
+                backlog_age_days=aggregation_backlog_age_days,
+            ),
+            reprocessing=ReprocessingSloBucket(active_reprocessing_keys=active_reprocessing_keys),
         )
 
     async def get_lineage(self, portfolio_id: str, security_id: str) -> LineageResponse:

--- a/tests/integration/services/query_service/test_operations_router_dependency.py
+++ b/tests/integration/services/query_service/test_operations_router_dependency.py
@@ -62,6 +62,51 @@ async def test_support_overview_unexpected_maps_to_500(async_test_client):
     assert "support overview" in response.json()["detail"].lower()
 
 
+async def test_calculator_slos_success(async_test_client):
+    client, mock_service = async_test_client
+    mock_service.get_calculator_slos.return_value = {
+        "portfolio_id": "P1",
+        "business_date": date(2025, 8, 31),
+        "stale_threshold_minutes": 15,
+        "generated_at_utc": "2026-03-03T10:05:11Z",
+        "valuation": {
+            "pending_jobs": 2,
+            "processing_jobs": 1,
+            "stale_processing_jobs": 0,
+            "failed_jobs": 0,
+            "failed_jobs_last_24h": 0,
+            "oldest_open_job_date": date(2025, 8, 31),
+            "backlog_age_days": 0,
+        },
+        "aggregation": {
+            "pending_jobs": 1,
+            "processing_jobs": 0,
+            "stale_processing_jobs": 0,
+            "failed_jobs": 0,
+            "failed_jobs_last_24h": 0,
+            "oldest_open_job_date": date(2025, 8, 31),
+            "backlog_age_days": 0,
+        },
+        "reprocessing": {"active_reprocessing_keys": 0},
+    }
+
+    response = await client.get("/support/portfolios/P1/calculator-slos")
+
+    assert response.status_code == 200
+    assert response.json()["portfolio_id"] == "P1"
+    assert response.json()["valuation"]["pending_jobs"] == 2
+
+
+async def test_calculator_slos_unexpected_maps_to_500(async_test_client):
+    client, mock_service = async_test_client
+    mock_service.get_calculator_slos.side_effect = RuntimeError("boom")
+
+    response = await client.get("/support/portfolios/P1/calculator-slos")
+
+    assert response.status_code == 500
+    assert "calculator slo snapshot" in response.json()["detail"].lower()
+
+
 async def test_lineage_success(async_test_client):
     client, mock_service = async_test_client
     mock_service.get_lineage.return_value = {
@@ -220,6 +265,16 @@ async def test_support_overview_not_found_maps_to_404(async_test_client):
     mock_service.get_support_overview.side_effect = ValueError("not found")
 
     response = await client.get("/support/portfolios/P404/overview")
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+async def test_calculator_slos_not_found_maps_to_404(async_test_client):
+    client, mock_service = async_test_client
+    mock_service.get_calculator_slos.side_effect = ValueError("not found")
+
+    response = await client.get("/support/portfolios/P404/calculator-slos")
 
     assert response.status_code == 404
     assert "not found" in response.json()["detail"].lower()

--- a/tests/unit/services/query_service/repositories/test_operations_repository.py
+++ b/tests/unit/services/query_service/repositories/test_operations_repository.py
@@ -89,6 +89,37 @@ async def test_get_pending_aggregation_jobs_count(
     assert "portfolio_aggregation_jobs.status IN ('PENDING', 'PROCESSING')" in compiled
 
 
+async def test_get_processing_aggregation_jobs_count(
+    repository: OperationsRepository, mock_db_session: AsyncMock
+):
+    mock_execute_scalar_one(mock_db_session, 2)
+
+    value = await repository.get_processing_aggregation_jobs_count("P1")
+
+    assert value == 2
+    stmt = mock_db_session.execute.call_args[0][0]
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "from portfolio_aggregation_jobs" in compiled.lower()
+    assert "portfolio_aggregation_jobs.status = 'PROCESSING'" in compiled
+
+
+async def test_get_stale_processing_aggregation_jobs_count(
+    repository: OperationsRepository, mock_db_session: AsyncMock
+):
+    mock_execute_scalar_one(mock_db_session, 1)
+
+    value = await repository.get_stale_processing_aggregation_jobs_count(
+        "P1", stale_minutes=15
+    )
+
+    assert value == 1
+    stmt = mock_db_session.execute.call_args[0][0]
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "from portfolio_aggregation_jobs" in compiled.lower()
+    assert "portfolio_aggregation_jobs.status = 'PROCESSING'" in compiled
+    assert "portfolio_aggregation_jobs.updated_at <" in compiled
+
+
 async def test_get_processing_valuation_jobs_count(
     repository: OperationsRepository, mock_db_session: AsyncMock
 ):
@@ -130,6 +161,78 @@ async def test_get_oldest_pending_valuation_date(
     compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
     assert "min(portfolio_valuation_jobs.valuation_date)" in compiled.lower()
     assert "portfolio_valuation_jobs.status IN ('PENDING', 'PROCESSING')" in compiled
+
+
+async def test_get_oldest_pending_aggregation_date(
+    repository: OperationsRepository, mock_db_session: AsyncMock
+):
+    mock_execute_scalar_one_or_none(mock_db_session, date(2025, 8, 10))
+
+    value = await repository.get_oldest_pending_aggregation_date("P1")
+
+    assert value == date(2025, 8, 10)
+    stmt = mock_db_session.execute.call_args[0][0]
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "min(portfolio_aggregation_jobs.aggregation_date)" in compiled.lower()
+    assert "portfolio_aggregation_jobs.status IN ('PENDING', 'PROCESSING')" in compiled
+
+
+async def test_get_valuation_failed_jobs_count(
+    repository: OperationsRepository, mock_db_session: AsyncMock
+):
+    mock_execute_scalar_one(mock_db_session, 3)
+
+    value = await repository.get_valuation_failed_jobs_count("P1")
+
+    assert value == 3
+    stmt = mock_db_session.execute.call_args[0][0]
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "from portfolio_valuation_jobs" in compiled.lower()
+    assert "portfolio_valuation_jobs.status = 'FAILED'" in compiled
+
+
+async def test_get_valuation_failed_jobs_last_hours(
+    repository: OperationsRepository, mock_db_session: AsyncMock
+):
+    mock_execute_scalar_one(mock_db_session, 1)
+
+    value = await repository.get_valuation_failed_jobs_last_hours("P1", hours=24)
+
+    assert value == 1
+    stmt = mock_db_session.execute.call_args[0][0]
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "from portfolio_valuation_jobs" in compiled.lower()
+    assert "portfolio_valuation_jobs.status = 'FAILED'" in compiled
+    assert "portfolio_valuation_jobs.updated_at >=" in compiled
+
+
+async def test_get_aggregation_failed_jobs_count(
+    repository: OperationsRepository, mock_db_session: AsyncMock
+):
+    mock_execute_scalar_one(mock_db_session, 2)
+
+    value = await repository.get_aggregation_failed_jobs_count("P1")
+
+    assert value == 2
+    stmt = mock_db_session.execute.call_args[0][0]
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "from portfolio_aggregation_jobs" in compiled.lower()
+    assert "portfolio_aggregation_jobs.status = 'FAILED'" in compiled
+
+
+async def test_get_aggregation_failed_jobs_last_hours(
+    repository: OperationsRepository, mock_db_session: AsyncMock
+):
+    mock_execute_scalar_one(mock_db_session, 1)
+
+    value = await repository.get_aggregation_failed_jobs_last_hours("P1", hours=24)
+
+    assert value == 1
+    stmt = mock_db_session.execute.call_args[0][0]
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "from portfolio_aggregation_jobs" in compiled.lower()
+    assert "portfolio_aggregation_jobs.status = 'FAILED'" in compiled
+    assert "portfolio_aggregation_jobs.updated_at >=" in compiled
 
 
 async def test_get_latest_transaction_date(

--- a/tests/unit/services/query_service/services/test_operations_service.py
+++ b/tests/unit/services/query_service/services/test_operations_service.py
@@ -190,3 +190,34 @@ async def test_get_support_overview_without_business_date(
     assert response.latest_booked_position_snapshot_date is None
     mock_ops_repo.get_latest_transaction_date_as_of.assert_not_awaited()
     mock_ops_repo.get_latest_snapshot_date_for_current_epoch_as_of.assert_not_awaited()
+
+
+async def test_get_calculator_slos(service: OperationsService, mock_ops_repo: AsyncMock):
+    mock_ops_repo.get_latest_business_date.return_value = date(2025, 8, 30)
+    mock_ops_repo.get_active_reprocessing_keys_count.return_value = 2
+    mock_ops_repo.get_pending_valuation_jobs_count.return_value = 7
+    mock_ops_repo.get_processing_valuation_jobs_count.return_value = 3
+    mock_ops_repo.get_stale_processing_valuation_jobs_count.return_value = 1
+    mock_ops_repo.get_valuation_failed_jobs_count.return_value = 4
+    mock_ops_repo.get_valuation_failed_jobs_last_hours.return_value = 2
+    mock_ops_repo.get_oldest_pending_valuation_date.return_value = date(2025, 8, 20)
+    mock_ops_repo.get_pending_aggregation_jobs_count.return_value = 5
+    mock_ops_repo.get_processing_aggregation_jobs_count.return_value = 2
+    mock_ops_repo.get_stale_processing_aggregation_jobs_count.return_value = 1
+    mock_ops_repo.get_aggregation_failed_jobs_count.return_value = 1
+    mock_ops_repo.get_aggregation_failed_jobs_last_hours.return_value = 1
+    mock_ops_repo.get_oldest_pending_aggregation_date.return_value = date(2025, 8, 25)
+
+    response = await service.get_calculator_slos("P1", stale_threshold_minutes=15)
+
+    assert response.portfolio_id == "P1"
+    assert response.business_date == date(2025, 8, 30)
+    assert response.stale_threshold_minutes == 15
+    assert response.valuation.pending_jobs == 7
+    assert response.valuation.failed_jobs == 4
+    assert response.valuation.failed_jobs_last_24h == 2
+    assert response.valuation.backlog_age_days == 10
+    assert response.aggregation.pending_jobs == 5
+    assert response.aggregation.failed_jobs == 1
+    assert response.aggregation.backlog_age_days == 5
+    assert response.reprocessing.active_reprocessing_keys == 2


### PR DESCRIPTION
## Summary
- add RFC 065 roadmap for event-driven calculator scalability and reliability
- add Phase 0 operational baseline endpoint `GET /support/portfolios/{portfolio_id}/calculator-slos`
- extend operations DTO/repository/service/router for valuation/aggregation/reprocessing SLO snapshot fields
- add Phase 0 runbook with initial SLO targets and incident triage flow
- add unit/integration test coverage for the new SLO contract

## Validation
- `python -m py_compile src/services/query_service/app/dtos/operations_dto.py src/services/query_service/app/repositories/operations_repository.py src/services/query_service/app/services/operations_service.py src/services/query_service/app/routers/operations.py tests/unit/services/query_service/services/test_operations_service.py tests/unit/services/query_service/repositories/test_operations_repository.py tests/integration/services/query_service/test_operations_router_dependency.py`

## Notes
- `pytest` is currently unavailable in the local venv on this machine (`No module named pytest`), so compile checks were used for local sanity and CI will be source of truth for test execution.
