### PR TITLE
RFC-065 Phase 5a: ops playbook + ops-contract CI suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
           - suite: unit
           - suite: unit-db
           - suite: integration-lite
+          - suite: ops-contract
           - suite: buy-rfc
           - suite: sell-rfc
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint typecheck architecture-guard monetary-float-guard ingestion-contract-gate no-alias-gate openapi-gate api-vocabulary-gate warning-gate migration-smoke migration-apply test test-unit test-unit-db test-integration-lite test-buy-rfc test-sell-rfc test-e2e-smoke test-docker-smoke test-latency-gate security-audit check coverage-gate ci ci-local docker-build clean
+.PHONY: install lint typecheck architecture-guard monetary-float-guard ingestion-contract-gate no-alias-gate openapi-gate api-vocabulary-gate warning-gate migration-smoke migration-apply test test-unit test-unit-db test-integration-lite test-ops-contract test-buy-rfc test-sell-rfc test-e2e-smoke test-docker-smoke test-latency-gate security-audit check coverage-gate ci ci-local docker-build clean
 
 install:
 	python scripts/bootstrap_dev.py
@@ -51,6 +51,9 @@ test-unit-db:
 
 test-integration-lite:
 	python scripts/test_manifest.py --suite integration-lite --quiet
+
+test-ops-contract:
+	python scripts/test_manifest.py --suite ops-contract --quiet
 
 test-buy-rfc:
 	python scripts/test_manifest.py --suite buy-rfc --quiet

--- a/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
+++ b/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
@@ -316,3 +316,12 @@ Acceptance:
 - error-budget response now includes replay backlog pressure ratio and DLQ pressure ratio (`P_dlq`) aligned to RFC formulas
 - included raw supporting controls in the same response (`dlq_events_in_window`, `dlq_budget_events_per_window`) for runbook decisions
 - added unit and integration coverage to lock new contract fields and calculations
+
+### Phase 5 progress (2026-03-03)
+1. Added dedicated RFC-065 operational playbook:
+- `docs/operations/RFC-065-Calculator-Scalability-Operations-Playbook.md`
+- includes canonical signal definitions, operating bands, incident workflow, replay safety rules, and incident exit criteria
+2. Added explicit CI smoke contract coverage for ingestion operations APIs:
+- introduced `ops-contract` test suite in `scripts/test_manifest.py`
+- wired suite into CI matrix as `Tests (ops-contract)`
+- added local runner target `make test-ops-contract`

--- a/docs/operations/RFC-065-Calculator-Scalability-Operations-Playbook.md
+++ b/docs/operations/RFC-065-Calculator-Scalability-Operations-Playbook.md
@@ -1,0 +1,87 @@
+# RFC-065 Calculator Scalability Operations Playbook
+
+## Purpose
+This runbook operationalizes RFC-065 for on-call and platform operators.
+It defines measurable trigger signals, deterministic response actions, and
+recovery guardrails for event-driven calculator scaling and replay safety.
+
+## Scope
+- Position calculator
+- Cost calculator
+- Valuation calculator
+- Cashflow calculator
+- Timeseries generator
+- Ingestion operations control plane signals used to gate replay pressure
+
+## Canonical Signals
+- `rho`: utilization ratio (`lambda_in / (N_replica * mu_msg)`)
+- `T_lag`: oldest unprocessed event age (seconds)
+- `L_lag`: consumer lag size (events)
+- `S_p95`: p95 end-to-end service time (seconds)
+- `J_backlog`: non-terminal ingestion backlog (`accepted + queued`)
+- `P_replay`: replay pressure (`replay_record_count / replay_max_records`)
+- `P_dlq`: DLQ pressure (`dlq_events_in_window / dlq_budget_events_per_window`)
+
+## Operating Bands
+Use these bands consistently for all calculator groups.
+
+| Band | Condition | Standard Action |
+|---|---|---|
+| Green | `rho < 0.60` and `T_lag < 15s` | Hold baseline replicas |
+| Yellow | `0.60 <= rho < 0.80` or `15s <= T_lag < 60s` | Scale up one step, monitor DLQ pressure |
+| Orange | `0.80 <= rho < 0.95` or `60s <= T_lag < 180s` | Aggressive autoscale, pause non-critical replay |
+| Red | `rho >= 0.95` or `T_lag >= 180s` | Incident mode, block replay except emergency paths |
+
+## Required Operational APIs
+- `GET /ingestion/health/summary`
+- `GET /ingestion/health/consumer-lag`
+- `GET /ingestion/health/slo`
+- `GET /ingestion/health/error-budget`
+- `GET /ingestion/health/backlog-breakdown`
+- `GET /ingestion/health/stalled-jobs`
+- `GET /ingestion/dlq/consumer-events`
+- `GET /ingestion/audit/replays`
+- `PUT /ingestion/ops/control`
+
+## Incident Workflow
+1. Confirm severity with `GET /ingestion/health/slo` and `GET /ingestion/health/error-budget`.
+2. Isolate pressure source:
+- Backlog hotspot: `GET /ingestion/health/backlog-breakdown`
+- Stalled jobs: `GET /ingestion/health/stalled-jobs`
+- Consumer failure concentration: `GET /ingestion/dlq/consumer-events`
+3. Apply control-plane mode:
+- `normal`: default
+- `drain`: stop new ingestion writes, continue queue drain
+- `paused`: stop ingestion writes and replay requests
+4. Guard replay blast radius:
+- allow replay only if backlog and replay pressure guardrails are within limits
+- prefer dry-run path for uncertain payload mappings
+5. Return to steady state:
+- reduce lag/age below yellow threshold
+- replay only deterministic, auditable batches
+- switch mode back to `normal`
+
+## Replay Safety Rules
+- Never run broad replay while in orange/red band.
+- Do not exceed configured replay maximum records per request.
+- Do not replay when ingestion backlog exceeds replay threshold.
+- Every replay must produce audit evidence (`consumer_dlq_replay_audit`).
+
+## Scaling Controls
+- Deploy KEDA scaled objects from:
+  - `deployment/kubernetes/keda/calculator-scaledobjects.yaml`
+- Validate scaling objects:
+  - `kubectl get scaledobject -n lotus-core`
+  - `kubectl describe scaledobject <name> -n lotus-core`
+
+## CI Gate Expectations
+Minimum required CI evidence for RFC-065 operational correctness:
+- `Tests (ops-contract)` validates ingestion ops contract and expected response shape.
+- `Tests (integration-lite)` validates query-service integration basics.
+- `Latency Gate` and `Docker Smoke Contract` remain required.
+
+## Exit Criteria for Incident
+- No red-band signal for 30 minutes.
+- DLQ pressure below 1.0 for two consecutive lookback windows.
+- Backlog trend non-increasing and oldest backlog age below critical threshold.
+- Replay queue empty or bounded with audited completion plan.

--- a/scripts/test_manifest.py
+++ b/scripts/test_manifest.py
@@ -24,6 +24,9 @@ SUITES: dict[str, list[str]] = {
         "tests/unit/services/calculators/position_valuation_calculator/repositories/test_unit_valuation_repo.py",
     ],
     "integration-lite": _discover_integration_lite(),
+    "ops-contract": [
+        "tests/integration/services/ingestion_service/test_ingestion_routers.py",
+    ],
     "e2e-smoke": [
         "tests/e2e/test_query_service_observability.py",
         "tests/e2e/test_complex_portfolio_lifecycle.py",


### PR DESCRIPTION
## Summary
- added a dedicated RFC-065 operations playbook at `docs/operations/RFC-065-Calculator-Scalability-Operations-Playbook.md`
- introduced a focused `ops-contract` test suite in `scripts/test_manifest.py` for ingestion operations API contract smoke
- added `make test-ops-contract` target
- wired `ops-contract` into CI test matrix (`Tests (ops-contract)`)
- updated RFC-065 Phase 5 progress section with these additions

## Validation
- `python scripts/test_manifest.py --suite ops-contract --validate-only`
- `uv run python -m pytest tests/integration/services/ingestion_service/test_ingestion_routers.py -q`
- `make test-ops-contract`
