### PR TITLE
RFC-065 Phase 4b: SQL aggregation deepening for ingestion ops

### DIFF
--- a/alembic/versions/d0e1f2a3b4c6_perf_add_ingestion_jobs_aggregate_indexes.py
+++ b/alembic/versions/d0e1f2a3b4c6_perf_add_ingestion_jobs_aggregate_indexes.py
@@ -1,0 +1,42 @@
+"""perf: add ingestion-jobs aggregate query indexes
+
+Revision ID: d0e1f2a3b4c6
+Revises: c8d9e0f1a2b3
+Create Date: 2026-03-03 16:45:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d0e1f2a3b4c6"
+down_revision: Union[str, None] = "c8d9e0f1a2b3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_ingestion_jobs_submitted_at",
+        "ingestion_jobs",
+        ["submitted_at"],
+    )
+    op.create_index(
+        "ix_ingestion_jobs_status_submitted_at",
+        "ingestion_jobs",
+        ["status", "submitted_at"],
+    )
+    op.create_index(
+        "ix_ingestion_jobs_idempotency_key_submitted_at",
+        "ingestion_jobs",
+        ["idempotency_key", "submitted_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ingestion_jobs_idempotency_key_submitted_at", table_name="ingestion_jobs")
+    op.drop_index("ix_ingestion_jobs_status_submitted_at", table_name="ingestion_jobs")
+    op.drop_index("ix_ingestion_jobs_submitted_at", table_name="ingestion_jobs")
+

--- a/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
+++ b/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
@@ -288,3 +288,11 @@ Acceptance:
 - `consumer_dlq_replay_audit(recovery_path, replay_status, requested_at)`
 - `consumer_dlq_replay_audit(replay_fingerprint, replay_status, recovery_path, requested_at)`
 3. Added Alembic migration for index rollout to keep runtime behavior and schema in sync.
+4. Deepened SQL-side aggregate execution for ingestion operations:
+- `get_backlog_breakdown` now uses grouped DB aggregation with conditional counts and backlog oldest-timestamp extraction
+- `get_idempotency_diagnostics` now uses grouped DB aggregation (`count`, `count distinct`, `array_agg distinct`, `min/max`) instead of full-row Python grouping
+- `get_error_budget_status` now computes current/previous windows via aggregate SQL queries instead of loading job rows
+5. Added ingestion-job aggregate indexes for these operations:
+- `ingestion_jobs(submitted_at)`
+- `ingestion_jobs(status, submitted_at)`
+- `ingestion_jobs(idempotency_key, submitted_at)`

--- a/src/libs/portfolio-common/portfolio_common/database_models.py
+++ b/src/libs/portfolio-common/portfolio_common/database_models.py
@@ -796,6 +796,16 @@ class IngestionJob(Base):
     retry_count = Column(Integer, nullable=False, default=0, server_default="0")
     last_retried_at = Column(DateTime(timezone=True), nullable=True)
 
+    __table_args__ = (
+        Index("ix_ingestion_jobs_submitted_at", "submitted_at"),
+        Index("ix_ingestion_jobs_status_submitted_at", "status", submitted_at.desc()),
+        Index(
+            "ix_ingestion_jobs_idempotency_key_submitted_at",
+            "idempotency_key",
+            submitted_at.desc(),
+        ),
+    )
+
 
 class IngestionJobFailure(Base):
     __tablename__ = "ingestion_job_failures"

--- a/src/services/ingestion_service/app/services/ingestion_job_service.py
+++ b/src/services/ingestion_service/app/services/ingestion_job_service.py
@@ -427,52 +427,55 @@ class IngestionJobService:
     ) -> IngestionBacklogBreakdownResponse:
         async for db in get_async_db_session():
             since = datetime.now(UTC) - timedelta(minutes=lookback_minutes)
-            jobs = (
-                await db.scalars(
-                    select(DBIngestionJob)
-                    .where(DBIngestionJob.submitted_at >= since)
-                    .order_by(desc(DBIngestionJob.submitted_at))
-                )
-            ).all()
-
-            grouped: dict[tuple[str, str], dict[str, Any]] = {}
             now_utc = datetime.now(UTC)
-            for job in jobs:
-                key = (job.endpoint, job.entity_type)
-                state = grouped.setdefault(
-                    key,
-                    {
-                        "total": 0,
-                        "accepted": 0,
-                        "queued": 0,
-                        "failed": 0,
-                        "oldest_backlog_submitted_at": None,
-                    },
+            rows = await db.execute(
+                select(
+                    DBIngestionJob.endpoint,
+                    DBIngestionJob.entity_type,
+                    func.count(DBIngestionJob.id).label("total_jobs"),
+                    func.sum(case((DBIngestionJob.status == "accepted", 1), else_=0)).label(
+                        "accepted_jobs"
+                    ),
+                    func.sum(case((DBIngestionJob.status == "queued", 1), else_=0)).label(
+                        "queued_jobs"
+                    ),
+                    func.sum(case((DBIngestionJob.status == "failed", 1), else_=0)).label(
+                        "failed_jobs"
+                    ),
+                    func.min(
+                        case(
+                            (
+                                DBIngestionJob.status.in_(["accepted", "queued"]),
+                                DBIngestionJob.submitted_at,
+                            ),
+                            else_=None,
+                        )
+                    ).label("oldest_backlog_submitted_at"),
                 )
-                state["total"] += 1
-                if job.status == "accepted":
-                    state["accepted"] += 1
-                elif job.status == "queued":
-                    state["queued"] += 1
-                elif job.status == "failed":
-                    state["failed"] += 1
-
-                if job.status in {"accepted", "queued"}:
-                    oldest = state["oldest_backlog_submitted_at"]
-                    if oldest is None or job.submitted_at < oldest:
-                        state["oldest_backlog_submitted_at"] = job.submitted_at
+                .where(DBIngestionJob.submitted_at >= since)
+                .group_by(DBIngestionJob.endpoint, DBIngestionJob.entity_type)
+            )
 
             rows: list[IngestionBacklogBreakdownItemResponse] = []
-            for (endpoint, entity_type), state in grouped.items():
-                backlog_jobs = int(state["accepted"] + state["queued"])
-                oldest_backlog_submitted_at = state["oldest_backlog_submitted_at"]
+            for (
+                endpoint,
+                entity_type,
+                total_jobs_raw,
+                accepted_jobs_raw,
+                queued_jobs_raw,
+                failed_jobs_raw,
+                oldest_backlog_submitted_at,
+            ) in rows:
+                accepted_jobs = int(accepted_jobs_raw or 0)
+                queued_jobs = int(queued_jobs_raw or 0)
+                failed_jobs = int(failed_jobs_raw or 0)
+                backlog_jobs = int(accepted_jobs + queued_jobs)
                 oldest_backlog_age_seconds = (
                     float((now_utc - oldest_backlog_submitted_at).total_seconds())
                     if oldest_backlog_submitted_at is not None
                     else 0.0
                 )
-                total_jobs = int(state["total"])
-                failed_jobs = int(state["failed"])
+                total_jobs = int(total_jobs_raw or 0)
                 failure_rate = (
                     Decimal(failed_jobs) / Decimal(total_jobs) if total_jobs else Decimal("0")
                 )
@@ -481,8 +484,8 @@ class IngestionJobService:
                         endpoint=endpoint,
                         entity_type=entity_type,
                         total_jobs=total_jobs,
-                        accepted_jobs=int(state["accepted"]),
-                        queued_jobs=int(state["queued"]),
+                        accepted_jobs=accepted_jobs,
+                        queued_jobs=queued_jobs,
                         failed_jobs=failed_jobs,
                         backlog_jobs=backlog_jobs,
                         oldest_backlog_submitted_at=oldest_backlog_submitted_at,
@@ -812,39 +815,46 @@ class IngestionJobService:
     ) -> IngestionIdempotencyDiagnosticsResponse:
         async for db in get_async_db_session():
             since = datetime.now(UTC) - timedelta(minutes=lookback_minutes)
-            rows = (
-                await db.scalars(
-                    select(DBIngestionJob)
-                    .where(
-                        and_(
-                            DBIngestionJob.submitted_at >= since,
-                            DBIngestionJob.idempotency_key.is_not(None),
-                        )
-                    )
-                    .order_by(desc(DBIngestionJob.submitted_at))
-                )
-            ).all()
-
-            grouped: dict[str, list[DBIngestionJob]] = {}
-            for row in rows:
-                if row.idempotency_key is None:
-                    continue
-                grouped.setdefault(row.idempotency_key, []).append(row)
-
             items: list[IngestionIdempotencyDiagnosticItemResponse] = []
+            rows = await db.execute(
+                select(
+                    DBIngestionJob.idempotency_key,
+                    func.count(DBIngestionJob.id).label("usage_count"),
+                    func.count(func.distinct(DBIngestionJob.endpoint)).label("endpoint_count"),
+                    func.array_agg(func.distinct(DBIngestionJob.endpoint)).label("endpoints"),
+                    func.min(DBIngestionJob.submitted_at).label("first_seen_at"),
+                    func.max(DBIngestionJob.submitted_at).label("last_seen_at"),
+                )
+                .where(
+                    and_(
+                        DBIngestionJob.submitted_at >= since,
+                        DBIngestionJob.idempotency_key.is_not(None),
+                    )
+                )
+                .group_by(DBIngestionJob.idempotency_key)
+                .order_by(desc("usage_count"))
+                .limit(limit)
+            )
             collisions = 0
-            for key, jobs in grouped.items():
-                endpoints = sorted({job.endpoint for job in jobs})
-                collision_detected = len(endpoints) > 1
+            for (
+                key,
+                usage_count_raw,
+                endpoint_count_raw,
+                endpoints_raw,
+                first_seen_at,
+                last_seen_at,
+            ) in rows:
+                usage_count = int(usage_count_raw or 0)
+                endpoint_count = int(endpoint_count_raw or 0)
+                endpoints = sorted(list(endpoints_raw or []))
+                collision_detected = endpoint_count > 1
                 if collision_detected:
                     collisions += 1
-                first_seen_at = min(job.submitted_at for job in jobs)
-                last_seen_at = max(job.submitted_at for job in jobs)
                 items.append(
                     IngestionIdempotencyDiagnosticItemResponse(
                         idempotency_key=key,
-                        usage_count=len(jobs),
-                        endpoint_count=len(endpoints),
+                        usage_count=usage_count,
+                        endpoint_count=endpoint_count,
                         endpoints=endpoints,
                         first_seen_at=first_seen_at,
                         last_seen_at=last_seen_at,
@@ -852,7 +862,6 @@ class IngestionJobService:
                     )
                 )
 
-            items = sorted(items, key=lambda item: item.usage_count, reverse=True)[:limit]
             return IngestionIdempotencyDiagnosticsResponse(
                 lookback_minutes=lookback_minutes,
                 total_keys=len(items),
@@ -877,36 +886,48 @@ class IngestionJobService:
             now_utc = datetime.now(UTC)
             current_since = now_utc - timedelta(minutes=lookback_minutes)
             previous_since = now_utc - timedelta(minutes=lookback_minutes * 2)
-
-            current_jobs = (
-                await db.scalars(
-                    select(DBIngestionJob).where(DBIngestionJob.submitted_at >= current_since)
+            current_row = (
+                await db.execute(
+                    select(
+                        func.count(DBIngestionJob.id).label("total_jobs"),
+                        func.sum(case((DBIngestionJob.status == "failed", 1), else_=0)).label(
+                            "failed_jobs"
+                        ),
+                        func.sum(
+                            case(
+                                (DBIngestionJob.status.in_(["accepted", "queued"]), 1),
+                                else_=0,
+                            )
+                        ).label("backlog_jobs"),
+                    ).where(DBIngestionJob.submitted_at >= current_since)
                 )
-            ).all()
-            previous_jobs = (
-                await db.scalars(
-                    select(DBIngestionJob).where(
+            ).one()
+            previous_row = (
+                await db.execute(
+                    select(
+                        func.sum(
+                            case(
+                                (DBIngestionJob.status.in_(["accepted", "queued"]), 1),
+                                else_=0,
+                            )
+                        ).label("previous_backlog_jobs"),
+                    ).where(
                         and_(
                             DBIngestionJob.submitted_at >= previous_since,
                             DBIngestionJob.submitted_at < current_since,
                         )
                     )
                 )
-            ).all()
+            ).one()
 
-            total_jobs = len(current_jobs)
-            failed_jobs = len([job for job in current_jobs if job.status == "failed"])
+            total_jobs = int(current_row[0] or 0)
+            failed_jobs = int(current_row[1] or 0)
             failure_rate = (
                 Decimal(failed_jobs) / Decimal(total_jobs) if total_jobs else Decimal("0")
             )
             remaining_budget = max(Decimal("0"), failure_rate_threshold - failure_rate)
-
-            backlog_jobs = len(
-                [job for job in current_jobs if job.status in {"accepted", "queued"}]
-            )
-            previous_backlog_jobs = len(
-                [job for job in previous_jobs if job.status in {"accepted", "queued"}]
-            )
+            backlog_jobs = int(current_row[2] or 0)
+            previous_backlog_jobs = int(previous_row[0] or 0)
             backlog_growth = backlog_jobs - previous_backlog_jobs
 
             return IngestionErrorBudgetStatusResponse(


### PR DESCRIPTION
## Summary
- deepen RFC-065 Phase 4 by moving remaining ingestion ops aggregations from Python loops to SQL aggregation
- add composite ingestion_jobs indexes for new aggregate query patterns
- update RFC 065 Phase 4 progress notes

## Changes
- optimize `get_backlog_breakdown` with grouped SQL + conditional aggregate expressions
- optimize `get_idempotency_diagnostics` with grouped SQL (`count`, `count distinct`, `array_agg distinct`, `min/max`)
- optimize `get_error_budget_status` with current/previous window aggregate queries
- add migration `d0e1f2a3b4c6`:
  - `ingestion_jobs(submitted_at)`
  - `ingestion_jobs(status, submitted_at)`
  - `ingestion_jobs(idempotency_key, submitted_at)`

## Validation
- `uv run python -m pytest tests/integration/services/ingestion_service/test_ingestion_routers.py -q`
- `uv run python -m pytest tests/unit/libs/portfolio-common/test_kafka_consumer.py -q`
- `uv run python -m pytest tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py -q`
