### PR TITLE
RFC-065: expose reprocessing worker tuning in ops policy

### DIFF
--- a/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
+++ b/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
@@ -350,3 +350,7 @@ Acceptance:
 - added `GET /ingestion/health/reprocessing-queue` with per-job-type pending/processing/failed counts
 - endpoint includes oldest pending age signal for queue pressure triage and worker-scaling decisions
 - added unit and integration coverage to lock response contract and aggregation behavior
+8. Aligned reprocessing worker tuning with policy introspection:
+- `ReprocessingWorker` poll interval and batch size are now env-driven (`REPROCESSING_WORKER_POLL_INTERVAL_SECONDS`, `REPROCESSING_WORKER_BATCH_SIZE`)
+- `GET /ingestion/health/policy` now exposes both worker tuning values so automation and runbooks can detect drift
+- added focused unit coverage for env override behavior and policy contract fields

--- a/src/services/calculators/position_valuation_calculator/app/core/reprocessing_worker.py
+++ b/src/services/calculators/position_valuation_calculator/app/core/reprocessing_worker.py
@@ -1,6 +1,7 @@
 # src/services/calculators/position_valuation_calculator/app/core/reprocessing_worker.py
 import logging
 import asyncio
+import os
 from datetime import date, timedelta, datetime
 
 from portfolio_common.db import get_async_db_session
@@ -10,13 +11,26 @@ from portfolio_common.reprocessing_job_repository import ReprocessingJobReposito
 
 logger = logging.getLogger(__name__)
 
+
+def _env_positive_int(name: str, default: int) -> int:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return max(1, int(default))
+    try:
+        return max(1, int(raw_value))
+    except Exception:
+        return max(1, int(default))
+
+
 class ReprocessingWorker:
     """
     A background worker that polls for and processes durable reprocessing jobs.
     """
     def __init__(self, poll_interval: int = 10, batch_size: int = 10):
-        self._poll_interval = poll_interval
-        self._batch_size = batch_size
+        self._poll_interval = _env_positive_int(
+            "REPROCESSING_WORKER_POLL_INTERVAL_SECONDS", poll_interval
+        )
+        self._batch_size = _env_positive_int("REPROCESSING_WORKER_BATCH_SIZE", batch_size)
         self._running = True
 
     def stop(self):

--- a/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
+++ b/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
@@ -276,6 +276,16 @@ class IngestionOpsPolicyResponse(BaseModel):
         description="Replay guardrail: backlog ceiling beyond which replay is blocked.",
         examples=[5000],
     )
+    reprocessing_worker_poll_interval_seconds: int = Field(
+        ge=1,
+        description="Configured poll interval (seconds) for the valuation reprocessing worker.",
+        examples=[10],
+    )
+    reprocessing_worker_batch_size: int = Field(
+        ge=1,
+        description="Configured batch size used by the valuation reprocessing worker claim loop.",
+        examples=[10],
+    )
     dlq_budget_events_per_window: int = Field(
         ge=1,
         description="DLQ budget used to compute DLQ pressure ratios for the active window.",

--- a/src/services/ingestion_service/app/services/ingestion_job_service.py
+++ b/src/services/ingestion_service/app/services/ingestion_job_service.py
@@ -81,6 +81,10 @@ DEFAULT_QUEUE_LATENCY_THRESHOLD_SECONDS = float(
 DEFAULT_BACKLOG_AGE_THRESHOLD_SECONDS = float(
     os.getenv("LOTUS_CORE_DEFAULT_BACKLOG_AGE_THRESHOLD_SECONDS", "300.0")
 )
+REPROCESSING_WORKER_POLL_INTERVAL_SECONDS = int(
+    os.getenv("REPROCESSING_WORKER_POLL_INTERVAL_SECONDS", "10")
+)
+REPROCESSING_WORKER_BATCH_SIZE = int(os.getenv("REPROCESSING_WORKER_BATCH_SIZE", "10"))
 
 
 @dataclass(frozen=True, slots=True)
@@ -686,6 +690,10 @@ class IngestionJobService:
             "backlog_age_threshold_seconds_default": DEFAULT_BACKLOG_AGE_THRESHOLD_SECONDS,
             "replay_max_records_per_request": max(1, REPLAY_MAX_RECORDS_PER_REQUEST),
             "replay_max_backlog_jobs": max(1, REPLAY_MAX_BACKLOG_JOBS),
+            "reprocessing_worker_poll_interval_seconds": max(
+                1, REPROCESSING_WORKER_POLL_INTERVAL_SECONDS
+            ),
+            "reprocessing_worker_batch_size": max(1, REPROCESSING_WORKER_BATCH_SIZE),
             "dlq_budget_events_per_window": max(1, DLQ_BUDGET_EVENTS_PER_WINDOW),
             "operating_band_yellow_backlog_age_seconds": OPERATING_BAND_POLICY.yellow_backlog_age_seconds,
             "operating_band_orange_backlog_age_seconds": OPERATING_BAND_POLICY.orange_backlog_age_seconds,
@@ -705,6 +713,10 @@ class IngestionJobService:
             backlog_age_threshold_seconds_default=DEFAULT_BACKLOG_AGE_THRESHOLD_SECONDS,
             replay_max_records_per_request=max(1, REPLAY_MAX_RECORDS_PER_REQUEST),
             replay_max_backlog_jobs=max(1, REPLAY_MAX_BACKLOG_JOBS),
+            reprocessing_worker_poll_interval_seconds=max(
+                1, REPROCESSING_WORKER_POLL_INTERVAL_SECONDS
+            ),
+            reprocessing_worker_batch_size=max(1, REPROCESSING_WORKER_BATCH_SIZE),
             dlq_budget_events_per_window=max(1, DLQ_BUDGET_EVENTS_PER_WINDOW),
             operating_band_yellow_backlog_age_seconds=OPERATING_BAND_POLICY.yellow_backlog_age_seconds,
             operating_band_orange_backlog_age_seconds=OPERATING_BAND_POLICY.orange_backlog_age_seconds,

--- a/tests/integration/services/ingestion_service/test_ingestion_routers.py
+++ b/tests/integration/services/ingestion_service/test_ingestion_routers.py
@@ -446,6 +446,8 @@ async def async_test_client(mock_kafka_producer: MagicMock):
                 "backlog_age_threshold_seconds_default": 300.0,
                 "replay_max_records_per_request": 5000,
                 "replay_max_backlog_jobs": 5000,
+                "reprocessing_worker_poll_interval_seconds": 10,
+                "reprocessing_worker_batch_size": 10,
                 "dlq_budget_events_per_window": 10,
                 "operating_band_yellow_backlog_age_seconds": 15.0,
                 "operating_band_orange_backlog_age_seconds": 60.0,
@@ -1029,6 +1031,7 @@ async def test_ingestion_operating_policy_endpoint(async_test_client: httpx.Asyn
     assert body["policy_fingerprint"]
     assert "lookback_minutes_default" in body
     assert "replay_max_records_per_request" in body
+    assert "reprocessing_worker_batch_size" in body
     assert "operating_band_red_backlog_age_seconds" in body
 
 

--- a/tests/unit/services/calculators/position_valuation_calculator/core/test_reprocessing_worker.py
+++ b/tests/unit/services/calculators/position_valuation_calculator/core/test_reprocessing_worker.py
@@ -78,3 +78,13 @@ async def test_worker_processes_reset_watermarks_job(mock_dependencies):
     
     # 3. Marked the job as complete
     mock_repro_job_repo.update_job_status.assert_awaited_once_with(1, "COMPLETE")
+
+
+async def test_worker_reads_poll_and_batch_from_environment(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("REPROCESSING_WORKER_POLL_INTERVAL_SECONDS", "7")
+    monkeypatch.setenv("REPROCESSING_WORKER_BATCH_SIZE", "21")
+
+    worker = ReprocessingWorker()
+
+    assert worker._poll_interval == 7
+    assert worker._batch_size == 21

--- a/tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py
+++ b/tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py
@@ -249,6 +249,8 @@ async def test_get_operating_policy_returns_configured_thresholds(
     assert policy.lookback_minutes_default >= 1
     assert policy.replay_max_records_per_request >= 1
     assert policy.replay_max_backlog_jobs >= 1
+    assert policy.reprocessing_worker_poll_interval_seconds >= 1
+    assert policy.reprocessing_worker_batch_size >= 1
     assert policy.dlq_budget_events_per_window >= 1
 
 


### PR DESCRIPTION
## Summary
- make `ReprocessingWorker` poll interval and batch size env-driven (`REPROCESSING_WORKER_POLL_INTERVAL_SECONDS`, `REPROCESSING_WORKER_BATCH_SIZE`)
- expose these values in `GET /ingestion/health/policy` contract
- include new values in policy fingerprint computation for drift detection
- update unit/integration tests and RFC-065 progress

## Validation
- `uv run python -m pytest tests/unit/services/calculators/position_valuation_calculator/core/test_reprocessing_worker.py -q`
- `uv run python -m pytest tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py -q`
- `uv run python -m pytest tests/integration/services/ingestion_service/test_ingestion_routers.py -q`