### PR TITLE
RFC-065: add ingestion capacity/saturation health endpoint

### DIFF
--- a/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
+++ b/docs/RFCs/RFC 065 - Event-Driven Calculator Scalability and Reliability Roadmap.md
@@ -375,3 +375,7 @@ Acceptance:
 - `GET /ingestion/health/policy` now exposes `VALUATION_SCHEDULER_POLL_INTERVAL`, `VALUATION_SCHEDULER_BATCH_SIZE`, and `VALUATION_SCHEDULER_DISPATCH_ROUNDS`
 - policy fingerprint now includes scheduler tuning values for deterministic drift detection
 - added unit and integration coverage for the new scheduler policy fields
+10. Added ingestion capacity and saturation diagnostics endpoint:
+- added `GET /ingestion/health/capacity` with per endpoint/entity throughput and saturation signals
+- endpoint derives RFC-065 canonical capacity variables (`lambda_in`, `mu_msg`, `rho`, `headroom`, `T_drain`) from ingestion control-plane data
+- added focused unit coverage for capacity math and integration coverage for endpoint contract shape

--- a/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
+++ b/src/services/ingestion_service/app/DTOs/ingestion_job_dto.py
@@ -394,6 +394,109 @@ class IngestionReprocessingQueueHealthResponse(BaseModel):
     )
 
 
+class IngestionCapacityGroupResponse(BaseModel):
+    endpoint: str = Field(
+        description="Ingestion endpoint associated with this capacity group.",
+        examples=["/ingest/transactions"],
+    )
+    entity_type: str = Field(
+        description="Canonical entity type associated with this capacity group.",
+        examples=["transaction"],
+    )
+    total_records: int = Field(
+        ge=0,
+        description="Total accepted records observed in the lookback window for this group.",
+        examples=[25000],
+    )
+    processed_records: int = Field(
+        ge=0,
+        description="Records in this group that progressed out of accepted state (queued or failed).",
+        examples=[24000],
+    )
+    backlog_records: int = Field(
+        ge=0,
+        description="Records still pending processing in accepted state.",
+        examples=[1000],
+    )
+    backlog_jobs: int = Field(
+        ge=0,
+        description="Pending job count in accepted state for this group.",
+        examples=[12],
+    )
+    lambda_in_events_per_second: Decimal = Field(
+        ge=Decimal("0"),
+        description="Inbound record rate (`lambda_in`) for this group over the lookback window.",
+        examples=["6.944444"],
+    )
+    mu_msg_per_replica_events_per_second: Decimal = Field(
+        ge=Decimal("0"),
+        description="Estimated per-replica processing rate (`mu_msg`) for this group.",
+        examples=["6.666667"],
+    )
+    assumed_replicas: int = Field(
+        ge=1,
+        description="Replica count assumed for effective-capacity and utilization calculations.",
+        examples=[2],
+    )
+    effective_capacity_events_per_second: Decimal = Field(
+        ge=Decimal("0"),
+        description="Estimated effective capacity (`N_replica * mu_msg`) for this group.",
+        examples=["13.333334"],
+    )
+    utilization_ratio: Decimal = Field(
+        ge=Decimal("0"),
+        description="Utilization ratio (`rho = lambda_in / capacity`). Values above 1 indicate overload.",
+        examples=["0.520833"],
+    )
+    headroom_ratio: Decimal = Field(
+        description="Capacity headroom ratio (`1 - rho`). Negative values indicate sustained overload.",
+        examples=["0.479167"],
+    )
+    estimated_drain_seconds: float | None = Field(
+        default=None,
+        ge=0.0,
+        description=(
+            "Estimated backlog drain time in seconds using `T_drain = backlog / (capacity - lambda_in)` "
+            "when net drain capacity is positive."
+        ),
+        examples=[300.0],
+    )
+    saturation_state: Literal["stable", "near_capacity", "over_capacity"] = Field(
+        description="Operational saturation classification derived from utilization ratio bands.",
+        examples=["stable"],
+    )
+
+
+class IngestionCapacityStatusResponse(BaseModel):
+    as_of: datetime = Field(
+        description="UTC timestamp when capacity status was computed.",
+        examples=["2026-03-03T14:55:22.000Z"],
+    )
+    lookback_minutes: int = Field(
+        ge=1,
+        description="Lookback window in minutes used for capacity calculations.",
+        examples=[60],
+    )
+    assumed_replicas: int = Field(
+        ge=1,
+        description="Replica count assumption used for all capacity rows in this response.",
+        examples=[2],
+    )
+    total_backlog_records: int = Field(
+        ge=0,
+        description="Total accepted-state backlog records across all returned groups.",
+        examples=[4200],
+    )
+    total_groups: int = Field(
+        ge=0,
+        description="Number of capacity groups returned in this response.",
+        examples=[5],
+    )
+    groups: list[IngestionCapacityGroupResponse] = Field(
+        description="Per endpoint/entity capacity diagnostics sorted by highest backlog pressure."
+    )
+
+
 class IngestionBacklogBreakdownItemResponse(BaseModel):
     endpoint: str = Field(
         description="Ingestion endpoint associated with this backlog group.",

--- a/src/services/ingestion_service/app/routers/ingestion_jobs.py
+++ b/src/services/ingestion_service/app/routers/ingestion_jobs.py
@@ -12,6 +12,7 @@ from app.DTOs.ingestion_job_dto import (
     ConsumerDlqEventListResponse,
     IngestionBacklogBreakdownResponse,
     IngestionConsumerLagResponse,
+    IngestionCapacityStatusResponse,
     IngestionErrorBudgetStatusResponse,
     IngestionHealthSummaryResponse,
     IngestionIdempotencyDiagnosticsResponse,
@@ -658,6 +659,31 @@ async def get_reprocessing_queue_health(
     ingestion_job_service: IngestionJobService = Depends(get_ingestion_job_service),
 ):
     return await ingestion_job_service.get_reprocessing_queue_health()
+
+
+@router.get(
+    "/ingestion/health/capacity",
+    response_model=IngestionCapacityStatusResponse,
+    status_code=status.HTTP_200_OK,
+    tags=["Ingestion Operations"],
+    summary="Get ingestion capacity and saturation diagnostics",
+    description=(
+        "What: Return per endpoint/entity ingestion capacity diagnostics using RFC-065 throughput signals.\n"
+        "How: Aggregate accepted, processed, and backlog records and derive lambda_in, mu_msg, rho, headroom, and drain time.\n"
+        "When: Use to detect overload, prioritize scaling, and estimate backlog recovery time."
+    ),
+)
+async def get_ingestion_capacity_status(
+    lookback_minutes: int = Query(default=60, ge=5, le=1440),
+    limit: int = Query(default=200, ge=1, le=500),
+    assumed_replicas: int = Query(default=1, ge=1, le=500),
+    ingestion_job_service: IngestionJobService = Depends(get_ingestion_job_service),
+):
+    return await ingestion_job_service.get_capacity_status(
+        lookback_minutes=lookback_minutes,
+        limit=limit,
+        assumed_replicas=assumed_replicas,
+    )
 
 
 @router.get(

--- a/src/services/ingestion_service/app/services/ingestion_job_service.py
+++ b/src/services/ingestion_service/app/services/ingestion_job_service.py
@@ -13,6 +13,8 @@ from app.DTOs.ingestion_job_dto import (
     IngestionBacklogBreakdownItemResponse,
     IngestionBacklogBreakdownResponse,
     ConsumerDlqEventResponse,
+    IngestionCapacityGroupResponse,
+    IngestionCapacityStatusResponse,
     IngestionReplayAuditResponse,
     IngestionConsumerLagGroupResponse,
     IngestionConsumerLagResponse,
@@ -92,6 +94,7 @@ VALUATION_SCHEDULER_BATCH_SIZE = int(os.getenv("VALUATION_SCHEDULER_BATCH_SIZE",
 VALUATION_SCHEDULER_DISPATCH_ROUNDS = int(
     os.getenv("VALUATION_SCHEDULER_DISPATCH_ROUNDS", "3")
 )
+CAPACITY_ASSUMED_REPLICAS = int(os.getenv("LOTUS_CORE_CAPACITY_ASSUMED_REPLICAS", "1"))
 
 
 @dataclass(frozen=True, slots=True)
@@ -300,6 +303,64 @@ def _to_replay_audit_response(row: DBConsumerDlqReplayAudit) -> IngestionReplayA
         requested_by=row.requested_by,
         requested_at=row.requested_at,
         completed_at=row.completed_at,
+    )
+
+
+def _derive_capacity_group(
+    *,
+    endpoint: str,
+    entity_type: str,
+    total_records: int,
+    processed_records: int,
+    backlog_records: int,
+    backlog_jobs: int,
+    lookback_seconds: Decimal,
+    assumed_replicas: int,
+) -> IngestionCapacityGroupResponse:
+    safe_lookback_seconds = max(lookback_seconds, Decimal("1"))
+    safe_replicas = max(assumed_replicas, 1)
+    decimal_total_records = Decimal(total_records)
+    decimal_processed_records = Decimal(processed_records)
+    decimal_backlog_records = Decimal(backlog_records)
+
+    lambda_in = decimal_total_records / safe_lookback_seconds
+    mu_msg_per_replica = decimal_processed_records / safe_lookback_seconds
+    effective_capacity = mu_msg_per_replica * Decimal(safe_replicas)
+
+    if effective_capacity > Decimal("0"):
+        utilization_ratio = lambda_in / effective_capacity
+    else:
+        utilization_ratio = Decimal("0")
+    headroom_ratio = Decimal("1") - utilization_ratio
+
+    drain_denominator = effective_capacity - lambda_in
+    if decimal_backlog_records > Decimal("0") and drain_denominator > Decimal("0"):
+        estimated_drain_seconds = float(decimal_backlog_records / drain_denominator)
+    else:
+        estimated_drain_seconds = None
+
+    if utilization_ratio >= Decimal("1"):
+        saturation_state: Literal["stable", "near_capacity", "over_capacity"] = "over_capacity"
+    elif utilization_ratio >= Decimal("0.8"):
+        saturation_state = "near_capacity"
+    else:
+        saturation_state = "stable"
+
+    return IngestionCapacityGroupResponse(
+        endpoint=endpoint,
+        entity_type=entity_type,
+        total_records=total_records,
+        processed_records=processed_records,
+        backlog_records=backlog_records,
+        backlog_jobs=backlog_jobs,
+        lambda_in_events_per_second=lambda_in,
+        mu_msg_per_replica_events_per_second=mu_msg_per_replica,
+        assumed_replicas=safe_replicas,
+        effective_capacity_events_per_second=effective_capacity,
+        utilization_ratio=utilization_ratio,
+        headroom_ratio=headroom_ratio,
+        estimated_drain_seconds=estimated_drain_seconds,
+        saturation_state=saturation_state,
     )
 
 
@@ -813,6 +874,90 @@ class IngestionJobService:
             total_processing_jobs=total_processing,
             total_failed_jobs=total_failed,
             queues=queue_items,
+        )
+
+    async def get_capacity_status(
+        self,
+        *,
+        lookback_minutes: int = 60,
+        limit: int = 200,
+        assumed_replicas: int | None = None,
+    ) -> IngestionCapacityStatusResponse:
+        now = datetime.now(UTC)
+        lookback_seconds = Decimal(max(lookback_minutes * 60, 1))
+        resolved_replicas = max(
+            assumed_replicas if assumed_replicas is not None else CAPACITY_ASSUMED_REPLICAS, 1
+        )
+        async for db in get_async_db_session():
+            since = now - timedelta(minutes=lookback_minutes)
+            rows = await db.execute(
+                select(
+                    DBIngestionJob.endpoint,
+                    DBIngestionJob.entity_type,
+                    func.sum(DBIngestionJob.accepted_count).label("total_records"),
+                    func.sum(
+                        case(
+                            (
+                                DBIngestionJob.status.in_(["queued", "failed"]),
+                                DBIngestionJob.accepted_count,
+                            ),
+                            else_=0,
+                        )
+                    ).label("processed_records"),
+                    func.sum(
+                        case(
+                            (DBIngestionJob.status == "accepted", DBIngestionJob.accepted_count),
+                            else_=0,
+                        )
+                    ).label("backlog_records"),
+                    func.sum(case((DBIngestionJob.status == "accepted", 1), else_=0)).label(
+                        "backlog_jobs"
+                    ),
+                )
+                .where(DBIngestionJob.submitted_at >= since)
+                .group_by(DBIngestionJob.endpoint, DBIngestionJob.entity_type)
+                .order_by(desc("backlog_records"), desc("total_records"))
+                .limit(limit)
+            )
+
+            groups: list[IngestionCapacityGroupResponse] = []
+            for (
+                endpoint,
+                entity_type,
+                total_records_raw,
+                processed_records_raw,
+                backlog_records_raw,
+                backlog_jobs_raw,
+            ) in rows:
+                groups.append(
+                    _derive_capacity_group(
+                        endpoint=str(endpoint),
+                        entity_type=str(entity_type),
+                        total_records=int(total_records_raw or 0),
+                        processed_records=int(processed_records_raw or 0),
+                        backlog_records=int(backlog_records_raw or 0),
+                        backlog_jobs=int(backlog_jobs_raw or 0),
+                        lookback_seconds=lookback_seconds,
+                        assumed_replicas=resolved_replicas,
+                    )
+                )
+
+            return IngestionCapacityStatusResponse(
+                as_of=now,
+                lookback_minutes=lookback_minutes,
+                assumed_replicas=resolved_replicas,
+                total_backlog_records=sum(item.backlog_records for item in groups),
+                total_groups=len(groups),
+                groups=groups,
+            )
+
+        return IngestionCapacityStatusResponse(
+            as_of=now,
+            lookback_minutes=lookback_minutes,
+            assumed_replicas=resolved_replicas,
+            total_backlog_records=0,
+            total_groups=0,
+            groups=[],
         )
 
     async def get_backlog_breakdown(

--- a/tests/integration/services/ingestion_service/test_ingestion_routers.py
+++ b/tests/integration/services/ingestion_service/test_ingestion_routers.py
@@ -482,6 +482,40 @@ async def async_test_client(mock_kafka_producer: MagicMock):
                 ],
             }
 
+        async def get_capacity_status(
+            self,
+            *,
+            lookback_minutes: int = 60,
+            limit: int = 200,
+            assumed_replicas: int = 1,
+        ):
+            now = datetime.now(UTC)
+            return {
+                "as_of": now,
+                "lookback_minutes": lookback_minutes,
+                "assumed_replicas": assumed_replicas,
+                "total_backlog_records": 300,
+                "total_groups": 1,
+                "groups": [
+                    {
+                        "endpoint": "/ingest/transactions",
+                        "entity_type": "transaction",
+                        "total_records": 1200,
+                        "processed_records": 900,
+                        "backlog_records": 300,
+                        "backlog_jobs": 6,
+                        "lambda_in_events_per_second": Decimal("0.333333"),
+                        "mu_msg_per_replica_events_per_second": Decimal("0.250000"),
+                        "assumed_replicas": assumed_replicas,
+                        "effective_capacity_events_per_second": Decimal("0.500000"),
+                        "utilization_ratio": Decimal("0.666666"),
+                        "headroom_ratio": Decimal("0.333334"),
+                        "estimated_drain_seconds": 1800.0,
+                        "saturation_state": "stable",
+                    }
+                ][:limit],
+            }
+
         async def find_successful_replay_audit_by_fingerprint(
             self,
             replay_fingerprint: str,
@@ -1052,6 +1086,27 @@ async def test_ingestion_reprocessing_queue_health_endpoint(async_test_client: h
     assert body["total_pending_jobs"] >= 0
     assert body["queues"][0]["job_type"] == "RESET_WATERMARKS"
     assert "oldest_pending_age_seconds" in body["queues"][0]
+
+
+async def test_ingestion_capacity_status_endpoint(async_test_client: httpx.AsyncClient):
+    response = await async_test_client.get(
+        "/ingestion/health/capacity",
+        params={"lookback_minutes": 60, "assumed_replicas": 2},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["lookback_minutes"] == 60
+    assert body["assumed_replicas"] == 2
+    assert body["total_backlog_records"] >= 0
+    assert body["total_groups"] >= 1
+    assert body["groups"][0]["endpoint"] == "/ingest/transactions"
+    assert "lambda_in_events_per_second" in body["groups"][0]
+    assert "mu_msg_per_replica_events_per_second" in body["groups"][0]
+    assert body["groups"][0]["saturation_state"] in {
+        "stable",
+        "near_capacity",
+        "over_capacity",
+    }
 
 
 async def test_ingestion_idempotency_diagnostics_endpoint(async_test_client: httpx.AsyncClient):

--- a/tests/unit/services/ingestion_service/services/test_ingestion_job_service_capacity_status.py
+++ b/tests/unit/services/ingestion_service/services/test_ingestion_job_service_capacity_status.py
@@ -1,0 +1,79 @@
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from src.services.ingestion_service.app.services import ingestion_job_service as service_module
+from src.services.ingestion_service.app.services.ingestion_job_service import (
+    IngestionJobService,
+    _derive_capacity_group,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def service() -> IngestionJobService:
+    return IngestionJobService()
+
+
+async def test_derive_capacity_group_marks_over_capacity_when_utilization_exceeds_one() -> None:
+    result = _derive_capacity_group(
+        endpoint="/ingest/transactions",
+        entity_type="transaction",
+        total_records=720,
+        processed_records=360,
+        backlog_records=120,
+        backlog_jobs=3,
+        lookback_seconds=Decimal("60"),
+        assumed_replicas=1,
+    )
+
+    assert result.lambda_in_events_per_second == Decimal("12")
+    assert result.mu_msg_per_replica_events_per_second == Decimal("6")
+    assert result.effective_capacity_events_per_second == Decimal("6")
+    assert result.utilization_ratio == Decimal("2")
+    assert result.headroom_ratio == Decimal("-1")
+    assert result.saturation_state == "over_capacity"
+    assert result.estimated_drain_seconds is None
+
+
+async def test_get_capacity_status_aggregates_groups(service: IngestionJobService, monkeypatch):
+    class _FakeSession:
+        async def execute(self, _stmt):
+            return [
+                ("/ingest/transactions", "transaction", 1200, 900, 300, 6),
+                ("/ingest/instruments", "instrument", 200, 200, 0, 0),
+            ]
+
+    async def _mock_get_async_db_session():
+        yield _FakeSession()
+
+    monkeypatch.setattr(service_module, "get_async_db_session", _mock_get_async_db_session)
+
+    result = await service.get_capacity_status(
+        lookback_minutes=60,
+        limit=10,
+        assumed_replicas=2,
+    )
+
+    assert result.lookback_minutes == 60
+    assert result.assumed_replicas == 2
+    assert result.total_groups == 2
+    assert result.total_backlog_records == 300
+    assert result.as_of <= datetime.now(UTC)
+
+    first = result.groups[0]
+    assert first.endpoint == "/ingest/transactions"
+    assert first.total_records == 1200
+    assert first.processed_records == 900
+    assert first.backlog_records == 300
+    assert first.lambda_in_events_per_second == Decimal("0.3333333333333333333333333333")
+    assert (
+        first.mu_msg_per_replica_events_per_second
+        == Decimal("0.25")
+    )
+    assert first.effective_capacity_events_per_second == Decimal("0.50")
+    assert first.utilization_ratio == Decimal("0.6666666666666666666666666666")
+    assert first.saturation_state == "stable"
+    assert first.estimated_drain_seconds is not None


### PR DESCRIPTION
## Summary
- add `GET /ingestion/health/capacity` for per endpoint/entity throughput and saturation diagnostics
- derive RFC-065 capacity signals (`lambda_in`, `mu_msg`, `rho`, `headroom`, `T_drain`) from ingestion control-plane data
- extend OpenAPI response models with fully documented capacity fields and examples
- add unit coverage for capacity math and integration coverage for router contract
- update RFC-065 progress log with this completed slice

## Validation
- `uv run python -m pytest tests/unit/services/ingestion_service/services/test_ingestion_job_service_capacity_status.py -q`
- `uv run python -m pytest tests/unit/services/ingestion_service/services/test_ingestion_job_service_guardrails.py tests/unit/services/ingestion_service/services/test_ingestion_job_service_backlog_breakdown.py tests/unit/services/ingestion_service/services/test_ingestion_job_service_capacity_status.py -q`
- `uv run python -m pytest tests/integration/services/ingestion_service/test_ingestion_routers.py -k "capacity_status_endpoint or reprocessing_queue_health_endpoint or operating_policy_endpoint" -q`
