### PR TITLE
RFC-065: version and fingerprint ingestion policy contract

### DIFF
--- a/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
+++ b/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
@@ -337,3 +337,7 @@ Acceptance:
 - added `GET /ingestion/health/policy` exposing active SLO defaults, replay guardrails, DLQ budget, and operating-band thresholds
 - enables runbooks and automation to consume runtime policy directly and avoid configuration drift
 - added unit and integration coverage for endpoint contract shape
+6. Added deterministic policy-version and fingerprint metadata for drift detection:
+- `GET /ingestion/health/policy` now includes `policy_version` and `policy_fingerprint`
+- fingerprint is computed from canonical active policy values with stable JSON serialization and SHA-256 truncation
+- enables automation to detect runtime policy drift with a single contract read

--- a/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
+++ b/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
@@ -238,6 +238,14 @@ class IngestionOperatingBandResponse(BaseModel):
 
 
 class IngestionOpsPolicyResponse(BaseModel):
+    policy_version: str = Field(
+        description="Semantic policy schema/version identifier for ingestion operating policy.",
+        examples=["v1"],
+    )
+    policy_fingerprint: str = Field(
+        description="Deterministic fingerprint of active policy values for drift detection.",
+        examples=["e6a9f2cc3bb5e5a7"],
+    )
     lookback_minutes_default: int = Field(
         ge=1,
         description="Default lookback window (minutes) used by ingestion health endpoints.",

--- a/src/services/ingestion_service/app/services/ingestion_job_service.py
+++ b/src/services/ingestion_service/app/services/ingestion_job_service.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
+import hashlib
+import json
 import os
 from typing import Any, Literal
 from uuid import uuid4
@@ -674,7 +676,26 @@ class IngestionJobService:
         )
 
     async def get_operating_policy(self) -> IngestionOpsPolicyResponse:
+        values = {
+            "lookback_minutes_default": DEFAULT_LOOKBACK_MINUTES,
+            "failure_rate_threshold_default": str(DEFAULT_FAILURE_RATE_THRESHOLD),
+            "queue_latency_threshold_seconds_default": DEFAULT_QUEUE_LATENCY_THRESHOLD_SECONDS,
+            "backlog_age_threshold_seconds_default": DEFAULT_BACKLOG_AGE_THRESHOLD_SECONDS,
+            "replay_max_records_per_request": max(1, REPLAY_MAX_RECORDS_PER_REQUEST),
+            "replay_max_backlog_jobs": max(1, REPLAY_MAX_BACKLOG_JOBS),
+            "dlq_budget_events_per_window": max(1, DLQ_BUDGET_EVENTS_PER_WINDOW),
+            "operating_band_yellow_backlog_age_seconds": OPERATING_BAND_POLICY.yellow_backlog_age_seconds,
+            "operating_band_orange_backlog_age_seconds": OPERATING_BAND_POLICY.orange_backlog_age_seconds,
+            "operating_band_red_backlog_age_seconds": OPERATING_BAND_POLICY.red_backlog_age_seconds,
+            "operating_band_yellow_dlq_pressure_ratio": str(OPERATING_BAND_POLICY.yellow_dlq_pressure_ratio),
+            "operating_band_orange_dlq_pressure_ratio": str(OPERATING_BAND_POLICY.orange_dlq_pressure_ratio),
+            "operating_band_red_dlq_pressure_ratio": str(OPERATING_BAND_POLICY.red_dlq_pressure_ratio),
+        }
+        serialized = json.dumps(values, sort_keys=True, separators=(",", ":"))
+        fingerprint = hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]
         return IngestionOpsPolicyResponse(
+            policy_version="v1",
+            policy_fingerprint=fingerprint,
             lookback_minutes_default=DEFAULT_LOOKBACK_MINUTES,
             failure_rate_threshold_default=DEFAULT_FAILURE_RATE_THRESHOLD,
             queue_latency_threshold_seconds_default=DEFAULT_QUEUE_LATENCY_THRESHOLD_SECONDS,

--- a/tests/integration/services/ingestion_service/test_ingestion_routers.py
+++ b/tests/integration/services/ingestion_service/test_ingestion_routers.py
@@ -438,6 +438,8 @@ async def async_test_client(mock_kafka_producer: MagicMock):
 
         async def get_operating_policy(self):
             return {
+                "policy_version": "v1",
+                "policy_fingerprint": "e6a9f2cc3bb5e5a7",
                 "lookback_minutes_default": 60,
                 "failure_rate_threshold_default": Decimal("0.03"),
                 "queue_latency_threshold_seconds_default": 5.0,
@@ -1004,6 +1006,8 @@ async def test_ingestion_operating_policy_endpoint(async_test_client: httpx.Asyn
     response = await async_test_client.get("/ingestion/health/policy")
     assert response.status_code == 200
     body = response.json()
+    assert body["policy_version"] == "v1"
+    assert body["policy_fingerprint"]
     assert "lookback_minutes_default" in body
     assert "replay_max_records_per_request" in body
     assert "operating_band_red_backlog_age_seconds" in body

--- a/tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py
+++ b/tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py
@@ -243,6 +243,9 @@ async def test_get_operating_policy_returns_configured_thresholds(
     service: IngestionJobService,
 ):
     policy = await service.get_operating_policy()
+    assert policy.policy_version == "v1"
+    assert len(policy.policy_fingerprint) == 16
+    assert all(char in "0123456789abcdef" for char in policy.policy_fingerprint)
     assert policy.lookback_minutes_default >= 1
     assert policy.replay_max_records_per_request >= 1
     assert policy.replay_max_backlog_jobs >= 1


### PR DESCRIPTION
## Summary
- add `policy_version` and `policy_fingerprint` to `GET /ingestion/health/policy`
- compute deterministic fingerprint from canonical active policy values using stable JSON + SHA-256 truncation
- extend unit/integration tests and update RFC-065 implementation progress

## Validation
- `uv run python -m pytest tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py -q`
- `uv run python -m pytest tests/integration/services/ingestion_service/test_ingestion_routers.py -q`
- `make test-ops-contract`