### PR TITLE
RFC-065 Phase 5d: add ingestion policy introspection endpoint

### DIFF
--- a/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
+++ b/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
@@ -333,3 +333,7 @@ Acceptance:
 - extracted `OperatingBandPolicy`, `OperatingBandSignals`, and `classify_operating_band(...)`
 - centralized threshold policy to avoid duplicated branching logic and simplify future tuning
 - added deterministic unit coverage for policy ordering (yellow -> orange -> red)
+5. Added ingestion policy introspection endpoint:
+- added `GET /ingestion/health/policy` exposing active SLO defaults, replay guardrails, DLQ budget, and operating-band thresholds
+- enables runbooks and automation to consume runtime policy directly and avoid configuration drift
+- added unit and integration coverage for endpoint contract shape

--- a/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
+++ b/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
@@ -237,6 +237,74 @@ class IngestionOperatingBandResponse(BaseModel):
     )
 
 
+class IngestionOpsPolicyResponse(BaseModel):
+    lookback_minutes_default: int = Field(
+        ge=1,
+        description="Default lookback window (minutes) used by ingestion health endpoints.",
+        examples=[60],
+    )
+    failure_rate_threshold_default: Decimal = Field(
+        ge=Decimal("0"),
+        description="Default failure-rate threshold used for SLO/error-budget evaluations.",
+        examples=["0.03"],
+    )
+    queue_latency_threshold_seconds_default: float = Field(
+        ge=0.0,
+        description="Default queue-latency threshold (seconds) used for SLO evaluation.",
+        examples=[5.0],
+    )
+    backlog_age_threshold_seconds_default: float = Field(
+        ge=0.0,
+        description="Default backlog-age threshold (seconds) used for SLO evaluation.",
+        examples=[300.0],
+    )
+    replay_max_records_per_request: int = Field(
+        ge=1,
+        description="Replay guardrail: maximum replay records allowed per request.",
+        examples=[5000],
+    )
+    replay_max_backlog_jobs: int = Field(
+        ge=1,
+        description="Replay guardrail: backlog ceiling beyond which replay is blocked.",
+        examples=[5000],
+    )
+    dlq_budget_events_per_window: int = Field(
+        ge=1,
+        description="DLQ budget used to compute DLQ pressure ratios for the active window.",
+        examples=[10],
+    )
+    operating_band_yellow_backlog_age_seconds: float = Field(
+        ge=0.0,
+        description="Backlog age threshold (seconds) that triggers yellow operating band.",
+        examples=[15.0],
+    )
+    operating_band_orange_backlog_age_seconds: float = Field(
+        ge=0.0,
+        description="Backlog age threshold (seconds) that triggers orange operating band.",
+        examples=[60.0],
+    )
+    operating_band_red_backlog_age_seconds: float = Field(
+        ge=0.0,
+        description="Backlog age threshold (seconds) that triggers red operating band.",
+        examples=[180.0],
+    )
+    operating_band_yellow_dlq_pressure_ratio: Decimal = Field(
+        ge=Decimal("0"),
+        description="DLQ pressure threshold that triggers yellow operating band.",
+        examples=["0.25"],
+    )
+    operating_band_orange_dlq_pressure_ratio: Decimal = Field(
+        ge=Decimal("0"),
+        description="DLQ pressure threshold that triggers orange operating band.",
+        examples=["0.50"],
+    )
+    operating_band_red_dlq_pressure_ratio: Decimal = Field(
+        ge=Decimal("0"),
+        description="DLQ pressure threshold that triggers red operating band.",
+        examples=["1.0"],
+    )
+
+
 class IngestionBacklogBreakdownItemResponse(BaseModel):
     endpoint: str = Field(
         description="Ingestion endpoint associated with this backlog group.",

--- a/src/services/ingestion_service/app/routers/ingestion_jobs.py
+++ b/src/services/ingestion_service/app/routers/ingestion_jobs.py
@@ -21,6 +21,7 @@ from app.DTOs.ingestion_job_dto import (
     IngestionJobResponse,
     IngestionOpsModeResponse,
     IngestionOpsModeUpdateRequest,
+    IngestionOpsPolicyResponse,
     IngestionOperatingBandResponse,
     IngestionReplayAuditListResponse,
     IngestionReplayAuditResponse,
@@ -620,6 +621,24 @@ async def get_ingestion_operating_band(
         queue_latency_threshold_seconds=queue_latency_threshold_seconds,
         backlog_age_threshold_seconds=backlog_age_threshold_seconds,
     )
+
+
+@router.get(
+    "/ingestion/health/policy",
+    response_model=IngestionOpsPolicyResponse,
+    status_code=status.HTTP_200_OK,
+    tags=["Ingestion Operations"],
+    summary="Get ingestion operating policy thresholds",
+    description=(
+        "What: Return active ingestion policy thresholds and replay/DLQ guardrails.\n"
+        "How: Expose configured defaults used by SLO, operating-band, and replay gating flows.\n"
+        "When: Use to prevent config drift and keep runbooks/automation aligned with runtime policy."
+    ),
+)
+async def get_ingestion_operating_policy(
+    ingestion_job_service: IngestionJobService = Depends(get_ingestion_job_service),
+):
+    return await ingestion_job_service.get_operating_policy()
 
 
 @router.get(

--- a/src/services/ingestion_service/app/services/ingestion_job_service.py
+++ b/src/services/ingestion_service/app/services/ingestion_job_service.py
@@ -23,6 +23,7 @@ from app.DTOs.ingestion_job_dto import (
     IngestionJobResponse,
     IngestionJobStatus,
     IngestionOpsModeResponse,
+    IngestionOpsPolicyResponse,
     IngestionOperatingBandResponse,
     IngestionSloStatusResponse,
     IngestionStalledJobListResponse,
@@ -47,14 +48,6 @@ from portfolio_common.monitoring import (
 from sqlalchemy import and_, case, desc, func, select, update
 from sqlalchemy.exc import SQLAlchemyError
 
-REPLAY_MAX_RECORDS_PER_REQUEST = int(
-    os.getenv("LOTUS_CORE_REPLAY_MAX_RECORDS_PER_REQUEST", "5000")
-)
-REPLAY_MAX_BACKLOG_JOBS = int(os.getenv("LOTUS_CORE_REPLAY_MAX_BACKLOG_JOBS", "5000"))
-DLQ_BUDGET_EVENTS_PER_WINDOW = int(
-    os.getenv("LOTUS_CORE_DLQ_EVENTS_BUDGET_PER_WINDOW", "10")
-)
-
 
 def _env_decimal(name: str, default: str) -> Decimal:
     raw_value = os.getenv(name)
@@ -64,6 +57,25 @@ def _env_decimal(name: str, default: str) -> Decimal:
         return Decimal(raw_value)
     except Exception:
         return Decimal(default)
+
+
+REPLAY_MAX_RECORDS_PER_REQUEST = int(
+    os.getenv("LOTUS_CORE_REPLAY_MAX_RECORDS_PER_REQUEST", "5000")
+)
+REPLAY_MAX_BACKLOG_JOBS = int(os.getenv("LOTUS_CORE_REPLAY_MAX_BACKLOG_JOBS", "5000"))
+DLQ_BUDGET_EVENTS_PER_WINDOW = int(
+    os.getenv("LOTUS_CORE_DLQ_EVENTS_BUDGET_PER_WINDOW", "10")
+)
+DEFAULT_LOOKBACK_MINUTES = int(os.getenv("LOTUS_CORE_DEFAULT_LOOKBACK_MINUTES", "60"))
+DEFAULT_FAILURE_RATE_THRESHOLD = _env_decimal(
+    "LOTUS_CORE_DEFAULT_FAILURE_RATE_THRESHOLD", "0.03"
+)
+DEFAULT_QUEUE_LATENCY_THRESHOLD_SECONDS = float(
+    os.getenv("LOTUS_CORE_DEFAULT_QUEUE_LATENCY_THRESHOLD_SECONDS", "5.0")
+)
+DEFAULT_BACKLOG_AGE_THRESHOLD_SECONDS = float(
+    os.getenv("LOTUS_CORE_DEFAULT_BACKLOG_AGE_THRESHOLD_SECONDS", "300.0")
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -659,6 +671,23 @@ class IngestionJobService:
             dlq_pressure_ratio=dlq_pressure_ratio,
             failure_rate=failure_rate,
             triggered_signals=decision.triggered_signals,
+        )
+
+    async def get_operating_policy(self) -> IngestionOpsPolicyResponse:
+        return IngestionOpsPolicyResponse(
+            lookback_minutes_default=DEFAULT_LOOKBACK_MINUTES,
+            failure_rate_threshold_default=DEFAULT_FAILURE_RATE_THRESHOLD,
+            queue_latency_threshold_seconds_default=DEFAULT_QUEUE_LATENCY_THRESHOLD_SECONDS,
+            backlog_age_threshold_seconds_default=DEFAULT_BACKLOG_AGE_THRESHOLD_SECONDS,
+            replay_max_records_per_request=max(1, REPLAY_MAX_RECORDS_PER_REQUEST),
+            replay_max_backlog_jobs=max(1, REPLAY_MAX_BACKLOG_JOBS),
+            dlq_budget_events_per_window=max(1, DLQ_BUDGET_EVENTS_PER_WINDOW),
+            operating_band_yellow_backlog_age_seconds=OPERATING_BAND_POLICY.yellow_backlog_age_seconds,
+            operating_band_orange_backlog_age_seconds=OPERATING_BAND_POLICY.orange_backlog_age_seconds,
+            operating_band_red_backlog_age_seconds=OPERATING_BAND_POLICY.red_backlog_age_seconds,
+            operating_band_yellow_dlq_pressure_ratio=OPERATING_BAND_POLICY.yellow_dlq_pressure_ratio,
+            operating_band_orange_dlq_pressure_ratio=OPERATING_BAND_POLICY.orange_dlq_pressure_ratio,
+            operating_band_red_dlq_pressure_ratio=OPERATING_BAND_POLICY.red_dlq_pressure_ratio,
         )
 
     async def get_backlog_breakdown(

--- a/tests/integration/services/ingestion_service/test_ingestion_routers.py
+++ b/tests/integration/services/ingestion_service/test_ingestion_routers.py
@@ -436,6 +436,23 @@ async def async_test_client(mock_kafka_producer: MagicMock):
                 "triggered_signals": ["backlog_age_seconds>=15", "dlq_pressure_ratio>=0.25"],
             }
 
+        async def get_operating_policy(self):
+            return {
+                "lookback_minutes_default": 60,
+                "failure_rate_threshold_default": Decimal("0.03"),
+                "queue_latency_threshold_seconds_default": 5.0,
+                "backlog_age_threshold_seconds_default": 300.0,
+                "replay_max_records_per_request": 5000,
+                "replay_max_backlog_jobs": 5000,
+                "dlq_budget_events_per_window": 10,
+                "operating_band_yellow_backlog_age_seconds": 15.0,
+                "operating_band_orange_backlog_age_seconds": 60.0,
+                "operating_band_red_backlog_age_seconds": 180.0,
+                "operating_band_yellow_dlq_pressure_ratio": Decimal("0.25"),
+                "operating_band_orange_dlq_pressure_ratio": Decimal("0.50"),
+                "operating_band_red_dlq_pressure_ratio": Decimal("1.0"),
+            }
+
         async def find_successful_replay_audit_by_fingerprint(
             self,
             replay_fingerprint: str,
@@ -981,6 +998,15 @@ async def test_ingestion_operating_band_endpoint(async_test_client: httpx.AsyncC
     assert body["operating_band"] in {"green", "yellow", "orange", "red"}
     assert "recommended_action" in body
     assert "triggered_signals" in body
+
+
+async def test_ingestion_operating_policy_endpoint(async_test_client: httpx.AsyncClient):
+    response = await async_test_client.get("/ingestion/health/policy")
+    assert response.status_code == 200
+    body = response.json()
+    assert "lookback_minutes_default" in body
+    assert "replay_max_records_per_request" in body
+    assert "operating_band_red_backlog_age_seconds" in body
 
 
 async def test_ingestion_idempotency_diagnostics_endpoint(async_test_client: httpx.AsyncClient):

--- a/tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py
+++ b/tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py
@@ -237,3 +237,13 @@ async def test_classify_operating_band_policy_yellow_orange_red_ordering():
         policy=policy,
     )
     assert red.operating_band == "red"
+
+
+async def test_get_operating_policy_returns_configured_thresholds(
+    service: IngestionJobService,
+):
+    policy = await service.get_operating_policy()
+    assert policy.lookback_minutes_default >= 1
+    assert policy.replay_max_records_per_request >= 1
+    assert policy.replay_max_backlog_jobs >= 1
+    assert policy.dlq_budget_events_per_window >= 1


### PR DESCRIPTION
## Summary
- added `GET /ingestion/health/policy` to expose active SLO defaults, replay guardrails, DLQ budget, and operating-band thresholds
- introduced `IngestionOpsPolicyResponse` DTO with full descriptions/examples for policy introspection
- added `IngestionJobService.get_operating_policy()` as the single policy source for runtime/automation/readability
- wired integration and unit coverage for endpoint + service behavior
- updated RFC-065 Phase 5 progress notes

## Validation
- `uv run python -m pytest tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py -q`
- `uv run python -m pytest tests/integration/services/ingestion_service/test_ingestion_routers.py -q`
- `make test-ops-contract`
