### PR TITLE
RFC-065 Phase 4g: add replay/DLQ pressure ratios to error-budget API

### DIFF
--- a/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
+++ b/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
@@ -312,3 +312,7 @@ Acceptance:
 - `mark_failed` and `mark_retried` use `UPDATE ... RETURNING` for metric label context (`endpoint`, `entity_type`) without extra reads
 - retry counter increments are now DB-atomic (`coalesce(retry_count, 0) + 1`) to avoid lost updates under concurrent retry operations
 - added focused unit coverage to lock transition SQL intent and failure-record persistence behavior
+11. Added canonical pressure-ratio signals to ingestion error-budget endpoint:
+- error-budget response now includes replay backlog pressure ratio and DLQ pressure ratio (`P_dlq`) aligned to RFC formulas
+- included raw supporting controls in the same response (`dlq_events_in_window`, `dlq_budget_events_per_window`) for runbook decisions
+- added unit and integration coverage to lock new contract fields and calculations

--- a/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
+++ b/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
@@ -734,6 +734,32 @@ class IngestionErrorBudgetStatusResponse(BaseModel):
         description="Backlog growth compared with previous window.",
         examples=[3],
     )
+    replay_backlog_pressure_ratio: Decimal = Field(
+        ge=Decimal("0"),
+        description=(
+            "Backlog saturation ratio against replay guardrail capacity "
+            "(backlog_jobs / replay_max_backlog_jobs)."
+        ),
+        examples=["0.0024"],
+    )
+    dlq_events_in_window: int = Field(
+        ge=0,
+        description="Count of consumer DLQ events observed in current lookback window.",
+        examples=[4],
+    )
+    dlq_budget_events_per_window: int = Field(
+        ge=1,
+        description="Configured DLQ event budget for the same lookback window.",
+        examples=[10],
+    )
+    dlq_pressure_ratio: Decimal = Field(
+        ge=Decimal("0"),
+        description=(
+            "DLQ pressure ratio against budget "
+            "(dlq_events_in_window / dlq_budget_events_per_window)."
+        ),
+        examples=["0.4000"],
+    )
     breach_failure_rate: bool = Field(
         description="Whether failure rate exceeds threshold.",
         examples=[False],

--- a/src/services/ingestion_service/app/services/ingestion_job_service.py
+++ b/src/services/ingestion_service/app/services/ingestion_job_service.py
@@ -50,6 +50,9 @@ REPLAY_MAX_RECORDS_PER_REQUEST = int(
     os.getenv("LOTUS_CORE_REPLAY_MAX_RECORDS_PER_REQUEST", "5000")
 )
 REPLAY_MAX_BACKLOG_JOBS = int(os.getenv("LOTUS_CORE_REPLAY_MAX_BACKLOG_JOBS", "5000"))
+DLQ_BUDGET_EVENTS_PER_WINDOW = int(
+    os.getenv("LOTUS_CORE_DLQ_EVENTS_BUDGET_PER_WINDOW", "10")
+)
 
 
 @dataclass(slots=True)
@@ -989,6 +992,16 @@ class IngestionJobService:
                     )
                 )
             ).one()
+            dlq_events_in_window = int(
+                (
+                    await db.execute(
+                        select(func.count(DBConsumerDlqEvent.id)).where(
+                            DBConsumerDlqEvent.observed_at >= current_since
+                        )
+                    )
+                ).scalar_one()
+                or 0
+            )
 
             total_jobs = int(current_row[0] or 0)
             failed_jobs = int(current_row[1] or 0)
@@ -999,6 +1012,13 @@ class IngestionJobService:
             backlog_jobs = int(current_row[2] or 0)
             previous_backlog_jobs = int(previous_row[0] or 0)
             backlog_growth = backlog_jobs - previous_backlog_jobs
+            replay_backlog_pressure_ratio = Decimal(backlog_jobs) / Decimal(
+                max(1, REPLAY_MAX_BACKLOG_JOBS)
+            )
+            dlq_budget_events_per_window = max(1, DLQ_BUDGET_EVENTS_PER_WINDOW)
+            dlq_pressure_ratio = Decimal(dlq_events_in_window) / Decimal(
+                dlq_budget_events_per_window
+            )
 
             return IngestionErrorBudgetStatusResponse(
                 lookback_minutes=lookback_minutes,
@@ -1010,6 +1030,10 @@ class IngestionJobService:
                 backlog_jobs=backlog_jobs,
                 previous_backlog_jobs=previous_backlog_jobs,
                 backlog_growth=backlog_growth,
+                replay_backlog_pressure_ratio=replay_backlog_pressure_ratio,
+                dlq_events_in_window=dlq_events_in_window,
+                dlq_budget_events_per_window=dlq_budget_events_per_window,
+                dlq_pressure_ratio=dlq_pressure_ratio,
                 breach_failure_rate=failure_rate > failure_rate_threshold,
                 breach_backlog_growth=backlog_growth > backlog_growth_threshold,
             )
@@ -1023,6 +1047,10 @@ class IngestionJobService:
             backlog_jobs=0,
             previous_backlog_jobs=0,
             backlog_growth=0,
+            replay_backlog_pressure_ratio=Decimal("0"),
+            dlq_events_in_window=0,
+            dlq_budget_events_per_window=max(1, DLQ_BUDGET_EVENTS_PER_WINDOW),
+            dlq_pressure_ratio=Decimal("0"),
             breach_failure_rate=False,
             breach_backlog_growth=False,
         )

--- a/tests/integration/services/ingestion_service/test_ingestion_routers.py
+++ b/tests/integration/services/ingestion_service/test_ingestion_routers.py
@@ -410,6 +410,10 @@ async def async_test_client(mock_kafka_producer: MagicMock):
                 "backlog_jobs": 1,
                 "previous_backlog_jobs": 1,
                 "backlog_growth": 0,
+                "replay_backlog_pressure_ratio": Decimal("0.0002"),
+                "dlq_events_in_window": 0,
+                "dlq_budget_events_per_window": 10,
+                "dlq_pressure_ratio": Decimal("0"),
                 "breach_failure_rate": False,
                 "breach_backlog_growth": False,
             }
@@ -946,6 +950,10 @@ async def test_ingestion_error_budget_endpoint(async_test_client: httpx.AsyncCli
     body = response.json()
     assert "failure_rate" in body
     assert "remaining_error_budget" in body
+    assert "replay_backlog_pressure_ratio" in body
+    assert "dlq_events_in_window" in body
+    assert "dlq_budget_events_per_window" in body
+    assert "dlq_pressure_ratio" in body
 
 
 async def test_ingestion_idempotency_diagnostics_endpoint(async_test_client: httpx.AsyncClient):

--- a/tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py
+++ b/tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 from types import SimpleNamespace
 
 import pytest
@@ -77,3 +78,59 @@ async def test_assert_reprocessing_publish_allowed_reuses_retry_guardrails(
     monkeypatch.setattr(service, "assert_retry_allowed_for_records", _mock_guardrail)
     await service.assert_reprocessing_publish_allowed(7)
     assert called["count"] == 1
+
+
+async def test_get_error_budget_status_includes_pressure_ratios(
+    service: IngestionJobService,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class _FakeBegin:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+    class _FakeResult:
+        def __init__(self, *, row: tuple | None = None, scalar: int | None = None):
+            self._row = row
+            self._scalar = scalar
+
+        def one(self):
+            assert self._row is not None
+            return self._row
+
+        def scalar_one(self):
+            assert self._scalar is not None
+            return self._scalar
+
+    class _FakeSession:
+        def __init__(self):
+            self.calls = 0
+
+        async def execute(self, _stmt):
+            self.calls += 1
+            if self.calls == 1:
+                return _FakeResult(row=(100, 5, 20))
+            if self.calls == 2:
+                return _FakeResult(row=(10,))
+            if self.calls == 3:
+                return _FakeResult(scalar=4)
+            raise AssertionError("Unexpected execute call count")
+
+        def begin(self):
+            return _FakeBegin()
+
+    async def _mock_get_async_db_session():
+        yield _FakeSession()
+
+    monkeypatch.setattr(service_module, "get_async_db_session", _mock_get_async_db_session)
+    monkeypatch.setattr(service_module, "REPLAY_MAX_BACKLOG_JOBS", 5000)
+    monkeypatch.setattr(service_module, "DLQ_BUDGET_EVENTS_PER_WINDOW", 10)
+
+    result = await service.get_error_budget_status()
+    assert result.failure_rate == Decimal("0.05")
+    assert result.replay_backlog_pressure_ratio == Decimal("0.004")
+    assert result.dlq_events_in_window == 4
+    assert result.dlq_budget_events_per_window == 10
+    assert result.dlq_pressure_ratio == Decimal("0.4")


### PR DESCRIPTION
## Summary
- added canonical pressure metrics to ingestion error-budget contract:
  - `replay_backlog_pressure_ratio`
  - `dlq_events_in_window`
  - `dlq_budget_events_per_window`
  - `dlq_pressure_ratio`
- computed ratios in `IngestionJobService.get_error_budget_status` using current lookback windows and configured budgets
- added configurable DLQ budget env var: `LOTUS_CORE_DLQ_EVENTS_BUDGET_PER_WINDOW` (default `10`)
- updated ingestion integration fake service and endpoint assertions for new fields
- added unit test coverage for ratio calculations
- updated RFC-065 Phase 4 progress log

## Validation
- `uv run python -m pytest tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py -q`
- `uv run python -m pytest tests/unit/services/ingestion_service/services/test_ingestion_job_service_state_transitions.py -q`
- `uv run python -m pytest tests/integration/services/ingestion_service/test_ingestion_routers.py -q`
