### PR TITLE
RFC-065: expose valuation scheduler tuning in ops policy

### DIFF
--- a/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
+++ b/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
@@ -354,3 +354,7 @@ Acceptance:
 - `ReprocessingWorker` poll interval and batch size are now env-driven (`REPROCESSING_WORKER_POLL_INTERVAL_SECONDS`, `REPROCESSING_WORKER_BATCH_SIZE`)
 - `GET /ingestion/health/policy` now exposes both worker tuning values so automation and runbooks can detect drift
 - added focused unit coverage for env override behavior and policy contract fields
+9. Extended policy introspection with valuation scheduler runtime tuning:
+- `GET /ingestion/health/policy` now exposes `VALUATION_SCHEDULER_POLL_INTERVAL`, `VALUATION_SCHEDULER_BATCH_SIZE`, and `VALUATION_SCHEDULER_DISPATCH_ROUNDS`
+- policy fingerprint now includes scheduler tuning values for deterministic drift detection
+- added unit and integration coverage for the new scheduler policy fields

--- a/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
+++ b/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
@@ -286,6 +286,21 @@ class IngestionOpsPolicyResponse(BaseModel):
         description="Configured batch size used by the valuation reprocessing worker claim loop.",
         examples=[10],
     )
+    valuation_scheduler_poll_interval_seconds: int = Field(
+        ge=1,
+        description="Configured poll interval (seconds) for the valuation scheduler.",
+        examples=[30],
+    )
+    valuation_scheduler_batch_size: int = Field(
+        ge=1,
+        description="Configured batch size for valuation scheduler scans and claims.",
+        examples=[100],
+    )
+    valuation_scheduler_dispatch_rounds: int = Field(
+        ge=1,
+        description="Configured number of dispatch claim rounds executed per scheduler poll.",
+        examples=[3],
+    )
     dlq_budget_events_per_window: int = Field(
         ge=1,
         description="DLQ budget used to compute DLQ pressure ratios for the active window.",

--- a/src/services/ingestion_service/app/services/ingestion_job_service.py
+++ b/src/services/ingestion_service/app/services/ingestion_job_service.py
@@ -85,6 +85,13 @@ REPROCESSING_WORKER_POLL_INTERVAL_SECONDS = int(
     os.getenv("REPROCESSING_WORKER_POLL_INTERVAL_SECONDS", "10")
 )
 REPROCESSING_WORKER_BATCH_SIZE = int(os.getenv("REPROCESSING_WORKER_BATCH_SIZE", "10"))
+VALUATION_SCHEDULER_POLL_INTERVAL_SECONDS = int(
+    os.getenv("VALUATION_SCHEDULER_POLL_INTERVAL", "30")
+)
+VALUATION_SCHEDULER_BATCH_SIZE = int(os.getenv("VALUATION_SCHEDULER_BATCH_SIZE", "100"))
+VALUATION_SCHEDULER_DISPATCH_ROUNDS = int(
+    os.getenv("VALUATION_SCHEDULER_DISPATCH_ROUNDS", "3")
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -694,6 +701,11 @@ class IngestionJobService:
                 1, REPROCESSING_WORKER_POLL_INTERVAL_SECONDS
             ),
             "reprocessing_worker_batch_size": max(1, REPROCESSING_WORKER_BATCH_SIZE),
+            "valuation_scheduler_poll_interval_seconds": max(
+                1, VALUATION_SCHEDULER_POLL_INTERVAL_SECONDS
+            ),
+            "valuation_scheduler_batch_size": max(1, VALUATION_SCHEDULER_BATCH_SIZE),
+            "valuation_scheduler_dispatch_rounds": max(1, VALUATION_SCHEDULER_DISPATCH_ROUNDS),
             "dlq_budget_events_per_window": max(1, DLQ_BUDGET_EVENTS_PER_WINDOW),
             "operating_band_yellow_backlog_age_seconds": OPERATING_BAND_POLICY.yellow_backlog_age_seconds,
             "operating_band_orange_backlog_age_seconds": OPERATING_BAND_POLICY.orange_backlog_age_seconds,
@@ -717,6 +729,11 @@ class IngestionJobService:
                 1, REPROCESSING_WORKER_POLL_INTERVAL_SECONDS
             ),
             reprocessing_worker_batch_size=max(1, REPROCESSING_WORKER_BATCH_SIZE),
+            valuation_scheduler_poll_interval_seconds=max(
+                1, VALUATION_SCHEDULER_POLL_INTERVAL_SECONDS
+            ),
+            valuation_scheduler_batch_size=max(1, VALUATION_SCHEDULER_BATCH_SIZE),
+            valuation_scheduler_dispatch_rounds=max(1, VALUATION_SCHEDULER_DISPATCH_ROUNDS),
             dlq_budget_events_per_window=max(1, DLQ_BUDGET_EVENTS_PER_WINDOW),
             operating_band_yellow_backlog_age_seconds=OPERATING_BAND_POLICY.yellow_backlog_age_seconds,
             operating_band_orange_backlog_age_seconds=OPERATING_BAND_POLICY.orange_backlog_age_seconds,

--- a/tests/integration/services/ingestion_service/test_ingestion_routers.py
+++ b/tests/integration/services/ingestion_service/test_ingestion_routers.py
@@ -448,6 +448,9 @@ async def async_test_client(mock_kafka_producer: MagicMock):
                 "replay_max_backlog_jobs": 5000,
                 "reprocessing_worker_poll_interval_seconds": 10,
                 "reprocessing_worker_batch_size": 10,
+                "valuation_scheduler_poll_interval_seconds": 30,
+                "valuation_scheduler_batch_size": 100,
+                "valuation_scheduler_dispatch_rounds": 3,
                 "dlq_budget_events_per_window": 10,
                 "operating_band_yellow_backlog_age_seconds": 15.0,
                 "operating_band_orange_backlog_age_seconds": 60.0,
@@ -1032,6 +1035,7 @@ async def test_ingestion_operating_policy_endpoint(async_test_client: httpx.Asyn
     assert "lookback_minutes_default" in body
     assert "replay_max_records_per_request" in body
     assert "reprocessing_worker_batch_size" in body
+    assert "valuation_scheduler_dispatch_rounds" in body
     assert "operating_band_red_backlog_age_seconds" in body
 
 

--- a/tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py
+++ b/tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py
@@ -251,6 +251,9 @@ async def test_get_operating_policy_returns_configured_thresholds(
     assert policy.replay_max_backlog_jobs >= 1
     assert policy.reprocessing_worker_poll_interval_seconds >= 1
     assert policy.reprocessing_worker_batch_size >= 1
+    assert policy.valuation_scheduler_poll_interval_seconds >= 1
+    assert policy.valuation_scheduler_batch_size >= 1
+    assert policy.valuation_scheduler_dispatch_rounds >= 1
     assert policy.dlq_budget_events_per_window >= 1
 
 


### PR DESCRIPTION
## Summary
- extend `GET /ingestion/health/policy` with valuation scheduler runtime tuning fields
- include scheduler tuning in policy fingerprint for deterministic drift detection
- update integration/unit tests and RFC-065 progress notes

## Validation
- `uv run python -m pytest tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py -q`
- `uv run python -m pytest tests/integration/services/ingestion_service/test_ingestion_routers.py -q`