### PR TITLE
RFC-065: harden backlog breakdown correctness and hotspot visibility

### DIFF
--- a/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
+++ b/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
@@ -331,6 +331,13 @@ Acceptance:
 - added valuation queue indexes for hot operational paths:
   - claim ordering (`status, portfolio_id, security_id, valuation_date, id`)
   - stale-processing scan (`status, updated_at`)
+15. Hardened ingestion backlog breakdown correctness and hotspot visibility:
+- fixed grouped backlog aggregation path to correctly iterate SQL result rows (removed result-shadowing bug)
+- added backlog concentration signals to health contract:
+  - `largest_group_backlog_jobs`
+  - `largest_group_backlog_share`
+  - `top_3_backlog_share`
+- added focused unit coverage to lock concentration math and zero-backlog behavior
 
 ### Phase 5 progress (2026-03-03)
 1. Added dedicated RFC-065 operational playbook:

--- a/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
+++ b/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
@@ -456,6 +456,23 @@ class IngestionBacklogBreakdownResponse(BaseModel):
         description="Total backlog jobs across all returned groups.",
         examples=[17],
     )
+    largest_group_backlog_jobs: int = Field(
+        ge=0,
+        description="Backlog jobs in the largest endpoint/entity backlog group.",
+        examples=[9],
+    )
+    largest_group_backlog_share: Decimal = Field(
+        ge=Decimal("0"),
+        le=Decimal("1"),
+        description="Largest-group backlog concentration share (largest_group_backlog_jobs / total_backlog_jobs).",
+        examples=["0.5294"],
+    )
+    top_3_backlog_share: Decimal = Field(
+        ge=Decimal("0"),
+        le=Decimal("1"),
+        description="Backlog concentration share of the top 3 groups by backlog_jobs.",
+        examples=["0.8824"],
+    )
     groups: list[IngestionBacklogBreakdownItemResponse] = Field(
         description="Backlog and failure-rate breakdown grouped by endpoint and entity_type."
     )

--- a/src/services/ingestion_service/app/services/ingestion_job_service.py
+++ b/src/services/ingestion_service/app/services/ingestion_job_service.py
@@ -865,7 +865,8 @@ class IngestionJobService:
                 .group_by(DBIngestionJob.endpoint, DBIngestionJob.entity_type)
             )
 
-            rows: list[IngestionBacklogBreakdownItemResponse] = []
+            grouped_rows = rows.all()
+            items: list[IngestionBacklogBreakdownItemResponse] = []
             for (
                 endpoint,
                 entity_type,
@@ -874,7 +875,7 @@ class IngestionJobService:
                 queued_jobs_raw,
                 failed_jobs_raw,
                 oldest_backlog_submitted_at,
-            ) in rows:
+            ) in grouped_rows:
                 accepted_jobs = int(accepted_jobs_raw or 0)
                 queued_jobs = int(queued_jobs_raw or 0)
                 failed_jobs = int(failed_jobs_raw or 0)
@@ -888,7 +889,7 @@ class IngestionJobService:
                 failure_rate = (
                     Decimal(failed_jobs) / Decimal(total_jobs) if total_jobs else Decimal("0")
                 )
-                rows.append(
+                items.append(
                     IngestionBacklogBreakdownItemResponse(
                         endpoint=endpoint,
                         entity_type=entity_type,
@@ -903,21 +904,38 @@ class IngestionJobService:
                     )
                 )
 
-            rows = sorted(
-                rows,
+            items = sorted(
+                items,
                 key=lambda item: (item.backlog_jobs, item.oldest_backlog_age_seconds),
                 reverse=True,
             )[:limit]
 
+            largest_group_backlog_jobs = int(items[0].backlog_jobs if items else 0)
+            if total_backlog_jobs > 0:
+                largest_group_backlog_share = (
+                    Decimal(largest_group_backlog_jobs) / Decimal(total_backlog_jobs)
+                )
+                top_3_backlog_jobs = int(sum(item.backlog_jobs for item in items[:3]))
+                top_3_backlog_share = Decimal(top_3_backlog_jobs) / Decimal(total_backlog_jobs)
+            else:
+                largest_group_backlog_share = Decimal("0")
+                top_3_backlog_share = Decimal("0")
+
             return IngestionBacklogBreakdownResponse(
                 lookback_minutes=lookback_minutes,
                 total_backlog_jobs=total_backlog_jobs,
-                groups=rows,
+                largest_group_backlog_jobs=largest_group_backlog_jobs,
+                largest_group_backlog_share=largest_group_backlog_share,
+                top_3_backlog_share=top_3_backlog_share,
+                groups=items,
             )
 
         return IngestionBacklogBreakdownResponse(
             lookback_minutes=lookback_minutes,
             total_backlog_jobs=0,
+            largest_group_backlog_jobs=0,
+            largest_group_backlog_share=Decimal("0"),
+            top_3_backlog_share=Decimal("0"),
             groups=[],
         )
 

--- a/tests/integration/services/ingestion_service/test_ingestion_routers.py
+++ b/tests/integration/services/ingestion_service/test_ingestion_routers.py
@@ -258,6 +258,9 @@ async def async_test_client(mock_kafka_producer: MagicMock):
             return {
                 "lookback_minutes": lookback_minutes,
                 "total_backlog_jobs": 1,
+                "largest_group_backlog_jobs": 1,
+                "largest_group_backlog_share": Decimal("1"),
+                "top_3_backlog_share": Decimal("1"),
                 "groups": [
                     {
                         "endpoint": "/ingest/transactions",
@@ -941,6 +944,8 @@ async def test_ingestion_backlog_breakdown(async_test_client: httpx.AsyncClient)
     body = response.json()
     assert "groups" in body
     assert "total_backlog_jobs" in body
+    assert "largest_group_backlog_share" in body
+    assert "top_3_backlog_share" in body
     assert body["groups"][0]["endpoint"] == "/ingest/transactions"
 
 

--- a/tests/unit/services/ingestion_service/services/test_ingestion_job_service_backlog_breakdown.py
+++ b/tests/unit/services/ingestion_service/services/test_ingestion_job_service_backlog_breakdown.py
@@ -1,0 +1,80 @@
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from src.services.ingestion_service.app.services import ingestion_job_service as service_module
+from src.services.ingestion_service.app.services.ingestion_job_service import IngestionJobService
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def service() -> IngestionJobService:
+    return IngestionJobService()
+
+
+async def test_get_backlog_breakdown_computes_groups_and_concentration(
+    service: IngestionJobService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime.now(UTC)
+
+    class _FakeResult:
+        def all(self):
+            return [
+                ("/ingest/transactions", "transaction", 100, 4, 2, 3, now - timedelta(minutes=10)),
+                ("/ingest/market-prices", "market_price", 70, 3, 1, 1, now - timedelta(minutes=5)),
+                ("/ingest/instruments", "instrument", 40, 1, 0, 2, now - timedelta(minutes=2)),
+            ]
+
+    class _FakeSession:
+        async def scalar(self, _stmt):
+            return 11
+
+        async def execute(self, _stmt):
+            return _FakeResult()
+
+    async def _mock_get_async_db_session():
+        yield _FakeSession()
+
+    monkeypatch.setattr(service_module, "get_async_db_session", _mock_get_async_db_session)
+
+    result = await service.get_backlog_breakdown(lookback_minutes=60, limit=10)
+
+    assert result.total_backlog_jobs == 11
+    assert result.largest_group_backlog_jobs == 6
+    assert result.largest_group_backlog_share == Decimal("0.5454545454545454545454545455")
+    assert result.top_3_backlog_share == Decimal("1")
+    assert len(result.groups) == 3
+    assert result.groups[0].endpoint == "/ingest/transactions"
+    assert result.groups[0].backlog_jobs == 6
+
+
+async def test_get_backlog_breakdown_zero_backlog_has_zero_concentration(
+    service: IngestionJobService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeResult:
+        def all(self):
+            return []
+
+    class _FakeSession:
+        async def scalar(self, _stmt):
+            return 0
+
+        async def execute(self, _stmt):
+            return _FakeResult()
+
+    async def _mock_get_async_db_session():
+        yield _FakeSession()
+
+    monkeypatch.setattr(service_module, "get_async_db_session", _mock_get_async_db_session)
+
+    result = await service.get_backlog_breakdown(lookback_minutes=60, limit=10)
+
+    assert result.total_backlog_jobs == 0
+    assert result.largest_group_backlog_jobs == 0
+    assert result.largest_group_backlog_share == Decimal("0")
+    assert result.top_3_backlog_share == Decimal("0")
+    assert result.groups == []


### PR DESCRIPTION
## Summary
- fix ingestion backlog-breakdown aggregation bug caused by result-variable shadowing
- add backlog concentration signals to the response contract:
  - largest_group_backlog_jobs
  - largest_group_backlog_share
  - top_3_backlog_share
- add focused unit tests for concentration math and zero-backlog behavior
- update integration router test contract for new required fields
- update RFC-065 progress log

## Validation
- uv run python -m pytest tests/unit/services/ingestion_service/services/test_ingestion_job_service_backlog_breakdown.py -q
- uv run python -m pytest tests/integration/services/ingestion_service/test_ingestion_routers.py -k "backlog_breakdown or health_backlog" -q
- make migration-smoke
