### PR TITLE
RFC 065 Phase 2: independent consumer scaling controls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,3 +47,11 @@ LOTUS_CORE_INGEST_RATE_LIMIT_ENABLED=true
 LOTUS_CORE_INGEST_RATE_LIMIT_WINDOW_SECONDS=60
 LOTUS_CORE_INGEST_RATE_LIMIT_MAX_REQUESTS=120
 LOTUS_CORE_INGEST_RATE_LIMIT_MAX_RECORDS=10000
+
+# Kafka consumer runtime tuning (Phase 2 scaling controls)
+# JSON object of global defaults applied to every consumer group.
+LOTUS_CORE_KAFKA_CONSUMER_DEFAULTS_JSON={"max.poll.interval.ms":300000,"fetch.min.bytes":1}
+# JSON object keyed by consumer group id for fine-grained overrides.
+# Example:
+# LOTUS_CORE_KAFKA_CONSUMER_GROUP_OVERRIDES_JSON={"position_calculator_group":{"fetch.min.bytes":4096},"timeseries_generator_group_portfolios":{"max.poll.interval.ms":600000}}
+LOTUS_CORE_KAFKA_CONSUMER_GROUP_OVERRIDES_JSON={}

--- a/deployment/kubernetes/keda/README.md
+++ b/deployment/kubernetes/keda/README.md
@@ -1,0 +1,30 @@
+# Lotus Core KEDA Scaling Profiles
+
+This folder contains KEDA `ScaledObject` definitions for calculator consumer groups.
+
+## Intent
+- Scale each calculator independently by Kafka lag.
+- Preserve ordering guarantees per partition/key while increasing throughput.
+- Separate hot-path and heavy-path groups with different min/max bounds.
+
+## Prerequisites
+1. KEDA installed in the cluster.
+2. Kafka bootstrap DNS reachable from KEDA operator and workloads.
+3. Deployments named in `calculator-scaledobjects.yaml` exist.
+
+## Usage
+1. Review and adjust namespace, bootstrap servers, and lag thresholds.
+2. Apply:
+   ```bash
+   kubectl apply -f deployment/kubernetes/keda/calculator-scaledobjects.yaml
+   ```
+3. Verify:
+   ```bash
+   kubectl get scaledobject -n lotus-core
+   kubectl describe scaledobject position-calculator-scaledobject -n lotus-core
+   ```
+
+## Tuning guidance
+- Increase `maxReplicaCount` only when partition counts and DB capacity can support it.
+- Use lower `lagThreshold` for low-latency calculators.
+- Keep replay/heavy workloads with higher lag thresholds and wider cooldown windows.

--- a/deployment/kubernetes/keda/calculator-scaledobjects.yaml
+++ b/deployment/kubernetes/keda/calculator-scaledobjects.yaml
@@ -1,0 +1,125 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: position-calculator-scaledobject
+  namespace: lotus-core
+spec:
+  scaleTargetRef:
+    name: position-calculator
+  minReplicaCount: 2
+  maxReplicaCount: 12
+  pollingInterval: 15
+  cooldownPeriod: 120
+  triggers:
+    - type: kafka
+      metadata:
+        bootstrapServers: kafka:9092
+        consumerGroup: position_calculator_group
+        topic: processed_transactions_completed
+        lagThreshold: "200"
+        offsetResetPolicy: latest
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: cost-calculator-scaledobject
+  namespace: lotus-core
+spec:
+  scaleTargetRef:
+    name: cost-calculator
+  minReplicaCount: 2
+  maxReplicaCount: 10
+  pollingInterval: 15
+  cooldownPeriod: 120
+  triggers:
+    - type: kafka
+      metadata:
+        bootstrapServers: kafka:9092
+        consumerGroup: cost_calculator_group
+        topic: raw_transactions_completed
+        lagThreshold: "200"
+        offsetResetPolicy: latest
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: valuation-calculator-scaledobject
+  namespace: lotus-core
+spec:
+  scaleTargetRef:
+    name: position-valuation-calculator
+  minReplicaCount: 2
+  maxReplicaCount: 10
+  pollingInterval: 15
+  cooldownPeriod: 120
+  triggers:
+    - type: kafka
+      metadata:
+        bootstrapServers: kafka:9092
+        consumerGroup: position_valuation_group_jobs
+        topic: valuation_required
+        lagThreshold: "150"
+        offsetResetPolicy: latest
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: cashflow-calculator-scaledobject
+  namespace: lotus-core
+spec:
+  scaleTargetRef:
+    name: cashflow-calculator
+  minReplicaCount: 1
+  maxReplicaCount: 8
+  pollingInterval: 20
+  cooldownPeriod: 180
+  triggers:
+    - type: kafka
+      metadata:
+        bootstrapServers: kafka:9092
+        consumerGroup: cashflow_calculator_group
+        topic: processed_transactions_completed
+        lagThreshold: "300"
+        offsetResetPolicy: latest
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: timeseries-position-scaledobject
+  namespace: lotus-core
+spec:
+  scaleTargetRef:
+    name: timeseries-generator
+  minReplicaCount: 1
+  maxReplicaCount: 6
+  pollingInterval: 20
+  cooldownPeriod: 240
+  triggers:
+    - type: kafka
+      metadata:
+        bootstrapServers: kafka:9092
+        consumerGroup: timeseries_generator_group_positions
+        topic: daily_position_snapshot_persisted
+        lagThreshold: "400"
+        offsetResetPolicy: latest
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: timeseries-portfolio-scaledobject
+  namespace: lotus-core
+spec:
+  scaleTargetRef:
+    name: timeseries-generator
+  minReplicaCount: 1
+  maxReplicaCount: 6
+  pollingInterval: 20
+  cooldownPeriod: 240
+  triggers:
+    - type: kafka
+      metadata:
+        bootstrapServers: kafka:9092
+        consumerGroup: timeseries_generator_group_portfolios
+        topic: portfolio_aggregation_required
+        lagThreshold: "400"
+        offsetResetPolicy: latest

--- a/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
+++ b/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
@@ -188,3 +188,13 @@ Acceptance:
 1. Unit tests for transaction partition-key guardrails in ingestion service
 2. Unit tests for deterministic transaction ordering helper
 3. Unit test for deterministic ordering in backdated replay flow
+
+### Phase 2 progress (2026-03-03)
+1. Added environment-driven Kafka consumer tuning:
+- global defaults via `LOTUS_CORE_KAFKA_CONSUMER_DEFAULTS_JSON`
+- per-consumer-group overrides via `LOTUS_CORE_KAFKA_CONSUMER_GROUP_OVERRIDES_JSON`
+- strict key whitelist and type coercion to prevent unsafe runtime config
+2. Applied runtime tuning automatically in `BaseConsumer` for every service consumer group.
+3. Added autoscaling deployment artifacts:
+- KEDA `ScaledObject` definitions for core calculator consumer groups
+- runbook-style usage notes and tuning guidance

--- a/src/libs/portfolio-common/portfolio_common/config.py
+++ b/src/libs/portfolio-common/portfolio_common/config.py
@@ -1,9 +1,12 @@
 # libs/portfolio-common/portfolio_common/config.py
 import os
+import json
+import logging
 from dotenv import load_dotenv
 
 # Load environment variables from a .env file for local development.
 load_dotenv()
+logger = logging.getLogger(__name__)
 
 
 # Database Configurations
@@ -47,3 +50,99 @@ BUSINESS_DATE_ENFORCE_MONOTONIC_ADVANCE = os.getenv(
     "BUSINESS_DATE_ENFORCE_MONOTONIC_ADVANCE",
     "false",
 ).strip().lower() in {"1", "true", "yes", "on"}
+
+
+_CONSUMER_ALLOWED_TYPES: dict[str, type] = {
+    "auto.offset.reset": str,
+    "enable.auto.commit": bool,
+    "session.timeout.ms": int,
+    "heartbeat.interval.ms": int,
+    "max.poll.interval.ms": int,
+    "fetch.min.bytes": int,
+    "fetch.max.bytes": int,
+    "max.partition.fetch.bytes": int,
+    "queued.min.messages": int,
+    "queued.max.messages.kbytes": int,
+}
+
+
+def _coerce_consumer_config_value(key: str, value: object) -> object:
+    expected = _CONSUMER_ALLOWED_TYPES[key]
+    if expected is bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"1", "true", "yes", "on"}:
+                return True
+            if normalized in {"0", "false", "no", "off"}:
+                return False
+        raise ValueError(f"Expected bool for '{key}', got {value!r}")
+    if expected is int:
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str):
+            return int(value.strip())
+        raise ValueError(f"Expected int for '{key}', got {value!r}")
+    if expected is str:
+        if isinstance(value, str):
+            return value
+        raise ValueError(f"Expected str for '{key}', got {value!r}")
+    return value
+
+
+def _sanitize_consumer_override_map(raw: object, *, context: str) -> dict[str, object]:
+    if not isinstance(raw, dict):
+        raise ValueError(f"{context} must be a JSON object.")
+    sanitized: dict[str, object] = {}
+    for key, value in raw.items():
+        if key not in _CONSUMER_ALLOWED_TYPES:
+            logger.warning("Ignoring unsupported Kafka consumer config key.", extra={"key": key, "context": context})
+            continue
+        try:
+            sanitized[key] = _coerce_consumer_config_value(key, value)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            logger.warning(
+                "Ignoring invalid Kafka consumer config value.",
+                extra={"key": key, "value": value, "context": context, "error": str(exc)},
+            )
+    return sanitized
+
+
+def get_kafka_consumer_runtime_overrides(group_id: str) -> dict[str, object]:
+    """
+    Loads optional runtime Kafka consumer tuning from environment variables.
+    - LOTUS_CORE_KAFKA_CONSUMER_DEFAULTS_JSON: global defaults
+    - LOTUS_CORE_KAFKA_CONSUMER_GROUP_OVERRIDES_JSON: map keyed by group_id
+    """
+    merged: dict[str, object] = {}
+
+    defaults_raw = os.getenv("LOTUS_CORE_KAFKA_CONSUMER_DEFAULTS_JSON", "").strip()
+    if defaults_raw:
+        try:
+            defaults = json.loads(defaults_raw)
+            merged.update(
+                _sanitize_consumer_override_map(defaults, context="LOTUS_CORE_KAFKA_CONSUMER_DEFAULTS_JSON")
+            )
+        except Exception as exc:
+            logger.warning("Invalid consumer defaults JSON; ignoring.", extra={"error": str(exc)})
+
+    group_raw = os.getenv("LOTUS_CORE_KAFKA_CONSUMER_GROUP_OVERRIDES_JSON", "").strip()
+    if group_raw:
+        try:
+            parsed = json.loads(group_raw)
+            if isinstance(parsed, dict):
+                group_cfg = parsed.get(group_id)
+                if group_cfg is not None:
+                    merged.update(
+                        _sanitize_consumer_override_map(
+                            group_cfg,
+                            context=f"LOTUS_CORE_KAFKA_CONSUMER_GROUP_OVERRIDES_JSON[{group_id}]",
+                        )
+                    )
+            else:
+                logger.warning("Group overrides JSON must be an object; ignoring.")
+        except Exception as exc:
+            logger.warning("Invalid consumer group overrides JSON; ignoring.", extra={"error": str(exc)})
+
+    return merged

--- a/src/libs/portfolio-common/portfolio_common/kafka_consumer.py
+++ b/src/libs/portfolio-common/portfolio_common/kafka_consumer.py
@@ -11,6 +11,7 @@ from typing import Dict, Optional
 from uuid import uuid4
 from confluent_kafka import Consumer, Message
 
+from .config import get_kafka_consumer_runtime_overrides
 from .database_models import ConsumerDlqEvent
 from .db import get_async_db_session
 from .exceptions import RetryableConsumerError
@@ -48,6 +49,13 @@ class BaseConsumer(ABC):
             'session.timeout.ms': 30000,
             'heartbeat.interval.ms': 3000
         }
+        runtime_overrides = get_kafka_consumer_runtime_overrides(group_id)
+        if runtime_overrides:
+            self._consumer_config.update(runtime_overrides)
+            logger.info(
+                "Applied Kafka consumer runtime overrides.",
+                extra={"group_id": group_id, "override_keys": sorted(runtime_overrides.keys())},
+            )
         self._running = True
 
         if self.dlq_topic:

--- a/tests/unit/libs/portfolio-common/test_kafka_consumer.py
+++ b/tests/unit/libs/portfolio-common/test_kafka_consumer.py
@@ -149,3 +149,53 @@ async def test_dlq_payload_is_correct(test_consumer: ConcreteTestConsumer, mock_
     
     headers_dict = dict(call_args['headers'])
     assert headers_dict['correlation_id'] == correlation_id.encode('utf-8')
+
+
+async def test_consumer_applies_runtime_overrides(monkeypatch):
+    monkeypatch.setenv(
+        "LOTUS_CORE_KAFKA_CONSUMER_DEFAULTS_JSON",
+        '{"max.poll.interval.ms": 180000, "fetch.min.bytes": 1}',
+    )
+    monkeypatch.setenv(
+        "LOTUS_CORE_KAFKA_CONSUMER_GROUP_OVERRIDES_JSON",
+        '{"test-group": {"fetch.min.bytes": 4096, "max.partition.fetch.bytes": 1048576}}',
+    )
+
+    with patch("portfolio_common.kafka_consumer.Consumer", return_value=MagicMock()), patch(
+        "portfolio_common.kafka_consumer.get_kafka_producer", return_value=MagicMock()
+    ):
+        consumer = ConcreteTestConsumer(
+            bootstrap_servers="mock_bs",
+            topic="test-topic",
+            group_id="test-group",
+            dlq_topic="test.dlq",
+        )
+
+    assert consumer._consumer_config["max.poll.interval.ms"] == 180000
+    assert consumer._consumer_config["fetch.min.bytes"] == 4096
+    assert consumer._consumer_config["max.partition.fetch.bytes"] == 1048576
+
+
+async def test_consumer_ignores_invalid_runtime_overrides(monkeypatch):
+    monkeypatch.setenv(
+        "LOTUS_CORE_KAFKA_CONSUMER_DEFAULTS_JSON",
+        '{"unsupported.key": 1, "enable.auto.commit": "false"}',
+    )
+    monkeypatch.setenv(
+        "LOTUS_CORE_KAFKA_CONSUMER_GROUP_OVERRIDES_JSON",
+        '{"test-group": {"session.timeout.ms": "45000"}}',
+    )
+
+    with patch("portfolio_common.kafka_consumer.Consumer", return_value=MagicMock()), patch(
+        "portfolio_common.kafka_consumer.get_kafka_producer", return_value=MagicMock()
+    ):
+        consumer = ConcreteTestConsumer(
+            bootstrap_servers="mock_bs",
+            topic="test-topic",
+            group_id="test-group",
+            dlq_topic="test.dlq",
+        )
+
+    assert "unsupported.key" not in consumer._consumer_config
+    assert consumer._consumer_config["enable.auto.commit"] is False
+    assert consumer._consumer_config["session.timeout.ms"] == 45000


### PR DESCRIPTION
## Summary
- add Phase 2 runtime Kafka consumer tuning controls via env JSON overrides
- support global defaults and per-consumer-group overrides with strict key/type validation
- apply runtime overrides in BaseConsumer for all calculator/persistence/timeseries consumers
- add KEDA scaling profiles for calculator consumer groups
- add KEDA usage/tuning runbook notes
- update RFC 065 implementation progress for Phase 2

## Test
- `uvx --with pytest-asyncio --with pydantic --with fastapi --with sqlalchemy --with confluent-kafka --with prometheus-client --with requests --with python-dotenv --with python-json-logger --with psycopg2-binary --with asyncpg pytest -q tests/unit/libs/portfolio-common/test_kafka_consumer.py`
- `uvx --with pytest-asyncio --with pydantic --with fastapi --with sqlalchemy --with confluent-kafka --with prometheus-client --with requests --with python-dotenv --with python-json-logger pytest -q tests/unit/libs/portfolio-common/test_kafka_utils.py`
