### PR TITLE
RFC-065: add reprocessing queue health endpoint

### DIFF
--- a/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
+++ b/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
@@ -346,3 +346,7 @@ Acceptance:
 - `GET /ingestion/health/policy` now includes `policy_version` and `policy_fingerprint`
 - fingerprint is computed from canonical active policy values with stable JSON serialization and SHA-256 truncation
 - enables automation to detect runtime policy drift with a single contract read
+7. Added reprocessing-queue health endpoint for operations visibility:
+- added `GET /ingestion/health/reprocessing-queue` with per-job-type pending/processing/failed counts
+- endpoint includes oldest pending age signal for queue pressure triage and worker-scaling decisions
+- added unit and integration coverage to lock response contract and aggregation behavior

--- a/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
+++ b/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
@@ -313,6 +313,62 @@ class IngestionOpsPolicyResponse(BaseModel):
     )
 
 
+class IngestionReprocessingQueueItemResponse(BaseModel):
+    job_type: str = Field(
+        description="Canonical reprocessing job type.",
+        examples=["RESET_WATERMARKS"],
+    )
+    pending_jobs: int = Field(
+        ge=0,
+        description="Number of pending jobs for this job type.",
+        examples=[14],
+    )
+    processing_jobs: int = Field(
+        ge=0,
+        description="Number of currently processing jobs for this job type.",
+        examples=[2],
+    )
+    failed_jobs: int = Field(
+        ge=0,
+        description="Number of failed jobs for this job type.",
+        examples=[1],
+    )
+    oldest_pending_created_at: datetime | None = Field(
+        description="Timestamp of the oldest pending job for this type, if any.",
+        examples=["2026-03-03T04:10:11.000Z"],
+    )
+    oldest_pending_age_seconds: float = Field(
+        ge=0,
+        description="Age in seconds for the oldest pending job for this type.",
+        examples=[127.5],
+    )
+
+
+class IngestionReprocessingQueueHealthResponse(BaseModel):
+    as_of: datetime = Field(
+        description="UTC timestamp when queue health was computed.",
+        examples=["2026-03-03T04:12:20.000Z"],
+    )
+    total_pending_jobs: int = Field(
+        ge=0,
+        description="Total number of pending reprocessing jobs across all types.",
+        examples=[14],
+    )
+    total_processing_jobs: int = Field(
+        ge=0,
+        description="Total number of processing reprocessing jobs across all types.",
+        examples=[3],
+    )
+    total_failed_jobs: int = Field(
+        ge=0,
+        description="Total number of failed reprocessing jobs across all types.",
+        examples=[1],
+    )
+    queues: list[IngestionReprocessingQueueItemResponse] = Field(
+        description="Per-job-type queue health rows sorted by highest pending pressure."
+    )
+
+
 class IngestionBacklogBreakdownItemResponse(BaseModel):
     endpoint: str = Field(
         description="Ingestion endpoint associated with this backlog group.",

--- a/src/services/ingestion_service/app/routers/ingestion_jobs.py
+++ b/src/services/ingestion_service/app/routers/ingestion_jobs.py
@@ -23,6 +23,7 @@ from app.DTOs.ingestion_job_dto import (
     IngestionOpsModeUpdateRequest,
     IngestionOpsPolicyResponse,
     IngestionOperatingBandResponse,
+    IngestionReprocessingQueueHealthResponse,
     IngestionReplayAuditListResponse,
     IngestionReplayAuditResponse,
     IngestionRetryRequest,
@@ -639,6 +640,24 @@ async def get_ingestion_operating_policy(
     ingestion_job_service: IngestionJobService = Depends(get_ingestion_job_service),
 ):
     return await ingestion_job_service.get_operating_policy()
+
+
+@router.get(
+    "/ingestion/health/reprocessing-queue",
+    response_model=IngestionReprocessingQueueHealthResponse,
+    status_code=status.HTTP_200_OK,
+    tags=["Ingestion Operations"],
+    summary="Get reprocessing queue health by job type",
+    description=(
+        "What: Return pending/processing/failed reprocessing queue health grouped by job type.\n"
+        "How: Aggregate durable reprocessing job states and compute oldest pending age signal.\n"
+        "When: Use for operations triage and replay worker scaling decisions."
+    ),
+)
+async def get_reprocessing_queue_health(
+    ingestion_job_service: IngestionJobService = Depends(get_ingestion_job_service),
+):
+    return await ingestion_job_service.get_reprocessing_queue_health()
 
 
 @router.get(

--- a/src/services/ingestion_service/app/services/ingestion_job_service.py
+++ b/src/services/ingestion_service/app/services/ingestion_job_service.py
@@ -27,6 +27,8 @@ from app.DTOs.ingestion_job_dto import (
     IngestionOpsModeResponse,
     IngestionOpsPolicyResponse,
     IngestionOperatingBandResponse,
+    IngestionReprocessingQueueHealthResponse,
+    IngestionReprocessingQueueItemResponse,
     IngestionSloStatusResponse,
     IngestionStalledJobListResponse,
     IngestionStalledJobResponse,
@@ -36,6 +38,7 @@ from portfolio_common.database_models import ConsumerDlqReplayAudit as DBConsume
 from portfolio_common.database_models import IngestionJob as DBIngestionJob
 from portfolio_common.database_models import IngestionJobFailure as DBIngestionJobFailure
 from portfolio_common.database_models import IngestionOpsControl as DBIngestionOpsControl
+from portfolio_common.database_models import ReprocessingJob as DBReprocessingJob
 from portfolio_common.db import get_async_db_session
 from portfolio_common.monitoring import (
     INGESTION_BACKLOG_AGE_SECONDS,
@@ -709,6 +712,78 @@ class IngestionJobService:
             operating_band_yellow_dlq_pressure_ratio=OPERATING_BAND_POLICY.yellow_dlq_pressure_ratio,
             operating_band_orange_dlq_pressure_ratio=OPERATING_BAND_POLICY.orange_dlq_pressure_ratio,
             operating_band_red_dlq_pressure_ratio=OPERATING_BAND_POLICY.red_dlq_pressure_ratio,
+        )
+
+    async def get_reprocessing_queue_health(self) -> IngestionReprocessingQueueHealthResponse:
+        now = datetime.now(UTC)
+        async for db in get_async_db_session():
+            stmt = (
+                select(
+                    DBReprocessingJob.job_type.label("job_type"),
+                    func.sum(case((DBReprocessingJob.status == "PENDING", 1), else_=0)).label(
+                        "pending_jobs"
+                    ),
+                    func.sum(
+                        case((DBReprocessingJob.status == "PROCESSING", 1), else_=0)
+                    ).label("processing_jobs"),
+                    func.sum(case((DBReprocessingJob.status == "FAILED", 1), else_=0)).label(
+                        "failed_jobs"
+                    ),
+                    func.min(
+                        case(
+                            (DBReprocessingJob.status == "PENDING", DBReprocessingJob.created_at),
+                            else_=None,
+                        )
+                    ).label("oldest_pending_created_at"),
+                )
+                .group_by(DBReprocessingJob.job_type)
+            )
+            result = await db.execute(stmt)
+            rows = result.mappings().all()
+
+        queue_items: list[IngestionReprocessingQueueItemResponse] = []
+        total_pending = 0
+        total_processing = 0
+        total_failed = 0
+        for row in rows:
+            oldest_pending_created_at = row["oldest_pending_created_at"]
+            oldest_pending_age_seconds = (
+                max(0.0, (now - oldest_pending_created_at).total_seconds())
+                if oldest_pending_created_at
+                else 0.0
+            )
+            pending_jobs = int(row["pending_jobs"] or 0)
+            processing_jobs = int(row["processing_jobs"] or 0)
+            failed_jobs = int(row["failed_jobs"] or 0)
+            queue_items.append(
+                IngestionReprocessingQueueItemResponse(
+                    job_type=row["job_type"],
+                    pending_jobs=pending_jobs,
+                    processing_jobs=processing_jobs,
+                    failed_jobs=failed_jobs,
+                    oldest_pending_created_at=oldest_pending_created_at,
+                    oldest_pending_age_seconds=oldest_pending_age_seconds,
+                )
+            )
+            total_pending += pending_jobs
+            total_processing += processing_jobs
+            total_failed += failed_jobs
+
+        queue_items.sort(
+            key=lambda item: (
+                item.pending_jobs,
+                item.processing_jobs,
+                item.oldest_pending_age_seconds,
+                item.job_type,
+            ),
+            reverse=True,
+        )
+        return IngestionReprocessingQueueHealthResponse(
+            as_of=now,
+            total_pending_jobs=total_pending,
+            total_processing_jobs=total_processing,
+            total_failed_jobs=total_failed,
+            queues=queue_items,
         )
 
     async def get_backlog_breakdown(

--- a/tests/integration/services/ingestion_service/test_ingestion_routers.py
+++ b/tests/integration/services/ingestion_service/test_ingestion_routers.py
@@ -455,6 +455,25 @@ async def async_test_client(mock_kafka_producer: MagicMock):
                 "operating_band_red_dlq_pressure_ratio": Decimal("1.0"),
             }
 
+        async def get_reprocessing_queue_health(self):
+            now = datetime.now(UTC)
+            return {
+                "as_of": now,
+                "total_pending_jobs": 4,
+                "total_processing_jobs": 1,
+                "total_failed_jobs": 0,
+                "queues": [
+                    {
+                        "job_type": "RESET_WATERMARKS",
+                        "pending_jobs": 4,
+                        "processing_jobs": 1,
+                        "failed_jobs": 0,
+                        "oldest_pending_created_at": now,
+                        "oldest_pending_age_seconds": 12.5,
+                    }
+                ],
+            }
+
         async def find_successful_replay_audit_by_fingerprint(
             self,
             replay_fingerprint: str,
@@ -1011,6 +1030,16 @@ async def test_ingestion_operating_policy_endpoint(async_test_client: httpx.Asyn
     assert "lookback_minutes_default" in body
     assert "replay_max_records_per_request" in body
     assert "operating_band_red_backlog_age_seconds" in body
+
+
+async def test_ingestion_reprocessing_queue_health_endpoint(async_test_client: httpx.AsyncClient):
+    response = await async_test_client.get("/ingestion/health/reprocessing-queue")
+    assert response.status_code == 200
+    body = response.json()
+    assert "as_of" in body
+    assert body["total_pending_jobs"] >= 0
+    assert body["queues"][0]["job_type"] == "RESET_WATERMARKS"
+    assert "oldest_pending_age_seconds" in body["queues"][0]
 
 
 async def test_ingestion_idempotency_diagnostics_endpoint(async_test_client: httpx.AsyncClient):

--- a/tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py
+++ b/tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py
@@ -250,3 +250,57 @@ async def test_get_operating_policy_returns_configured_thresholds(
     assert policy.replay_max_records_per_request >= 1
     assert policy.replay_max_backlog_jobs >= 1
     assert policy.dlq_budget_events_per_window >= 1
+
+
+async def test_get_reprocessing_queue_health_aggregates_by_job_type(
+    service: IngestionJobService,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class _FakeBegin:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+    class _FakeResult:
+        def mappings(self):
+            return self
+
+        def all(self):
+            now = datetime.now(UTC)
+            return [
+                {
+                    "job_type": "RESET_WATERMARKS",
+                    "pending_jobs": 3,
+                    "processing_jobs": 1,
+                    "failed_jobs": 0,
+                    "oldest_pending_created_at": now - timedelta(seconds=30),
+                },
+                {
+                    "job_type": "REINDEX_SNAPSHOTS",
+                    "pending_jobs": 1,
+                    "processing_jobs": 0,
+                    "failed_jobs": 2,
+                    "oldest_pending_created_at": now - timedelta(seconds=10),
+                },
+            ]
+
+    class _FakeSession:
+        async def execute(self, _stmt):
+            return _FakeResult()
+
+        def begin(self):
+            return _FakeBegin()
+
+    async def _mock_get_async_db_session():
+        yield _FakeSession()
+
+    monkeypatch.setattr(service_module, "get_async_db_session", _mock_get_async_db_session)
+
+    response = await service.get_reprocessing_queue_health()
+    assert response.total_pending_jobs == 4
+    assert response.total_processing_jobs == 1
+    assert response.total_failed_jobs == 2
+    assert response.queues[0].job_type == "RESET_WATERMARKS"
+    assert response.queues[0].oldest_pending_age_seconds > 0


### PR DESCRIPTION
## Summary
- add `GET /ingestion/health/reprocessing-queue` for reprocessing queue operations visibility
- introduce documented DTO contracts for queue totals and per-job-type backlog/age signals
- add service aggregation logic over durable `reprocessing_jobs` state
- add unit/integration coverage and update RFC-065 progress log

## Validation
- `uv run python -m pytest tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py -q`
- `uv run python -m pytest tests/integration/services/ingestion_service/test_ingestion_routers.py -q`