### PR TITLE
RFC-065 Phase 4d: operations index hardening

### DIFF
--- a/alembic/versions/f2a3b4c5d6e7_perf_add_ops_partial_and_failure_indexes.py
+++ b/alembic/versions/f2a3b4c5d6e7_perf_add_ops_partial_and_failure_indexes.py
@@ -1,0 +1,38 @@
+"""perf: add ops partial backlog index and failure-history index
+
+Revision ID: f2a3b4c5d6e7
+Revises: e1f2a3b4c7d8
+Create Date: 2026-03-03 17:45:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f2a3b4c5d6e7"
+down_revision: Union[str, None] = "e1f2a3b4c7d8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_ingestion_job_failures_job_failed_at",
+        "ingestion_job_failures",
+        ["job_id", "failed_at"],
+    )
+    op.create_index(
+        "ix_ingestion_jobs_non_terminal_submitted_at",
+        "ingestion_jobs",
+        ["submitted_at"],
+        postgresql_where=sa.text("status IN ('accepted', 'queued')"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ingestion_jobs_non_terminal_submitted_at", table_name="ingestion_jobs")
+    op.drop_index("ix_ingestion_job_failures_job_failed_at", table_name="ingestion_job_failures")
+

--- a/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
+++ b/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
@@ -301,3 +301,6 @@ Acceptance:
 - retained safe fallback path to Python-side p95 calculation for environments without percentile support
 7. Added latency-path support index:
 - `ingestion_jobs(submitted_at, completed_at)` for p95 latency window scanning efficiency
+8. Hardened operational-index coverage for backlog and failure runbooks:
+- added partial non-terminal backlog index on ingestion jobs (`status in accepted/queued`) to accelerate stalled/backlog scans
+- added ordered failure-history index for ingestion job failures (`job_id, failed_at`) to accelerate runbook failure lookups

--- a/src/libs/portfolio-common/portfolio_common/database_models.py
+++ b/src/libs/portfolio-common/portfolio_common/database_models.py
@@ -823,6 +823,10 @@ class IngestionJobFailure(Base):
     failed_record_keys = Column(JSON, nullable=True)
     failed_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
+    __table_args__ = (
+        Index("ix_ingestion_job_failures_job_failed_at", "job_id", failed_at.desc()),
+    )
+
 
 class IngestionOpsControl(Base):
     __tablename__ = "ingestion_ops_control"


### PR DESCRIPTION
## Summary
- continue RFC-065 optimization with index hardening for operations hot paths
- add partial index for non-terminal backlog scans
- add ordered failure-history index for ingestion job failure lookups
- update RFC 065 implementation progress

## Changes
- migration `f2a3b4c5d6e7` adds:
  - `ix_ingestion_jobs_non_terminal_submitted_at` (partial index where status in accepted/queued)
  - `ix_ingestion_job_failures_job_failed_at` (job_id, failed_at)
- model metadata updated for `ingestion_job_failures` ordered index

## Validation
- `uv run python -m pytest tests/integration/services/ingestion_service/test_ingestion_routers.py -q`
- `uv run python -m pytest tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py -q`
