### PR TITLE
RFC-065 Phase 4c: optimize SLO aggregate path

### DIFF
--- a/alembic/versions/e1f2a3b4c7d8_perf_add_ingestion_jobs_latency_index.py
+++ b/alembic/versions/e1f2a3b4c7d8_perf_add_ingestion_jobs_latency_index.py
@@ -1,0 +1,30 @@
+"""perf: add ingestion-jobs submitted/completed latency index
+
+Revision ID: e1f2a3b4c7d8
+Revises: d0e1f2a3b4c6
+Create Date: 2026-03-03 17:10:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "e1f2a3b4c7d8"
+down_revision: Union[str, None] = "d0e1f2a3b4c6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_ingestion_jobs_submitted_completed_at",
+        "ingestion_jobs",
+        ["submitted_at", "completed_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ingestion_jobs_submitted_completed_at", table_name="ingestion_jobs")
+

--- a/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
+++ b/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
@@ -296,3 +296,8 @@ Acceptance:
 - `ingestion_jobs(submitted_at)`
 - `ingestion_jobs(status, submitted_at)`
 - `ingestion_jobs(idempotency_key, submitted_at)`
+6. Optimized SLO computation path:
+- `get_slo_status` now uses DB-side aggregate query for total/failure/backlog-age signals and DB percentile (`percentile_cont`) for p95 queue latency
+- retained safe fallback path to Python-side p95 calculation for environments without percentile support
+7. Added latency-path support index:
+- `ingestion_jobs(submitted_at, completed_at)` for p95 latency window scanning efficiency

--- a/src/libs/portfolio-common/portfolio_common/database_models.py
+++ b/src/libs/portfolio-common/portfolio_common/database_models.py
@@ -804,6 +804,11 @@ class IngestionJob(Base):
             "idempotency_key",
             submitted_at.desc(),
         ),
+        Index(
+            "ix_ingestion_jobs_submitted_completed_at",
+            "submitted_at",
+            "completed_at",
+        ),
     )
 
 

--- a/src/services/ingestion_service/app/services/ingestion_job_service.py
+++ b/src/services/ingestion_service/app/services/ingestion_job_service.py
@@ -365,32 +365,73 @@ class IngestionJobService:
     ) -> IngestionSloStatusResponse:
         async for db in get_async_db_session():
             since = datetime.now(UTC) - timedelta(minutes=lookback_minutes)
-            jobs = (
-                await db.scalars(select(DBIngestionJob).where(DBIngestionJob.submitted_at >= since))
-            ).all()
-            total_jobs = len(jobs)
-            failed_jobs = len([j for j in jobs if j.status == "failed"])
-
-            latencies = [
-                (j.completed_at - j.submitted_at).total_seconds()
-                for j in jobs
-                if j.completed_at is not None
-            ]
-            latencies.sort()
-            if not latencies:
-                p95_latency = 0.0
-            else:
-                p95_index = max(0, min(len(latencies) - 1, int(len(latencies) * 0.95) - 1))
-                p95_latency = float(latencies[p95_index])
-
-            non_terminal = [j for j in jobs if j.status in {"accepted", "queued"}]
-            if non_terminal:
-                oldest = min(non_terminal, key=lambda item: item.submitted_at)
-                backlog_age_seconds = float(
-                    (datetime.now(UTC) - oldest.submitted_at).total_seconds()
+            # Prefer DB-side aggregation (including percentile) to avoid loading all jobs in memory.
+            p95_latency = 0.0
+            total_jobs = 0
+            failed_jobs = 0
+            backlog_age_seconds = 0.0
+            try:
+                latency_seconds = func.extract(
+                    "epoch",
+                    DBIngestionJob.completed_at - DBIngestionJob.submitted_at,
                 )
-            else:
-                backlog_age_seconds = 0.0
+                row = (
+                    await db.execute(
+                        select(
+                            func.count(DBIngestionJob.id).label("total_jobs"),
+                            func.sum(case((DBIngestionJob.status == "failed", 1), else_=0)).label(
+                                "failed_jobs"
+                            ),
+                            func.min(
+                                case(
+                                    (
+                                        DBIngestionJob.status.in_(["accepted", "queued"]),
+                                        DBIngestionJob.submitted_at,
+                                    ),
+                                    else_=None,
+                                )
+                            ).label("oldest_backlog_submitted_at"),
+                            func.percentile_cont(0.95)
+                            .within_group(latency_seconds)
+                            .filter(DBIngestionJob.completed_at.is_not(None))
+                            .label("p95_latency"),
+                        ).where(DBIngestionJob.submitted_at >= since)
+                    )
+                ).one()
+                total_jobs = int(row[0] or 0)
+                failed_jobs = int(row[1] or 0)
+                oldest_backlog_submitted_at = row[2]
+                p95_latency = float(row[3] or 0.0)
+                if oldest_backlog_submitted_at is not None:
+                    backlog_age_seconds = float(
+                        (datetime.now(UTC) - oldest_backlog_submitted_at).total_seconds()
+                    )
+            except Exception:
+                # Fallback path for dialects/environments without percentile_cont support.
+                jobs = (
+                    await db.scalars(
+                        select(DBIngestionJob).where(DBIngestionJob.submitted_at >= since)
+                    )
+                ).all()
+                total_jobs = len(jobs)
+                failed_jobs = len([j for j in jobs if j.status == "failed"])
+
+                latencies = [
+                    (j.completed_at - j.submitted_at).total_seconds()
+                    for j in jobs
+                    if j.completed_at is not None
+                ]
+                latencies.sort()
+                if latencies:
+                    p95_index = max(0, min(len(latencies) - 1, int(len(latencies) * 0.95) - 1))
+                    p95_latency = float(latencies[p95_index])
+
+                non_terminal = [j for j in jobs if j.status in {"accepted", "queued"}]
+                if non_terminal:
+                    oldest = min(non_terminal, key=lambda item: item.submitted_at)
+                    backlog_age_seconds = float(
+                        (datetime.now(UTC) - oldest.submitted_at).total_seconds()
+                    )
             INGESTION_BACKLOG_AGE_SECONDS.set(backlog_age_seconds)
 
             failure_rate = (


### PR DESCRIPTION
## Summary
- continue RFC-065 Phase 4 by optimizing SLO computation path with DB-side aggregate and percentile logic
- add supporting index for latency-window scans
- update RFC 065 Phase 4 progress details

## Changes
- `get_slo_status` now computes total jobs, failed jobs, backlog oldest timestamp, and p95 queue latency via SQL aggregation
- p95 uses DB percentile (`percentile_cont`) when available, with safe Python fallback path
- add migration `e1f2a3b4c7d8` for index: `ingestion_jobs(submitted_at, completed_at)`

## Validation
- `uv run python -m pytest tests/integration/services/ingestion_service/test_ingestion_routers.py -q`
- `uv run python -m pytest tests/unit/libs/portfolio-common/test_kafka_consumer.py -q`
- `uv run python -m pytest tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py -q`
