### PR TITLE
RFC-065 Phase 4f: atomic ingestion-job transitions

### DIFF
--- a/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
+++ b/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
@@ -307,3 +307,8 @@ Acceptance:
 9. Correctness and resilience hardening for ops metrics:
 - `get_backlog_breakdown.total_backlog_jobs` now reports full-window backlog across all endpoint groups (not only the limited top-N group page)
 - narrowed SLO percentile fallback to `SQLAlchemyError` instead of a broad catch-all, reducing risk of masking non-database defects
+10. Reduced ingestion job lifecycle transition contention and race windows:
+- `mark_queued`, `mark_failed`, and `mark_retried` now use single-statement atomic `UPDATE` paths instead of select-then-mutate flows
+- `mark_failed` and `mark_retried` use `UPDATE ... RETURNING` for metric label context (`endpoint`, `entity_type`) without extra reads
+- retry counter increments are now DB-atomic (`coalesce(retry_count, 0) + 1`) to avoid lost updates under concurrent retry operations
+- added focused unit coverage to lock transition SQL intent and failure-record persistence behavior

--- a/src/services/ingestion_service/app/services/ingestion_job_service.py
+++ b/src/services/ingestion_service/app/services/ingestion_job_service.py
@@ -43,7 +43,7 @@ from portfolio_common.monitoring import (
     INGESTION_REPLAY_DUPLICATE_BLOCKED_TOTAL,
     INGESTION_REPLAY_FAILURE_TOTAL,
 )
-from sqlalchemy import and_, case, desc, func, select
+from sqlalchemy import and_, case, desc, func, select, update
 from sqlalchemy.exc import SQLAlchemyError
 
 REPLAY_MAX_RECORDS_PER_REQUEST = int(
@@ -192,14 +192,15 @@ class IngestionJobService:
     async def mark_queued(self, job_id: str) -> None:
         async for db in get_async_db_session():
             async with db.begin():
-                row = await db.scalar(
-                    select(DBIngestionJob).where(DBIngestionJob.job_id == job_id).limit(1)
+                await db.execute(
+                    update(DBIngestionJob)
+                    .where(DBIngestionJob.job_id == job_id)
+                    .values(
+                        status="queued",
+                        completed_at=datetime.now(UTC),
+                        failure_reason=None,
+                    )
                 )
-                if row is None:
-                    return
-                row.status = "queued"
-                row.completed_at = datetime.now(UTC)
-                row.failure_reason = None
 
     async def mark_failed(
         self,
@@ -210,14 +211,21 @@ class IngestionJobService:
     ) -> None:
         async for db in get_async_db_session():
             async with db.begin():
-                row = await db.scalar(
-                    select(DBIngestionJob).where(DBIngestionJob.job_id == job_id).limit(1)
+                updated = (
+                    await db.execute(
+                        update(DBIngestionJob)
+                        .where(DBIngestionJob.job_id == job_id)
+                        .values(
+                            status="failed",
+                            completed_at=datetime.now(UTC),
+                            failure_reason=failure_reason,
+                        )
+                        .returning(DBIngestionJob.endpoint, DBIngestionJob.entity_type)
+                    )
                 )
+                row = updated.first()
                 if row is None:
                     return
-                row.status = "failed"
-                row.completed_at = datetime.now(UTC)
-                row.failure_reason = failure_reason
                 db.add(
                     DBIngestionJobFailure(
                         failure_id=f"fail_{uuid4().hex}",
@@ -236,13 +244,20 @@ class IngestionJobService:
     async def mark_retried(self, job_id: str) -> None:
         async for db in get_async_db_session():
             async with db.begin():
-                row = await db.scalar(
-                    select(DBIngestionJob).where(DBIngestionJob.job_id == job_id).limit(1)
+                updated = (
+                    await db.execute(
+                        update(DBIngestionJob)
+                        .where(DBIngestionJob.job_id == job_id)
+                        .values(
+                            retry_count=func.coalesce(DBIngestionJob.retry_count, 0) + 1,
+                            last_retried_at=datetime.now(UTC),
+                        )
+                        .returning(DBIngestionJob.endpoint, DBIngestionJob.entity_type)
+                    )
                 )
+                row = updated.first()
                 if row is None:
                     return
-                row.retry_count = int(row.retry_count or 0) + 1
-                row.last_retried_at = datetime.now(UTC)
                 INGESTION_JOBS_RETRIED_TOTAL.labels(
                     endpoint=row.endpoint, entity_type=row.entity_type, result="accepted"
                 ).inc()

--- a/tests/unit/services/ingestion_service/services/test_ingestion_job_service_state_transitions.py
+++ b/tests/unit/services/ingestion_service/services/test_ingestion_job_service_state_transitions.py
@@ -1,0 +1,126 @@
+from types import SimpleNamespace
+
+import pytest
+
+from portfolio_common.database_models import IngestionJobFailure as DBIngestionJobFailure
+from src.services.ingestion_service.app.services import ingestion_job_service as service_module
+from src.services.ingestion_service.app.services.ingestion_job_service import IngestionJobService
+from tests.unit.test_support.async_session_iter import make_single_session_getter
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeBeginContext:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+
+class _FakeResult:
+    def __init__(self, row: object | None = None) -> None:
+        self._row = row
+
+    def first(self) -> object | None:
+        return self._row
+
+
+class _FakeSession:
+    def __init__(self, returned_row: object | None = None) -> None:
+        self.returned_row = returned_row
+        self.executed_statements: list[object] = []
+        self.added_rows: list[object] = []
+
+    def begin(self) -> _FakeBeginContext:
+        return _FakeBeginContext()
+
+    async def execute(self, statement):
+        self.executed_statements.append(statement)
+        return _FakeResult(self.returned_row)
+
+    def add(self, row: object) -> None:
+        self.added_rows.append(row)
+
+
+@pytest.fixture
+def service() -> IngestionJobService:
+    return IngestionJobService()
+
+
+async def test_mark_queued_uses_single_atomic_update(
+    service: IngestionJobService,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    session = _FakeSession()
+    monkeypatch.setattr(
+        service_module,
+        "get_async_db_session",
+        make_single_session_getter(session),
+    )
+
+    await service.mark_queued("job_mark_queued")
+
+    assert len(session.executed_statements) == 1
+    compiled_sql = str(session.executed_statements[0])
+    assert "UPDATE ingestion_jobs" in compiled_sql
+    assert "status=:status" in compiled_sql
+    assert "completed_at=:completed_at" in compiled_sql
+    assert "failure_reason=:failure_reason" in compiled_sql
+
+
+async def test_mark_failed_uses_atomic_update_and_records_failure(
+    service: IngestionJobService,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    session = _FakeSession(
+        returned_row=SimpleNamespace(endpoint="transactions", entity_type="transaction")
+    )
+    monkeypatch.setattr(
+        service_module,
+        "get_async_db_session",
+        make_single_session_getter(session),
+    )
+
+    await service.mark_failed(
+        "job_mark_failed",
+        failure_reason="publish failed",
+        failure_phase="retry_publish",
+        failed_record_keys=["tx-001"],
+    )
+
+    assert len(session.executed_statements) == 1
+    compiled_sql = str(session.executed_statements[0])
+    assert "UPDATE ingestion_jobs" in compiled_sql
+    assert "RETURNING ingestion_jobs.endpoint, ingestion_jobs.entity_type" in compiled_sql
+
+    assert len(session.added_rows) == 1
+    failure_row = session.added_rows[0]
+    assert isinstance(failure_row, DBIngestionJobFailure)
+    assert failure_row.job_id == "job_mark_failed"
+    assert failure_row.failure_phase == "retry_publish"
+    assert failure_row.failure_reason == "publish failed"
+    assert failure_row.failed_record_keys == ["tx-001"]
+
+
+async def test_mark_retried_uses_atomic_increment_update(
+    service: IngestionJobService,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    session = _FakeSession(
+        returned_row=SimpleNamespace(endpoint="transactions", entity_type="transaction")
+    )
+    monkeypatch.setattr(
+        service_module,
+        "get_async_db_session",
+        make_single_session_getter(session),
+    )
+
+    await service.mark_retried("job_mark_retried")
+
+    assert len(session.executed_statements) == 1
+    compiled_sql = str(session.executed_statements[0])
+    assert "UPDATE ingestion_jobs" in compiled_sql
+    assert "retry_count=(coalesce(ingestion_jobs.retry_count, :coalesce_1) + :coalesce_2)" in compiled_sql
+    assert "last_retried_at=:last_retried_at" in compiled_sql
+    assert "RETURNING ingestion_jobs.endpoint, ingestion_jobs.entity_type" in compiled_sql


### PR DESCRIPTION
## Summary
- refactored ingestion job lifecycle transitions to single-statement atomic updates
- moved `mark_failed` and `mark_retried` to `UPDATE ... RETURNING` so metrics labels are captured without extra row reads
- made retry counter increment DB-atomic via `coalesce(retry_count, 0) + 1`
- added focused unit coverage for transition SQL intent and failure-row persistence
- updated RFC-065 Phase 4 progress log with this slice

## Why
This closes a remaining RFC-065 Phase 4 gap around job-table contention and race windows from select-then-mutate patterns under concurrent retries/updates.

## Validation
- `uv run python -m pytest tests/unit/services/ingestion_service/services/test_ingestion_job_service_state_transitions.py tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py -q`
- `uv run python -m pytest tests/integration/services/ingestion_service/test_ingestion_routers.py -q`
