### PR TITLE
RFC-065 Phase 5b: add ingestion operating-band API

### DIFF
--- a/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
+++ b/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
@@ -325,3 +325,7 @@ Acceptance:
 - introduced `ops-contract` test suite in `scripts/test_manifest.py`
 - wired suite into CI matrix as `Tests (ops-contract)`
 - added local runner target `make test-ops-contract`
+3. Added canonical operating-band endpoint for automation and runbooks:
+- added `GET /ingestion/health/operating-band` to return `green|yellow|orange|red` severity
+- classification combines backlog age, DLQ pressure ratio, and SLO breach signals in one response contract
+- added unit and integration coverage to lock endpoint behavior and routing shape

--- a/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
+++ b/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
@@ -202,6 +202,41 @@ class IngestionSloStatusResponse(BaseModel):
     )
 
 
+class IngestionOperatingBandResponse(BaseModel):
+    lookback_minutes: int = Field(
+        ge=1,
+        description="Lookback window in minutes used for operating-band classification.",
+        examples=[60],
+    )
+    operating_band: Literal["green", "yellow", "orange", "red"] = Field(
+        description="Current operating severity band for ingestion and calculator scaling workflows.",
+        examples=["yellow"],
+    )
+    recommended_action: str = Field(
+        description="Runbook-oriented next action for this band.",
+        examples=["Scale up one band and monitor DLQ pressure."],
+    )
+    backlog_age_seconds: float = Field(
+        ge=0.0,
+        description="Oldest non-terminal ingestion backlog age used for band classification.",
+        examples=[42.0],
+    )
+    dlq_pressure_ratio: Decimal = Field(
+        ge=Decimal("0"),
+        description="DLQ pressure ratio used for band classification.",
+        examples=["0.3000"],
+    )
+    failure_rate: Decimal = Field(
+        ge=Decimal("0"),
+        description="Current failure rate used for band classification.",
+        examples=["0.0125"],
+    )
+    triggered_signals: list[str] = Field(
+        description="List of signals that triggered the final band decision.",
+        examples=[["backlog_age_seconds>=15", "dlq_pressure_ratio>=0.25"]],
+    )
+
+
 class IngestionBacklogBreakdownItemResponse(BaseModel):
     endpoint: str = Field(
         description="Ingestion endpoint associated with this backlog group.",

--- a/src/services/ingestion_service/app/routers/ingestion_jobs.py
+++ b/src/services/ingestion_service/app/routers/ingestion_jobs.py
@@ -21,6 +21,7 @@ from app.DTOs.ingestion_job_dto import (
     IngestionJobResponse,
     IngestionOpsModeResponse,
     IngestionOpsModeUpdateRequest,
+    IngestionOperatingBandResponse,
     IngestionReplayAuditListResponse,
     IngestionReplayAuditResponse,
     IngestionRetryRequest,
@@ -591,6 +592,33 @@ async def get_ingestion_error_budget_status(
         lookback_minutes=lookback_minutes,
         failure_rate_threshold=failure_rate_threshold,
         backlog_growth_threshold=backlog_growth_threshold,
+    )
+
+
+@router.get(
+    "/ingestion/health/operating-band",
+    response_model=IngestionOperatingBandResponse,
+    status_code=status.HTTP_200_OK,
+    tags=["Ingestion Operations"],
+    summary="Get ingestion operating band",
+    description=(
+        "What: Return canonical ingestion operating band (green/yellow/orange/red).\n"
+        "How: Combine backlog-age, DLQ pressure, and SLO breach signals into one runbook-ready severity.\n"
+        "When: Use for autoscaling decisions, replay safety gating, and incident triage automation."
+    ),
+)
+async def get_ingestion_operating_band(
+    lookback_minutes: int = Query(default=60, ge=5, le=1440),
+    failure_rate_threshold: Decimal = Query(default=Decimal("0.03"), ge=0, le=1),
+    queue_latency_threshold_seconds: float = Query(default=5.0, ge=0.1, le=600),
+    backlog_age_threshold_seconds: float = Query(default=300, ge=1, le=86400),
+    ingestion_job_service: IngestionJobService = Depends(get_ingestion_job_service),
+):
+    return await ingestion_job_service.get_operating_band(
+        lookback_minutes=lookback_minutes,
+        failure_rate_threshold=failure_rate_threshold,
+        queue_latency_threshold_seconds=queue_latency_threshold_seconds,
+        backlog_age_threshold_seconds=backlog_age_threshold_seconds,
     )
 
 

--- a/src/services/ingestion_service/app/services/ingestion_job_service.py
+++ b/src/services/ingestion_service/app/services/ingestion_job_service.py
@@ -23,6 +23,7 @@ from app.DTOs.ingestion_job_dto import (
     IngestionJobResponse,
     IngestionJobStatus,
     IngestionOpsModeResponse,
+    IngestionOperatingBandResponse,
     IngestionSloStatusResponse,
     IngestionStalledJobListResponse,
     IngestionStalledJobResponse,
@@ -477,6 +478,83 @@ class IngestionJobService:
             breach_failure_rate=False,
             breach_queue_latency=False,
             breach_backlog_age=False,
+        )
+
+    async def get_operating_band(
+        self,
+        *,
+        lookback_minutes: int = 60,
+        failure_rate_threshold: Decimal = Decimal("0.03"),
+        queue_latency_threshold_seconds: float = 5.0,
+        backlog_age_threshold_seconds: float = 300.0,
+    ) -> IngestionOperatingBandResponse:
+        slo_status = await self.get_slo_status(
+            lookback_minutes=lookback_minutes,
+            failure_rate_threshold=failure_rate_threshold,
+            queue_latency_threshold_seconds=queue_latency_threshold_seconds,
+            backlog_age_threshold_seconds=backlog_age_threshold_seconds,
+        )
+        error_budget = await self.get_error_budget_status(
+            lookback_minutes=lookback_minutes,
+            failure_rate_threshold=failure_rate_threshold,
+        )
+
+        triggered_signals: list[str] = []
+        operating_band = "green"
+        recommended_action = "Hold baseline replicas."
+        backlog_age_seconds = float(slo_status.backlog_age_seconds)
+        dlq_pressure_ratio = Decimal(error_budget.dlq_pressure_ratio)
+        failure_rate = Decimal(slo_status.failure_rate)
+
+        if backlog_age_seconds >= 180 or dlq_pressure_ratio >= Decimal("1.0"):
+            operating_band = "red"
+            recommended_action = (
+                "Enter incident mode and block non-emergency replay until lag pressure stabilizes."
+            )
+            if backlog_age_seconds >= 180:
+                triggered_signals.append("backlog_age_seconds>=180")
+            if dlq_pressure_ratio >= Decimal("1.0"):
+                triggered_signals.append("dlq_pressure_ratio>=1.0")
+        elif (
+            backlog_age_seconds >= 60
+            or dlq_pressure_ratio >= Decimal("0.50")
+            or slo_status.breach_failure_rate
+            or slo_status.breach_queue_latency
+            or slo_status.breach_backlog_age
+        ):
+            operating_band = "orange"
+            recommended_action = (
+                "Aggressively scale calculators and pause non-critical replay operations."
+            )
+            if backlog_age_seconds >= 60:
+                triggered_signals.append("backlog_age_seconds>=60")
+            if dlq_pressure_ratio >= Decimal("0.50"):
+                triggered_signals.append("dlq_pressure_ratio>=0.50")
+            if slo_status.breach_failure_rate:
+                triggered_signals.append("breach_failure_rate")
+            if slo_status.breach_queue_latency:
+                triggered_signals.append("breach_queue_latency")
+            if slo_status.breach_backlog_age:
+                triggered_signals.append("breach_backlog_age")
+        elif backlog_age_seconds >= 15 or dlq_pressure_ratio >= Decimal("0.25"):
+            operating_band = "yellow"
+            recommended_action = "Scale up one band and monitor DLQ pressure."
+            if backlog_age_seconds >= 15:
+                triggered_signals.append("backlog_age_seconds>=15")
+            if dlq_pressure_ratio >= Decimal("0.25"):
+                triggered_signals.append("dlq_pressure_ratio>=0.25")
+
+        if not triggered_signals:
+            triggered_signals.append("stable_signals")
+
+        return IngestionOperatingBandResponse(
+            lookback_minutes=lookback_minutes,
+            operating_band=operating_band,  # type: ignore[arg-type]
+            recommended_action=recommended_action,
+            backlog_age_seconds=backlog_age_seconds,
+            dlq_pressure_ratio=dlq_pressure_ratio,
+            failure_rate=failure_rate,
+            triggered_signals=triggered_signals,
         )
 
     async def get_backlog_breakdown(

--- a/tests/integration/services/ingestion_service/test_ingestion_routers.py
+++ b/tests/integration/services/ingestion_service/test_ingestion_routers.py
@@ -418,6 +418,24 @@ async def async_test_client(mock_kafka_producer: MagicMock):
                 "breach_backlog_growth": False,
             }
 
+        async def get_operating_band(
+            self,
+            *,
+            lookback_minutes: int = 60,
+            failure_rate_threshold: Decimal = Decimal("0.03"),
+            queue_latency_threshold_seconds: float = 5.0,
+            backlog_age_threshold_seconds: float = 300.0,
+        ):
+            return {
+                "lookback_minutes": lookback_minutes,
+                "operating_band": "yellow",
+                "recommended_action": "Scale up one band and monitor DLQ pressure.",
+                "backlog_age_seconds": 42.0,
+                "dlq_pressure_ratio": Decimal("0.25"),
+                "failure_rate": Decimal("0"),
+                "triggered_signals": ["backlog_age_seconds>=15", "dlq_pressure_ratio>=0.25"],
+            }
+
         async def find_successful_replay_audit_by_fingerprint(
             self,
             replay_fingerprint: str,
@@ -954,6 +972,15 @@ async def test_ingestion_error_budget_endpoint(async_test_client: httpx.AsyncCli
     assert "dlq_events_in_window" in body
     assert "dlq_budget_events_per_window" in body
     assert "dlq_pressure_ratio" in body
+
+
+async def test_ingestion_operating_band_endpoint(async_test_client: httpx.AsyncClient):
+    response = await async_test_client.get("/ingestion/health/operating-band")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["operating_band"] in {"green", "yellow", "orange", "red"}
+    assert "recommended_action" in body
+    assert "triggered_signals" in body
 
 
 async def test_ingestion_idempotency_diagnostics_endpoint(async_test_client: httpx.AsyncClient):

--- a/tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py
+++ b/tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py
@@ -134,3 +134,51 @@ async def test_get_error_budget_status_includes_pressure_ratios(
     assert result.dlq_events_in_window == 4
     assert result.dlq_budget_events_per_window == 10
     assert result.dlq_pressure_ratio == Decimal("0.4")
+
+
+async def test_get_operating_band_returns_red_for_high_backlog_or_dlq(
+    service: IngestionJobService,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def _mock_slo_status(**_kwargs):
+        return SimpleNamespace(
+            backlog_age_seconds=200.0,
+            breach_failure_rate=False,
+            breach_queue_latency=False,
+            breach_backlog_age=True,
+            failure_rate=Decimal("0.01"),
+        )
+
+    async def _mock_error_budget_status(**_kwargs):
+        return SimpleNamespace(dlq_pressure_ratio=Decimal("1.2"))
+
+    monkeypatch.setattr(service, "get_slo_status", _mock_slo_status)
+    monkeypatch.setattr(service, "get_error_budget_status", _mock_error_budget_status)
+
+    result = await service.get_operating_band()
+    assert result.operating_band == "red"
+    assert "backlog_age_seconds>=180" in result.triggered_signals
+
+
+async def test_get_operating_band_returns_yellow_for_early_pressure(
+    service: IngestionJobService,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def _mock_slo_status(**_kwargs):
+        return SimpleNamespace(
+            backlog_age_seconds=20.0,
+            breach_failure_rate=False,
+            breach_queue_latency=False,
+            breach_backlog_age=False,
+            failure_rate=Decimal("0.005"),
+        )
+
+    async def _mock_error_budget_status(**_kwargs):
+        return SimpleNamespace(dlq_pressure_ratio=Decimal("0.10"))
+
+    monkeypatch.setattr(service, "get_slo_status", _mock_slo_status)
+    monkeypatch.setattr(service, "get_error_budget_status", _mock_error_budget_status)
+
+    result = await service.get_operating_band()
+    assert result.operating_band == "yellow"
+    assert result.recommended_action.startswith("Scale up one band")


### PR DESCRIPTION
## Summary
- added `GET /ingestion/health/operating-band` for canonical green/yellow/orange/red severity classification
- introduced `IngestionOperatingBandResponse` with explicit signal fields and runbook action guidance
- implemented service-level classification using existing SLO and error-budget signals (backlog age, DLQ pressure, SLO breaches)
- added integration and unit coverage for endpoint shape and classification behavior
- updated RFC-065 Phase 5 progress notes

## Validation
- `uv run python -m pytest tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py -q`
- `uv run python -m pytest tests/integration/services/ingestion_service/test_ingestion_routers.py -q`
- `make test-ops-contract`
