### PR TITLE
RFC-065 Phase 4e: metrics correctness and resilience hardening

### DIFF
--- a/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
+++ b/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
@@ -304,3 +304,6 @@ Acceptance:
 8. Hardened operational-index coverage for backlog and failure runbooks:
 - added partial non-terminal backlog index on ingestion jobs (`status in accepted/queued`) to accelerate stalled/backlog scans
 - added ordered failure-history index for ingestion job failures (`job_id, failed_at`) to accelerate runbook failure lookups
+9. Correctness and resilience hardening for ops metrics:
+- `get_backlog_breakdown.total_backlog_jobs` now reports full-window backlog across all endpoint groups (not only the limited top-N group page)
+- narrowed SLO percentile fallback to `SQLAlchemyError` instead of a broad catch-all, reducing risk of masking non-database defects

--- a/src/services/ingestion_service/app/services/ingestion_job_service.py
+++ b/src/services/ingestion_service/app/services/ingestion_job_service.py
@@ -44,6 +44,7 @@ from portfolio_common.monitoring import (
     INGESTION_REPLAY_FAILURE_TOTAL,
 )
 from sqlalchemy import and_, case, desc, func, select
+from sqlalchemy.exc import SQLAlchemyError
 
 REPLAY_MAX_RECORDS_PER_REQUEST = int(
     os.getenv("LOTUS_CORE_REPLAY_MAX_RECORDS_PER_REQUEST", "5000")
@@ -406,7 +407,7 @@ class IngestionJobService:
                     backlog_age_seconds = float(
                         (datetime.now(UTC) - oldest_backlog_submitted_at).total_seconds()
                     )
-            except Exception:
+            except SQLAlchemyError:
                 # Fallback path for dialects/environments without percentile_cont support.
                 jobs = (
                     await db.scalars(
@@ -469,6 +470,19 @@ class IngestionJobService:
         async for db in get_async_db_session():
             since = datetime.now(UTC) - timedelta(minutes=lookback_minutes)
             now_utc = datetime.now(UTC)
+            total_backlog_jobs = int(
+                (
+                    await db.scalar(
+                        select(func.count(DBIngestionJob.id)).where(
+                            and_(
+                                DBIngestionJob.submitted_at >= since,
+                                DBIngestionJob.status.in_(["accepted", "queued"]),
+                            )
+                        )
+                    )
+                )
+                or 0
+            )
             rows = await db.execute(
                 select(
                     DBIngestionJob.endpoint,
@@ -543,7 +557,7 @@ class IngestionJobService:
 
             return IngestionBacklogBreakdownResponse(
                 lookback_minutes=lookback_minutes,
-                total_backlog_jobs=sum(item.backlog_jobs for item in rows),
+                total_backlog_jobs=total_backlog_jobs,
                 groups=rows,
             )
 


### PR DESCRIPTION
## Summary
- continue RFC-065 hardening with metrics correctness and safer fallback behavior

## Changes
- `get_backlog_breakdown.total_backlog_jobs` now reflects full-window backlog across all groups
- narrowed SLO percentile fallback from broad exception to `SQLAlchemyError`
- updated RFC 065 progress notes

## Validation
- `uv run python -m pytest tests/integration/services/ingestion_service/test_ingestion_routers.py -q`
- `uv run python -m pytest tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py -q`
