### PR TITLE
RFC 065 Phase 1: deterministic ordering + partition key hardening

### DIFF
--- a/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
+++ b/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
@@ -1,7 +1,7 @@
 # RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap
 
 ## Status
-Proposed (Needs Approval)
+In Progress (Phase 1 hardening underway)
 
 ## Date
 2026-03-03
@@ -165,3 +165,26 @@ Acceptance:
 2. SLOs consistently met in load and replay scenarios.
 3. No financial correctness regressions in characterization suites.
 4. Full operational runbook and monitoring coverage in place.
+
+## 11. Implementation Progress (2026-03-03)
+
+### Completed in this change set
+1. Partition-key hardening at ingestion publish boundary:
+- transaction publish now rejects empty `portfolio_id` partition keys
+- transaction partition keys are normalized (`strip`) before Kafka publish
+2. Deterministic replay ordering hardening:
+- added canonical transaction ordering function with explicit tie-breaks:
+  - effective business date (derived from transaction timestamp)
+  - transaction timestamp
+  - ingestion timestamp (`created_at`) when available
+  - transaction id
+- position replay now uses deterministic ordering key
+- replay query ordering no longer uses surrogate DB id as tie-break; uses `transaction_id`
+3. Persistence safety update:
+- transaction UPSERT now excludes `None` values to prevent nullable event fields
+  from clobbering non-null DB defaults
+
+### Validation coverage added
+1. Unit tests for transaction partition-key guardrails in ingestion service
+2. Unit tests for deterministic transaction ordering helper
+3. Unit test for deterministic ordering in backdated replay flow

--- a/src/libs/portfolio-common/portfolio_common/events.py
+++ b/src/libs/portfolio-common/portfolio_common/events.py
@@ -1,5 +1,5 @@
 # libs/portfolio-common/portfolio_common/events.py
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import Optional
 from pydantic import BaseModel, Field, ConfigDict
 from decimal import Decimal
@@ -111,7 +111,26 @@ class TransactionEvent(BaseModel):
     calculation_policy_id: Optional[str] = None
     calculation_policy_version: Optional[str] = None
     source_system: Optional[str] = None
+    created_at: Optional[datetime] = None
     epoch: Optional[int] = None
+
+
+def transaction_event_ordering_key(event: "TransactionEvent") -> tuple[date, datetime, datetime, str]:
+    """
+    Deterministic intra-partition ordering for transaction processing.
+    Priority:
+    1) effective business date (derived from transaction_date)
+    2) transaction timestamp
+    3) ingestion timestamp (created_at when present)
+    4) stable event identity (transaction_id)
+    """
+    ingestion_ts = event.created_at or datetime.fromtimestamp(0, tz=timezone.utc)
+    return (
+        event.transaction_date.date(),
+        event.transaction_date,
+        ingestion_ts,
+        event.transaction_id,
+    )
 
 class DailyPositionSnapshotPersistedEvent(BaseModel):
     """

--- a/src/services/calculators/position_calculator/app/core/position_logic.py
+++ b/src/services/calculators/position_calculator/app/core/position_logic.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 from sqlalchemy.ext.asyncio import AsyncSession
 from portfolio_common.database_models import PositionHistory, Transaction as DBTransaction, PositionState
 from ..core.position_models import PositionState as PositionStateDTO
-from portfolio_common.events import TransactionEvent
+from portfolio_common.events import TransactionEvent, transaction_event_ordering_key
 from ..repositories.position_repository import PositionRepository
 from portfolio_common.position_state_repository import PositionStateRepository
 from portfolio_common.outbox_repository import OutboxRepository
@@ -84,7 +84,8 @@ class PositionCalculator:
             # Combine historical events with the current triggering event
             all_events_to_replay = [TransactionEvent.model_validate(t) for t in historical_db_txns]
             all_events_to_replay.append(event)
-            all_events_to_replay.sort(key=lambda x: x.transaction_date) # Re-sort to ensure chronological order
+            # Ensure replay order is deterministic even when timestamps collide.
+            all_events_to_replay.sort(key=transaction_event_ordering_key)
             
             logger.info(f"Atomically queuing {len(all_events_to_replay)} events for reprocessing replay in Epoch {new_state.epoch}")
             for event_to_publish in all_events_to_replay:

--- a/src/services/calculators/position_calculator/app/repositories/position_repository.py
+++ b/src/services/calculators/position_calculator/app/repositories/position_repository.py
@@ -87,7 +87,7 @@ class PositionRepository:
         stmt = (
             select(Transaction)
             .where(Transaction.portfolio_id == portfolio_id, Transaction.security_id == security_id)
-            .order_by(Transaction.transaction_date.asc(), Transaction.id.asc())
+            .order_by(Transaction.transaction_date.asc(), Transaction.transaction_id.asc())
         )
         result = await self.db.execute(stmt)
         return result.scalars().all()
@@ -126,7 +126,7 @@ class PositionRepository:
             Transaction.portfolio_id == portfolio_id,
             Transaction.security_id == security_id,
             func.date(Transaction.transaction_date) >= a_date
-        ).order_by(Transaction.transaction_date.asc(), Transaction.id.asc())
+        ).order_by(Transaction.transaction_date.asc(), Transaction.transaction_id.asc())
 
         result = await self.db.execute(stmt)
         return result.scalars().all()

--- a/src/services/ingestion_service/app/services/ingestion_service.py
+++ b/src/services/ingestion_service/app/services/ingestion_service.py
@@ -42,6 +42,13 @@ class IngestionService:
             headers.append(("idempotency_key", idempotency_key.encode("utf-8")))
         return headers or None
 
+    @staticmethod
+    def _partition_key_or_raise(*, key: str, field_name: str) -> str:
+        normalized = key.strip()
+        if not normalized:
+            raise ValueError(f"Partition key field '{field_name}' must be non-empty.")
+        return normalized
+
     async def publish_business_dates(
         self, business_dates: List[BusinessDate], idempotency_key: str | None = None
     ) -> None:
@@ -87,10 +94,13 @@ class IngestionService:
         """Publishes a single transaction to the raw transactions topic."""
         headers = self._get_headers(idempotency_key)
         transaction_payload = transaction.model_dump()
+        partition_key = self._partition_key_or_raise(
+            key=transaction.portfolio_id, field_name="portfolio_id"
+        )
         try:
             self._kafka_producer.publish_message(
                 topic=KAFKA_RAW_TRANSACTIONS_TOPIC,
-                key=transaction.portfolio_id,
+                key=partition_key,
                 value=transaction_payload,
                 headers=headers,
             )
@@ -108,10 +118,13 @@ class IngestionService:
         headers = self._get_headers(idempotency_key)
         for transaction in transactions:
             transaction_payload = transaction.model_dump()
+            partition_key = self._partition_key_or_raise(
+                key=transaction.portfolio_id, field_name="portfolio_id"
+            )
             try:
                 self._kafka_producer.publish_message(
                     topic=KAFKA_RAW_TRANSACTIONS_TOPIC,
-                    key=transaction.portfolio_id,
+                    key=partition_key,
                     value=transaction_payload,
                     headers=headers,
                 )

--- a/src/services/persistence_service/app/repositories/transaction_db_repo.py
+++ b/src/services/persistence_service/app/repositories/transaction_db_repo.py
@@ -26,7 +26,8 @@ class TransactionDBRepository:
         try:
             # Exclude event-only fields that do not map to the transactions table.
             event_dict = event.model_dump(
-                exclude={"epoch", "brokerage", "stamp_duty", "exchange_fee", "gst", "other_fees"}
+                exclude={"epoch", "brokerage", "stamp_duty", "exchange_fee", "gst", "other_fees"},
+                exclude_none=True,
             )
             
             # The statement to execute.

--- a/tests/unit/libs/portfolio-common/test_events.py
+++ b/tests/unit/libs/portfolio-common/test_events.py
@@ -1,0 +1,41 @@
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from portfolio_common.events import TransactionEvent, transaction_event_ordering_key
+
+
+def _txn(transaction_id: str, transaction_date: datetime, created_at: datetime | None) -> TransactionEvent:
+    return TransactionEvent(
+        transaction_id=transaction_id,
+        portfolio_id="P1",
+        instrument_id="I1",
+        security_id="S1",
+        transaction_date=transaction_date,
+        transaction_type="BUY",
+        quantity=Decimal("1"),
+        price=Decimal("1"),
+        gross_transaction_amount=Decimal("1"),
+        trade_currency="USD",
+        currency="USD",
+        created_at=created_at,
+    )
+
+
+def test_transaction_event_ordering_key_is_deterministic_for_same_timestamp() -> None:
+    ts = datetime(2026, 1, 10, 8, 0, tzinfo=UTC)
+    later_ingest = datetime(2026, 1, 10, 8, 5, tzinfo=UTC)
+    earlier_ingest = datetime(2026, 1, 10, 8, 1, tzinfo=UTC)
+    txn_b = _txn("TXN_B", ts, later_ingest)
+    txn_a = _txn("TXN_A", ts, earlier_ingest)
+
+    ordered = sorted([txn_b, txn_a], key=transaction_event_ordering_key)
+    assert [t.transaction_id for t in ordered] == ["TXN_A", "TXN_B"]
+
+
+def test_transaction_event_ordering_key_uses_transaction_id_as_last_tiebreak() -> None:
+    ts = datetime(2026, 1, 10, 8, 0, tzinfo=UTC)
+    txn_b = _txn("TXN_B", ts, None)
+    txn_a = _txn("TXN_A", ts, None)
+
+    ordered = sorted([txn_b, txn_a], key=transaction_event_ordering_key)
+    assert [t.transaction_id for t in ordered] == ["TXN_A", "TXN_B"]

--- a/tests/unit/services/calculators/position_calculator/core/test_position_logic.py
+++ b/tests/unit/services/calculators/position_calculator/core/test_position_logic.py
@@ -164,6 +164,74 @@ async def test_calculate_re_emits_and_increments_metric_for_backdated_event(
     second_call_args = mock_outbox_repo.create_outbox_event.call_args_list[1].kwargs
     assert second_call_args['payload']['epoch'] == 1
 
+
+@pytest.mark.asyncio
+@patch("src.services.calculators.position_calculator.app.core.position_logic.EpochFencer")
+async def test_calculate_backdated_replay_has_deterministic_tie_break_order(
+    mock_fencer_class: MagicMock,
+    mock_repo: AsyncMock,
+    mock_state_repo: AsyncMock,
+    mock_outbox_repo: AsyncMock,
+    sample_event: TransactionEvent,
+):
+    """
+    GIVEN backdated replay candidates with identical transaction_date
+    WHEN reprocessing is triggered
+    THEN replay order is deterministic by transaction ordering key, not DB arrival order.
+    """
+    mock_fencer_instance = mock_fencer_class.return_value
+    mock_fencer_instance.check = AsyncMock(return_value=True)
+    sample_event.epoch = None
+    sample_event.transaction_id = "TXN_C"
+    sample_event.transaction_date = datetime(2025, 8, 20, 10, 0, 0)
+
+    mock_state_repo.get_or_create_state.return_value = PositionState(
+        watermark_date=date(2025, 8, 25), epoch=0
+    )
+    mock_state_repo.increment_epoch_and_reset_watermark.return_value = PositionState(epoch=1)
+
+    # Intentionally unsorted by transaction_id.
+    mock_repo.get_all_transactions_for_security.return_value = [
+        DBTransaction(
+            transaction_id="TXN_B",
+            portfolio_id="P1",
+            security_id="S1",
+            instrument_id="I1",
+            transaction_date=datetime(2025, 8, 20, 10, 0, 0),
+            transaction_type="BUY",
+            quantity=Decimal("1"),
+            price=Decimal("1"),
+            gross_transaction_amount=Decimal("1"),
+            trade_currency="USD",
+            currency="USD",
+            trade_fee=Decimal("0"),
+        ),
+        DBTransaction(
+            transaction_id="TXN_A",
+            portfolio_id="P1",
+            security_id="S1",
+            instrument_id="I1",
+            transaction_date=datetime(2025, 8, 20, 10, 0, 0),
+            transaction_type="BUY",
+            quantity=Decimal("1"),
+            price=Decimal("1"),
+            gross_transaction_amount=Decimal("1"),
+            trade_currency="USD",
+            currency="USD",
+            trade_fee=Decimal("0"),
+        ),
+    ]
+
+    await PositionCalculator.calculate(
+        sample_event, AsyncMock(), mock_repo, mock_state_repo, mock_outbox_repo
+    )
+
+    replay_ids = [
+        call.kwargs["payload"]["transaction_id"]
+        for call in mock_outbox_repo.create_outbox_event.call_args_list
+    ]
+    assert replay_ids == ["TXN_A", "TXN_B", "TXN_C"]
+
 def test_calculate_next_position_for_sell_uses_net_cost():
     """
     Verifies that for a SELL transaction, the cost basis is correctly reduced

--- a/tests/unit/services/ingestion_service/services/test_ingestion_service.py
+++ b/tests/unit/services/ingestion_service/services/test_ingestion_service.py
@@ -90,6 +90,56 @@ async def test_publish_transactions(
     assert call_args["value"]["transaction_id"] == "T1"
 
 
+async def test_publish_transactions_normalizes_partition_key(
+    ingestion_service: IngestionService, mock_kafka_producer: MagicMock
+):
+    transactions = [
+        Transaction(
+            transaction_id="T2",
+            portfolio_id="  P1  ",
+            instrument_id="I1",
+            security_id="S1",
+            transaction_date=datetime.now(),
+            transaction_type="BUY",
+            quantity=1,
+            price=1,
+            gross_transaction_amount=1,
+            trade_currency="USD",
+            currency="USD",
+        )
+    ]
+
+    await ingestion_service.publish_transactions(transactions)
+
+    call_args = mock_kafka_producer.publish_message.call_args.kwargs
+    assert call_args["key"] == "P1"
+
+
+async def test_publish_transactions_rejects_empty_partition_key(
+    ingestion_service: IngestionService, mock_kafka_producer: MagicMock
+):
+    transactions = [
+        Transaction(
+            transaction_id="T3",
+            portfolio_id="   ",
+            instrument_id="I1",
+            security_id="S1",
+            transaction_date=datetime.now(),
+            transaction_type="BUY",
+            quantity=1,
+            price=1,
+            gross_transaction_amount=1,
+            trade_currency="USD",
+            currency="USD",
+        )
+    ]
+
+    with pytest.raises(ValueError, match="portfolio_id"):
+        await ingestion_service.publish_transactions(transactions)
+
+    mock_kafka_producer.publish_message.assert_not_called()
+
+
 async def test_publish_with_correlation_id(
     ingestion_service: IngestionService, mock_kafka_producer: MagicMock
 ):


### PR DESCRIPTION
## Summary
- harden transaction ingestion partition keys (normalize + reject empty portfolio_id)
- add deterministic transaction ordering key for replay tie-breaks
- remove DB surrogate `id` tie-break from transaction replay queries and use stable `transaction_id`
- guard transaction UPSERT from null-overwriting defaults via `exclude_none=True`
- update RFC 065 with Phase 1 progress notes

## Tests
- `uvx --with pytest-asyncio --with pydantic --with fastapi --with sqlalchemy --with confluent-kafka --with prometheus-client --with requests --with python-dotenv --with python-json-logger pytest -q tests/unit/services/ingestion_service/services/test_ingestion_service.py`
- `uvx --with pytest-asyncio --with pydantic --with fastapi --with sqlalchemy --with confluent-kafka --with prometheus-client --with requests --with python-dotenv --with python-json-logger pytest -q tests/unit/libs/portfolio-common/test_events.py`
- `uvx --with pytest-asyncio --with pydantic --with fastapi --with sqlalchemy --with confluent-kafka --with prometheus-client --with requests --with python-dotenv --with python-json-logger --with psycopg2-binary --with asyncpg pytest -q tests/unit/services/calculators/position_calculator/core/test_position_logic.py`
