### PR TITLE
RFC-065: add reprocessing worker observability metrics

### DIFF
--- a/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
+++ b/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
@@ -321,6 +321,10 @@ Acceptance:
 - claim flow now increments `attempt_count` and sets timestamps atomically at claim time
 - added composite claim-order index on `reprocessing_jobs(job_type, status, created_at, id)` for hot-path queue scans under load
 - added focused unit tests validating SKIP LOCKED SQL shape and row-to-model mapping
+13. Added dedicated reprocessing-worker observability signals:
+- worker now emits canonical counters for claimed/completed/failed reprocessing jobs
+- worker now records batch processing duration histogram for claim/process loop latency tracking
+- added focused unit coverage to assert success/failure metric emission paths and timer invocation behavior
 
 ### Phase 5 progress (2026-03-03)
 1. Added dedicated RFC-065 operational playbook:

--- a/src/libs/portfolio-common/portfolio_common/monitoring.py
+++ b/src/libs/portfolio-common/portfolio_common/monitoring.py
@@ -173,6 +173,30 @@ REPROCESSING_EPOCH_BUMPED_TOTAL = Counter(
     labelnames=("portfolio_id", "security_id"),
 )
 
+REPROCESSING_WORKER_JOBS_CLAIMED_TOTAL = Counter(
+    "reprocessing_worker_jobs_claimed_total",
+    "Total number of reprocessing jobs claimed by the worker.",
+    ["job_type"],
+)
+
+REPROCESSING_WORKER_JOBS_COMPLETED_TOTAL = Counter(
+    "reprocessing_worker_jobs_completed_total",
+    "Total number of reprocessing jobs completed by the worker.",
+    ["job_type"],
+)
+
+REPROCESSING_WORKER_JOBS_FAILED_TOTAL = Counter(
+    "reprocessing_worker_jobs_failed_total",
+    "Total number of reprocessing jobs that failed in worker processing.",
+    ["job_type"],
+)
+
+REPROCESSING_WORKER_BATCH_SECONDS = Histogram(
+    "reprocessing_worker_batch_seconds",
+    "Time taken to claim and process one reprocessing worker batch.",
+    buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30),
+)
+
 POSITION_STATE_WATERMARK_LAG_DAYS = Gauge(
     "position_state_watermark_lag_days",
     "The current lag in days between the latest business date and a key's watermark.",
@@ -287,6 +311,23 @@ ANALYTICS_EXPORT_PAGE_DEPTH = Histogram(
     labelnames=("dataset_type",),
     buckets=(1, 2, 5, 10, 20, 50, 100, 200),
 )
+
+
+def observe_reprocessing_worker_jobs_claimed(job_type: str, count: int = 1) -> None:
+    REPROCESSING_WORKER_JOBS_CLAIMED_TOTAL.labels(job_type).inc(count)
+
+
+def observe_reprocessing_worker_jobs_completed(job_type: str, count: int = 1) -> None:
+    REPROCESSING_WORKER_JOBS_COMPLETED_TOTAL.labels(job_type).inc(count)
+
+
+def observe_reprocessing_worker_jobs_failed(job_type: str, count: int = 1) -> None:
+    REPROCESSING_WORKER_JOBS_FAILED_TOTAL.labels(job_type).inc(count)
+
+
+def reprocessing_worker_batch_timer():
+    """Context manager that observes one reprocessing worker batch duration."""
+    return REPROCESSING_WORKER_BATCH_SECONDS.time()
 
 # --------------------------------------------------------------------------------------
 # Optional generic HTTP metrics (use across services if helpful)

--- a/src/services/calculators/position_valuation_calculator/app/core/reprocessing_worker.py
+++ b/src/services/calculators/position_valuation_calculator/app/core/reprocessing_worker.py
@@ -2,12 +2,18 @@
 import logging
 import asyncio
 import os
-from datetime import date, timedelta, datetime
+from datetime import date, timedelta
 
 from portfolio_common.db import get_async_db_session
 from ..repositories.valuation_repository import ValuationRepository
 from portfolio_common.position_state_repository import PositionStateRepository
 from portfolio_common.reprocessing_job_repository import ReprocessingJobRepository
+from portfolio_common.monitoring import (
+    observe_reprocessing_worker_jobs_claimed,
+    observe_reprocessing_worker_jobs_completed,
+    observe_reprocessing_worker_jobs_failed,
+    reprocessing_worker_batch_timer,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -39,37 +45,50 @@ class ReprocessingWorker:
 
     async def _process_batch(self):
         """Processes one batch of pending RESET_WATERMARKS jobs."""
-        async for db in get_async_db_session():
-            async with db.begin():
-                job_repo = ReprocessingJobRepository(db)
-                state_repo = PositionStateRepository(db)
-                valuation_repo = ValuationRepository(db)
+        with reprocessing_worker_batch_timer():
+            async for db in get_async_db_session():
+                async with db.begin():
+                    job_repo = ReprocessingJobRepository(db)
+                    state_repo = PositionStateRepository(db)
+                    valuation_repo = ValuationRepository(db)
 
-                claimed_jobs = await job_repo.find_and_claim_jobs('RESET_WATERMARKS', self._batch_size)
-                
-                for job in claimed_jobs:
-                    try:
-                        security_id = job.payload['security_id']
-                        earliest_date = date.fromisoformat(job.payload['earliest_impacted_date'])
-                        new_watermark = earliest_date - timedelta(days=1)
-                        
-                        affected_portfolios = await valuation_repo.find_portfolios_for_security(security_id)
-                        
-                        if affected_portfolios:
-                            keys_to_update = [(p_id, security_id) for p_id in affected_portfolios]
-                            updated_count = await state_repo.update_watermarks_if_older(
-                                keys=keys_to_update,
-                                new_watermark_date=new_watermark
-                            )
-                            logger.info(f"Job {job.id}: Fanned out watermark reset to {updated_count} portfolios for security {security_id}.")
-                        else:
-                            logger.info(f"Job {job.id}: No portfolios found for security {security_id}, skipping watermark reset.")
-                        
-                        await job_repo.update_job_status(job.id, 'COMPLETE')
+                    claimed_jobs = await job_repo.find_and_claim_jobs(
+                        "RESET_WATERMARKS", self._batch_size
+                    )
+                    if claimed_jobs:
+                        observe_reprocessing_worker_jobs_claimed(
+                            "RESET_WATERMARKS", len(claimed_jobs)
+                        )
 
-                    except Exception as e:
-                        logger.error(f"Failed to process reprocessing job {job.id}", exc_info=True)
-                        await job_repo.update_job_status(job.id, 'FAILED', failure_reason=str(e))
+                    for job in claimed_jobs:
+                        try:
+                            security_id = job.payload["security_id"]
+                            earliest_date = date.fromisoformat(job.payload["earliest_impacted_date"])
+                            new_watermark = earliest_date - timedelta(days=1)
+
+                            affected_portfolios = await valuation_repo.find_portfolios_for_security(security_id)
+
+                            if affected_portfolios:
+                                keys_to_update = [(p_id, security_id) for p_id in affected_portfolios]
+                                updated_count = await state_repo.update_watermarks_if_older(
+                                    keys=keys_to_update,
+                                    new_watermark_date=new_watermark,
+                                )
+                                logger.info(
+                                    f"Job {job.id}: Fanned out watermark reset to {updated_count} portfolios for security {security_id}."
+                                )
+                            else:
+                                logger.info(
+                                    f"Job {job.id}: No portfolios found for security {security_id}, skipping watermark reset."
+                                )
+
+                            await job_repo.update_job_status(job.id, "COMPLETE")
+                            observe_reprocessing_worker_jobs_completed("RESET_WATERMARKS")
+
+                        except Exception as e:
+                            logger.error(f"Failed to process reprocessing job {job.id}", exc_info=True)
+                            await job_repo.update_job_status(job.id, "FAILED", failure_reason=str(e))
+                            observe_reprocessing_worker_jobs_failed("RESET_WATERMARKS")
 
     async def run(self):
         logger.info(f"ReprocessingWorker started. Polling every {self._poll_interval} seconds.")

--- a/tests/unit/services/calculators/position_valuation_calculator/core/test_reprocessing_worker.py
+++ b/tests/unit/services/calculators/position_valuation_calculator/core/test_reprocessing_worker.py
@@ -1,83 +1,139 @@
 # tests/unit/services/calculators/position_valuation_calculator/core/test_reprocessing_worker.py
-import pytest
+from datetime import date
 from unittest.mock import AsyncMock, patch
-from datetime import date, timedelta
 
-from sqlalchemy.ext.asyncio import AsyncSession
+import pytest
 from portfolio_common.database_models import ReprocessingJob
-from src.services.calculators.position_valuation_calculator.app.core.reprocessing_worker import ReprocessingWorker
-from src.services.calculators.position_valuation_calculator.app.repositories.valuation_repository import ValuationRepository
 from portfolio_common.position_state_repository import PositionStateRepository
 from portfolio_common.reprocessing_job_repository import ReprocessingJobRepository
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.services.calculators.position_valuation_calculator.app.core.reprocessing_worker import (
+    ReprocessingWorker,
+)
+from src.services.calculators.position_valuation_calculator.app.repositories.valuation_repository import (
+    ValuationRepository,
+)
 
 pytestmark = pytest.mark.asyncio
 
+
 @pytest.fixture
 def mock_dependencies():
-    """Mocks all repository dependencies for the ReprocessingWorker."""
+    """Mocks all repository and monitoring dependencies for the ReprocessingWorker."""
     mock_valuation_repo = AsyncMock(spec=ValuationRepository)
     mock_state_repo = AsyncMock(spec=PositionStateRepository)
     mock_repro_job_repo = AsyncMock(spec=ReprocessingJobRepository)
-    
+
     mock_db_session = AsyncMock(spec=AsyncSession)
     mock_transaction = AsyncMock()
     mock_db_session.begin.return_value = mock_transaction
-    
+
     async def get_session_gen():
         yield mock_db_session
 
     with patch(
-        "src.services.calculators.position_valuation_calculator.app.core.reprocessing_worker.get_async_db_session", new=get_session_gen
+        "src.services.calculators.position_valuation_calculator.app.core.reprocessing_worker.get_async_db_session",
+        new=get_session_gen,
     ), patch(
-        "src.services.calculators.position_valuation_calculator.app.core.reprocessing_worker.ValuationRepository", return_value=mock_valuation_repo
+        "src.services.calculators.position_valuation_calculator.app.core.reprocessing_worker.ValuationRepository",
+        return_value=mock_valuation_repo,
     ), patch(
-        "src.services.calculators.position_valuation_calculator.app.core.reprocessing_worker.PositionStateRepository", return_value=mock_state_repo
+        "src.services.calculators.position_valuation_calculator.app.core.reprocessing_worker.PositionStateRepository",
+        return_value=mock_state_repo,
     ), patch(
-        "src.services.calculators.position_valuation_calculator.app.core.reprocessing_worker.ReprocessingJobRepository", return_value=mock_repro_job_repo
-    ):
+        "src.services.calculators.position_valuation_calculator.app.core.reprocessing_worker.ReprocessingJobRepository",
+        return_value=mock_repro_job_repo,
+    ), patch(
+        "src.services.calculators.position_valuation_calculator.app.core.reprocessing_worker.observe_reprocessing_worker_jobs_claimed"
+    ) as mock_observe_claimed, patch(
+        "src.services.calculators.position_valuation_calculator.app.core.reprocessing_worker.observe_reprocessing_worker_jobs_completed"
+    ) as mock_observe_completed, patch(
+        "src.services.calculators.position_valuation_calculator.app.core.reprocessing_worker.observe_reprocessing_worker_jobs_failed"
+    ) as mock_observe_failed, patch(
+        "src.services.calculators.position_valuation_calculator.app.core.reprocessing_worker.reprocessing_worker_batch_timer"
+    ) as mock_batch_timer:
+        mock_batch_timer.return_value.__enter__.return_value = None
+        mock_batch_timer.return_value.__exit__.return_value = None
         yield {
             "valuation_repo": mock_valuation_repo,
             "state_repo": mock_state_repo,
-            "repro_job_repo": mock_repro_job_repo
+            "repro_job_repo": mock_repro_job_repo,
+            "observe_claimed": mock_observe_claimed,
+            "observe_completed": mock_observe_completed,
+            "observe_failed": mock_observe_failed,
+            "batch_timer": mock_batch_timer,
         }
+
 
 async def test_worker_processes_reset_watermarks_job(mock_dependencies):
     """
     GIVEN a pending RESET_WATERMARKS job
     WHEN the worker processes a batch
-    THEN it should fan-out the watermark updates and mark the job as complete.
+    THEN it should fan-out the watermark updates, emit success metrics, and mark the job complete.
     """
-    # ARRANGE
-    worker = ReprocessingWorker(poll_interval=0.1) # Short poll for test
+    worker = ReprocessingWorker(poll_interval=0.1)
     mock_repro_job_repo = mock_dependencies["repro_job_repo"]
     mock_valuation_repo = mock_dependencies["valuation_repo"]
     mock_state_repo = mock_dependencies["state_repo"]
+    mock_observe_claimed = mock_dependencies["observe_claimed"]
+    mock_observe_completed = mock_dependencies["observe_completed"]
+    mock_observe_failed = mock_dependencies["observe_failed"]
+    mock_batch_timer = mock_dependencies["batch_timer"]
 
     job_payload = {"security_id": "S1", "earliest_impacted_date": "2025-08-10"}
     pending_job = ReprocessingJob(
         id=1, job_type="RESET_WATERMARKS", payload=job_payload, status="PENDING"
     )
-    
+
     mock_repro_job_repo.find_and_claim_jobs.return_value = [pending_job]
     mock_valuation_repo.find_portfolios_for_security.return_value = ["P1", "P2"]
     mock_state_repo.update_watermarks_if_older.return_value = 2
 
-    # ACT
-    await worker._process_batch() # Call the internal method for one deterministic cycle
+    await worker._process_batch()
 
-    # ASSERT
-    # 1. Claimed the job
-    mock_repro_job_repo.find_and_claim_jobs.assert_awaited_once_with('RESET_WATERMARKS', 10)
+    mock_batch_timer.assert_called_once()
+    mock_observe_claimed.assert_called_once_with("RESET_WATERMARKS", 1)
+    mock_observe_completed.assert_called_once_with("RESET_WATERMARKS")
+    mock_observe_failed.assert_not_called()
 
-    # 2. Fanned out the work
+    mock_repro_job_repo.find_and_claim_jobs.assert_awaited_once_with("RESET_WATERMARKS", 10)
     mock_valuation_repo.find_portfolios_for_security.assert_awaited_once_with("S1")
     mock_state_repo.update_watermarks_if_older.assert_awaited_once_with(
         keys=[("P1", "S1"), ("P2", "S1")],
-        new_watermark_date=date(2025, 8, 9) # date - 1 day
+        new_watermark_date=date(2025, 8, 9),
     )
-    
-    # 3. Marked the job as complete
     mock_repro_job_repo.update_job_status.assert_awaited_once_with(1, "COMPLETE")
+
+
+async def test_worker_marks_failed_and_emits_failure_metric(mock_dependencies):
+    worker = ReprocessingWorker(poll_interval=0.1)
+    mock_repro_job_repo = mock_dependencies["repro_job_repo"]
+    mock_valuation_repo = mock_dependencies["valuation_repo"]
+    mock_state_repo = mock_dependencies["state_repo"]
+    mock_observe_claimed = mock_dependencies["observe_claimed"]
+    mock_observe_completed = mock_dependencies["observe_completed"]
+    mock_observe_failed = mock_dependencies["observe_failed"]
+
+    job_payload = {"security_id": "S1", "earliest_impacted_date": "2025-08-10"}
+    pending_job = ReprocessingJob(
+        id=2, job_type="RESET_WATERMARKS", payload=job_payload, status="PENDING"
+    )
+
+    mock_repro_job_repo.find_and_claim_jobs.return_value = [pending_job]
+    mock_valuation_repo.find_portfolios_for_security.return_value = ["P1"]
+    mock_state_repo.update_watermarks_if_older.side_effect = RuntimeError("db write failed")
+
+    await worker._process_batch()
+
+    mock_observe_claimed.assert_called_once_with("RESET_WATERMARKS", 1)
+    mock_observe_completed.assert_not_called()
+    mock_observe_failed.assert_called_once_with("RESET_WATERMARKS")
+
+    mock_repro_job_repo.update_job_status.assert_awaited_once()
+    args, kwargs = mock_repro_job_repo.update_job_status.await_args
+    assert args[:2] == (2, "FAILED")
+    assert "db write failed" in kwargs["failure_reason"]
 
 
 async def test_worker_reads_poll_and_batch_from_environment(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## Summary
- add dedicated reprocessing-worker metrics (claimed/completed/failed counters + batch duration histogram)
- instrument valuation reprocessing worker to emit metrics on success/failure paths
- extend unit tests to lock telemetry behavior
- update RFC-065 implementation progress log

## Validation
- uv run python -m pytest tests/unit/services/calculators/position_valuation_calculator/core/test_reprocessing_worker.py -q

## Notes
- local ruff binary is not installed in this environment (uff not found), so only targeted pytest was executed