### PR TITLE
RFC-065 Phase 3: DLQ reason codes and replay guardrails

### DIFF
--- a/alembic/versions/b7e8f9a0b1c2_feat_add_dlq_reason_code_taxonomy.py
+++ b/alembic/versions/b7e8f9a0b1c2_feat_add_dlq_reason_code_taxonomy.py
@@ -1,0 +1,47 @@
+"""feat: add consumer DLQ reason-code taxonomy column
+
+Revision ID: b7e8f9a0b1c2
+Revises: a1d9c8b7e6f5
+Create Date: 2026-03-03 14:15:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b7e8f9a0b1c2"
+down_revision: Union[str, None] = "a1d9c8b7e6f5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "consumer_dlq_events",
+        sa.Column(
+            "error_reason_code",
+            sa.String(),
+            nullable=True,
+            server_default="UNCLASSIFIED_PROCESSING_ERROR",
+        ),
+    )
+    op.execute(
+        "UPDATE consumer_dlq_events "
+        "SET error_reason_code = 'UNCLASSIFIED_PROCESSING_ERROR' "
+        "WHERE error_reason_code IS NULL"
+    )
+    op.alter_column("consumer_dlq_events", "error_reason_code", nullable=False)
+    op.create_index(
+        "ix_consumer_dlq_events_error_reason_code",
+        "consumer_dlq_events",
+        ["error_reason_code"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_consumer_dlq_events_error_reason_code", table_name="consumer_dlq_events")
+    op.drop_column("consumer_dlq_events", "error_reason_code")
+

--- a/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
+++ b/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
@@ -1,7 +1,7 @@
 # RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap
 
 ## Status
-In Progress (Phase 1 hardening underway)
+In Progress (Phase 3 hardening underway)
 
 ## Date
 2026-03-03
@@ -198,3 +198,23 @@ Acceptance:
 3. Added autoscaling deployment artifacts:
 - KEDA `ScaledObject` definitions for core calculator consumer groups
 - runbook-style usage notes and tuning guidance
+
+### Phase 3 progress (2026-03-03)
+1. Implemented canonical consumer DLQ reason-code taxonomy and persisted it durably:
+- added deterministic classifier in `BaseConsumer` for terminal failures
+- DLQ payload now includes `error_reason_code` for runbook routing and analytics
+- `consumer_dlq_events` now stores `error_reason_code` (indexed) via Alembic migration
+2. Exposed reason-code metadata through ingestion operations APIs:
+- `ConsumerDlqEventResponse` now includes `error_reason_code`
+- ingestion service DLQ event mapping includes new canonical field
+3. Added replay blast-radius guardrails:
+- replay max-record guardrail (`LOTUS_CORE_REPLAY_MAX_RECORDS_PER_REQUEST`)
+- replay backlog guardrail (`LOTUS_CORE_REPLAY_MAX_BACKLOG_JOBS`)
+- guardrails enforced for:
+  - ingestion job retry replays
+  - consumer DLQ correlated replays
+  - transaction reprocessing publish endpoint
+4. Added meaningful tests:
+- DLQ taxonomy and payload reason-code unit tests
+- replay guardrail unit tests for record and backlog limits
+- ingestion router integration coverage updated for new reason-code field and guardrail methods

--- a/src/libs/portfolio-common/portfolio_common/database_models.py
+++ b/src/libs/portfolio-common/portfolio_common/database_models.py
@@ -829,6 +829,7 @@ class ConsumerDlqEvent(Base):
     consumer_group = Column(String, index=True, nullable=False)
     dlq_topic = Column(String, index=True, nullable=False)
     original_key = Column(String, nullable=True)
+    error_reason_code = Column(String, index=True, nullable=False, server_default="UNCLASSIFIED_PROCESSING_ERROR")
     error_reason = Column(Text, nullable=False)
     correlation_id = Column(String, nullable=True)
     payload_excerpt = Column(Text, nullable=True)

--- a/src/libs/portfolio-common/portfolio_common/kafka_consumer.py
+++ b/src/libs/portfolio-common/portfolio_common/kafka_consumer.py
@@ -20,6 +20,34 @@ from .logging_utils import correlation_id_var, generate_correlation_id
 
 logger = logging.getLogger(__name__)
 
+DLQ_REASON_CODE_VALIDATION = "VALIDATION_ERROR"
+DLQ_REASON_CODE_DESERIALIZATION = "DESERIALIZATION_ERROR"
+DLQ_REASON_CODE_DATA_INTEGRITY = "DATA_INTEGRITY_ERROR"
+DLQ_REASON_CODE_DOWNSTREAM_TIMEOUT = "DOWNSTREAM_TIMEOUT"
+DLQ_REASON_CODE_AUTHORIZATION = "AUTHORIZATION_ERROR"
+DLQ_REASON_CODE_UNCLASSIFIED = "UNCLASSIFIED_PROCESSING_ERROR"
+
+
+def classify_dlq_reason_code(error: Exception) -> str:
+    """
+    Maps terminal consumer exceptions into a deterministic reason-code taxonomy.
+    """
+    error_name = error.__class__.__name__.lower()
+    error_text = str(error).lower()
+    combined = f"{error_name}:{error_text}"
+
+    if "json" in combined and any(token in combined for token in ("decode", "deserialize", "parsing")):
+        return DLQ_REASON_CODE_DESERIALIZATION
+    if any(token in combined for token in ("validation", "missing", "required", "invalid", "schema", "keyerror", "valueerror", "typeerror")):
+        return DLQ_REASON_CODE_VALIDATION
+    if any(token in combined for token in ("integrity", "foreign key", "constraint", "unique violation", "duplicate key")):
+        return DLQ_REASON_CODE_DATA_INTEGRITY
+    if any(token in combined for token in ("timeout", "timed out", "deadline exceeded")):
+        return DLQ_REASON_CODE_DOWNSTREAM_TIMEOUT
+    if any(token in combined for token in ("permission", "forbidden", "unauthorized", "access denied", "auth")):
+        return DLQ_REASON_CODE_AUTHORIZATION
+    return DLQ_REASON_CODE_UNCLASSIFIED
+
 
 class BaseConsumer(ABC):
     """
@@ -84,6 +112,7 @@ class BaseConsumer(ABC):
 
         try:
             correlation_id = correlation_id_var.get()
+            error_reason_code = classify_dlq_reason_code(error)
             
             dlq_payload = {
                 "correlation_id": correlation_id,
@@ -91,6 +120,7 @@ class BaseConsumer(ABC):
                 "original_key": msg.key().decode('utf-8') if msg.key() else None,
                 "original_value": msg.value().decode('utf-8'),
                 "error_timestamp": datetime.now(timezone.utc).isoformat(),
+                "error_reason_code": error_reason_code,
                 "error_reason": str(error),
                 "error_traceback": traceback.format_exc()
             }
@@ -106,14 +136,21 @@ class BaseConsumer(ABC):
             )
             self._producer.flush(timeout=5)
             await self._record_consumer_dlq_event(
-                msg=msg, error=error, correlation_id=correlation_id
+                msg=msg,
+                error=error,
+                error_reason_code=error_reason_code,
+                correlation_id=correlation_id,
             )
             logger.warning(f"Message with key '{dlq_payload['original_key']}' sent to DLQ '{self.dlq_topic}'.")
         except Exception as e:
             logger.error(f"FATAL: Could not send message to DLQ. Error: {e}", exc_info=True)
 
     async def _record_consumer_dlq_event(
-        self, msg: Message, error: Exception, correlation_id: str | None
+        self,
+        msg: Message,
+        error: Exception,
+        error_reason_code: str,
+        correlation_id: str | None,
     ) -> None:
         payload_excerpt = None
         try:
@@ -127,6 +164,7 @@ class BaseConsumer(ABC):
             consumer_group=self._consumer_config["group.id"],
             dlq_topic=self.dlq_topic or "",
             original_key=msg.key().decode("utf-8") if msg.key() else None,
+            error_reason_code=error_reason_code,
             error_reason=str(error),
             correlation_id=correlation_id,
             payload_excerpt=payload_excerpt,

--- a/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
+++ b/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
@@ -407,6 +407,10 @@ class ConsumerDlqEventResponse(BaseModel):
         description="Original message key, if available.",
         examples=["TXN-2026-000145"],
     )
+    error_reason_code: str = Field(
+        description="Canonical DLQ reason code for routing, replay policy, and incident analytics.",
+        examples=["VALIDATION_ERROR"],
+    )
     error_reason: str = Field(
         description="Error reason captured when consumer rejected the message.",
         examples=["ValidationError: portfolio_id is required"],

--- a/src/services/ingestion_service/app/routers/ingestion_jobs.py
+++ b/src/services/ingestion_service/app/routers/ingestion_jobs.py
@@ -168,6 +168,15 @@ def _deterministic_replay_fingerprint(
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
+def _payload_record_count(payload: dict[str, Any] | None) -> int:
+    if not payload:
+        return 0
+    counts = [len(value) for value in payload.values() if isinstance(value, list)]
+    if counts:
+        return max(counts)
+    return 1
+
+
 @router.get(
     "/ingestion/jobs/{job_id}",
     response_model=IngestionJobResponse,
@@ -328,14 +337,6 @@ async def retry_ingestion_job(
             },
         )
     try:
-        await ingestion_job_service.assert_retry_allowed(context.submitted_at)
-    except PermissionError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={"code": "INGESTION_RETRY_BLOCKED", "message": str(exc)},
-        ) from exc
-
-    try:
         replay_payload = _filter_payload_by_record_keys(
             endpoint=context.endpoint,
             payload=context.request_payload,
@@ -345,6 +346,17 @@ async def retry_ingestion_job(
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={"code": "INGESTION_PARTIAL_RETRY_UNSUPPORTED", "message": str(exc)},
+        ) from exc
+    replay_record_count = _payload_record_count(replay_payload)
+    try:
+        await ingestion_job_service.assert_retry_allowed_for_records(
+            submitted_at=context.submitted_at,
+            replay_record_count=replay_record_count,
+        )
+    except PermissionError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"code": "INGESTION_RETRY_BLOCKED", "message": str(exc)},
         ) from exc
 
     if retry_request.dry_run:
@@ -822,7 +834,10 @@ async def replay_consumer_dlq_event(
                 "Replay blocked because an equivalent deterministic replay already succeeded."
             ),
         )
-    await ingestion_job_service.assert_retry_allowed(context.submitted_at)
+    await ingestion_job_service.assert_retry_allowed_for_records(
+        submitted_at=context.submitted_at,
+        replay_record_count=_payload_record_count(context.request_payload),
+    )
     if replay_request.dry_run:
         replay_audit_id = await ingestion_job_service.record_consumer_dlq_replay_audit(
             recovery_path="consumer_dlq_replay",

--- a/src/services/ingestion_service/app/routers/reprocessing.py
+++ b/src/services/ingestion_service/app/routers/reprocessing.py
@@ -52,6 +52,13 @@ async def reprocess_transactions(
             detail={"code": "INGESTION_MODE_BLOCKS_WRITES", "message": str(exc)},
         ) from exc
     try:
+        await ingestion_job_service.assert_reprocessing_publish_allowed(num_to_reprocess)
+    except PermissionError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"code": "INGESTION_REPLAY_BLOCKED", "message": str(exc)},
+        ) from exc
+    try:
         enforce_ingestion_write_rate_limit(
             endpoint="/reprocess/transactions",
             record_count=len(request.transaction_ids),

--- a/src/services/ingestion_service/app/services/ingestion_job_service.py
+++ b/src/services/ingestion_service/app/services/ingestion_job_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
+import os
 from typing import Any
 from uuid import uuid4
 
@@ -43,6 +44,11 @@ from portfolio_common.monitoring import (
     INGESTION_REPLAY_FAILURE_TOTAL,
 )
 from sqlalchemy import and_, desc, func, select
+
+REPLAY_MAX_RECORDS_PER_REQUEST = int(
+    os.getenv("LOTUS_CORE_REPLAY_MAX_RECORDS_PER_REQUEST", "5000")
+)
+REPLAY_MAX_BACKLOG_JOBS = int(os.getenv("LOTUS_CORE_REPLAY_MAX_BACKLOG_JOBS", "5000"))
 
 
 @dataclass(slots=True)
@@ -99,6 +105,7 @@ def _to_dlq_event_response(event: DBConsumerDlqEvent) -> ConsumerDlqEventRespons
         consumer_group=event.consumer_group,
         dlq_topic=event.dlq_topic,
         original_key=event.original_key,
+        error_reason_code=event.error_reason_code,
         error_reason=event.error_reason,
         correlation_id=event.correlation_id,
         payload_excerpt=event.payload_excerpt,
@@ -1018,6 +1025,29 @@ class IngestionJobService:
             )
 
     async def assert_retry_allowed(self, submitted_at: datetime) -> None:
+        await self.assert_retry_allowed_for_records(submitted_at=submitted_at, replay_record_count=1)
+
+    async def _count_backlog_jobs(self) -> int:
+        async for db in get_async_db_session():
+            backlog = int(
+                (
+                    await db.scalar(
+                        select(func.count(DBIngestionJob.id)).where(
+                            DBIngestionJob.status.in_(("accepted", "queued"))
+                        )
+                    )
+                )
+                or 0
+            )
+            return backlog
+        return 0
+
+    async def assert_retry_allowed_for_records(
+        self,
+        *,
+        submitted_at: datetime,
+        replay_record_count: int,
+    ) -> None:
         mode = await self.get_ops_mode()
         if mode.mode == "paused":
             raise PermissionError("Retries are blocked while ingestion is paused.")
@@ -1028,6 +1058,25 @@ class IngestionJobService:
             raise PermissionError("Current time is after configured replay window.")
         if now < submitted_at:
             raise PermissionError("Retry blocked: job submission timestamp is in the future.")
+        if replay_record_count > REPLAY_MAX_RECORDS_PER_REQUEST:
+            raise PermissionError(
+                "Retry blocked: requested replay record count exceeds configured limit. "
+                f"requested_records={replay_record_count}, "
+                f"max_records={REPLAY_MAX_RECORDS_PER_REQUEST}."
+            )
+        backlog_jobs = await self._count_backlog_jobs()
+        if backlog_jobs >= REPLAY_MAX_BACKLOG_JOBS:
+            raise PermissionError(
+                "Retry blocked: ingestion backlog exceeds configured replay safety threshold. "
+                f"backlog_jobs={backlog_jobs}, max_backlog_jobs={REPLAY_MAX_BACKLOG_JOBS}."
+            )
+
+    async def assert_reprocessing_publish_allowed(self, record_count: int) -> None:
+        now = datetime.now(UTC)
+        await self.assert_retry_allowed_for_records(
+            submitted_at=now,
+            replay_record_count=max(1, int(record_count)),
+        )
 
 
 _INGESTION_JOB_SERVICE = IngestionJobService()

--- a/tests/integration/services/ingestion_service/test_ingestion_routers.py
+++ b/tests/integration/services/ingestion_service/test_ingestion_routers.py
@@ -313,6 +313,7 @@ async def async_test_client(mock_kafka_producer: MagicMock):
                     "consumer_group": consumer_group or "persistence-service-group",
                     "dlq_topic": "persistence_service.dlq",
                     "original_key": "TXN-2026-000145",
+                    "error_reason_code": "VALIDATION_ERROR",
                     "error_reason": "ValidationError: portfolio_id is required",
                     "correlation_id": "ING:test-correlation-id",
                     "payload_excerpt": '{"transaction_id":"TXN-2026-000145"}',
@@ -329,6 +330,7 @@ async def async_test_client(mock_kafka_producer: MagicMock):
                 consumer_group="persistence-service-group",
                 dlq_topic="persistence_service.dlq",
                 original_key="TXN-2026-000145",
+                error_reason_code="VALIDATION_ERROR",
                 error_reason="ValidationError: portfolio_id is required",
                 correlation_id="ING:test-correlation-id",
                 payload_excerpt='{"transaction_id":"TXN-2026-000145"}',
@@ -527,6 +529,17 @@ async def async_test_client(mock_kafka_producer: MagicMock):
         async def assert_retry_allowed(self, submitted_at: datetime) -> None:
             if self.mode == "paused":
                 raise PermissionError("Retries are blocked while ingestion is paused.")
+
+        async def assert_retry_allowed_for_records(
+            self,
+            *,
+            submitted_at: datetime,
+            replay_record_count: int,
+        ) -> None:
+            await self.assert_retry_allowed(submitted_at)
+
+        async def assert_reprocessing_publish_allowed(self, record_count: int) -> None:
+            return None
 
     fake_job_service = FakeIngestionJobService()
     app.dependency_overrides[get_ingestion_job_service] = lambda: fake_job_service

--- a/tests/unit/libs/portfolio-common/test_kafka_consumer.py
+++ b/tests/unit/libs/portfolio-common/test_kafka_consumer.py
@@ -5,7 +5,11 @@ import asyncio
 from unittest.mock import patch, MagicMock, AsyncMock
 
 from confluent_kafka import KafkaError
-from portfolio_common.kafka_consumer import BaseConsumer, RetryableConsumerError
+from portfolio_common.kafka_consumer import (
+    BaseConsumer,
+    RetryableConsumerError,
+    classify_dlq_reason_code,
+)
 from portfolio_common.logging_utils import correlation_id_var
 
 pytestmark = pytest.mark.asyncio
@@ -144,11 +148,20 @@ async def test_dlq_payload_is_correct(test_consumer: ConcreteTestConsumer, mock_
     assert payload['original_topic'] == "test-topic"
     assert payload['original_key'] == "key3"
     assert payload['original_value'] == '{"data": "value3"}'
+    assert payload["error_reason_code"] == "VALIDATION_ERROR"
     assert "Test Error" in payload['error_reason']
     assert "Traceback" in payload['error_traceback']
     
     headers_dict = dict(call_args['headers'])
     assert headers_dict['correlation_id'] == correlation_id.encode('utf-8')
+
+
+async def test_classify_dlq_reason_code_deserialization():
+    assert classify_dlq_reason_code(ValueError("JSON decode failed at position 13")) == "DESERIALIZATION_ERROR"
+
+
+async def test_classify_dlq_reason_code_timeout():
+    assert classify_dlq_reason_code(RuntimeError("downstream timeout while reading response")) == "DOWNSTREAM_TIMEOUT"
 
 
 async def test_consumer_applies_runtime_overrides(monkeypatch):

--- a/tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py
+++ b/tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py
@@ -1,0 +1,79 @@
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from src.services.ingestion_service.app.services import ingestion_job_service as service_module
+from src.services.ingestion_service.app.services.ingestion_job_service import IngestionJobService
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def service() -> IngestionJobService:
+    return IngestionJobService()
+
+
+async def test_assert_retry_allowed_for_records_blocks_large_replay(
+    service: IngestionJobService,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    now = datetime.now(UTC)
+    monkeypatch.setattr(
+        service_module,
+        "REPLAY_MAX_RECORDS_PER_REQUEST",
+        2,
+    )
+    async def _mock_get_ops_mode() -> SimpleNamespace:
+        return SimpleNamespace(mode="normal", replay_window_start=None, replay_window_end=None)
+
+    async def _mock_count_backlog_jobs() -> int:
+        return 0
+
+    monkeypatch.setattr(service, "get_ops_mode", _mock_get_ops_mode)
+    monkeypatch.setattr(service, "_count_backlog_jobs", _mock_count_backlog_jobs)
+
+    with pytest.raises(PermissionError, match="requested replay record count exceeds configured limit"):
+        await service.assert_retry_allowed_for_records(
+            submitted_at=now - timedelta(minutes=1),
+            replay_record_count=3,
+        )
+
+
+async def test_assert_retry_allowed_for_records_blocks_when_backlog_high(
+    service: IngestionJobService,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    now = datetime.now(UTC)
+    monkeypatch.setattr(service_module, "REPLAY_MAX_RECORDS_PER_REQUEST", 100)
+    monkeypatch.setattr(service_module, "REPLAY_MAX_BACKLOG_JOBS", 5)
+    async def _mock_get_ops_mode() -> SimpleNamespace:
+        return SimpleNamespace(mode="normal", replay_window_start=None, replay_window_end=None)
+
+    async def _mock_count_backlog_jobs() -> int:
+        return 5
+
+    monkeypatch.setattr(service, "get_ops_mode", _mock_get_ops_mode)
+    monkeypatch.setattr(service, "_count_backlog_jobs", _mock_count_backlog_jobs)
+
+    with pytest.raises(PermissionError, match="backlog exceeds configured replay safety threshold"):
+        await service.assert_retry_allowed_for_records(
+            submitted_at=now - timedelta(minutes=1),
+            replay_record_count=1,
+        )
+
+
+async def test_assert_reprocessing_publish_allowed_reuses_retry_guardrails(
+    service: IngestionJobService,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    called: dict[str, int] = {"count": 0}
+
+    async def _mock_guardrail(*, submitted_at: datetime, replay_record_count: int) -> None:
+        called["count"] += 1
+        assert replay_record_count == 7
+        assert submitted_at.tzinfo is not None
+
+    monkeypatch.setattr(service, "assert_retry_allowed_for_records", _mock_guardrail)
+    await service.assert_reprocessing_publish_allowed(7)
+    assert called["count"] == 1


### PR DESCRIPTION
## Summary
- add deterministic DLQ reason-code taxonomy in `BaseConsumer`
- persist `error_reason_code` in `consumer_dlq_events` (with Alembic migration) and expose it via ingestion operations API
- add replay blast-radius guardrails for ingestion retries, correlated DLQ replay, and reprocessing publish endpoint
- update RFC 065 progress section and add targeted guardrail tests

## Guardrails added
- `LOTUS_CORE_REPLAY_MAX_RECORDS_PER_REQUEST` (default `5000`)
- `LOTUS_CORE_REPLAY_MAX_BACKLOG_JOBS` (default `5000`)

## Validation
- `uv run python -m pytest tests/unit/libs/portfolio-common/test_kafka_consumer.py -q`
- `uv run python -m pytest tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py -q`
- `uv run python -m pytest tests/integration/services/ingestion_service/test_ingestion_routers.py -q`
