### PR TITLE
RFC-066 Slice-B: deterministic load-profile performance gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,49 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+  performance-load-gate:
+    name: Performance Load Gate
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request'
+    needs: [quality]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+
+      - name: Install Tooling and Project Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          make install
+
+      - name: Run deterministic performance load gate
+        run: make test-performance-load-gate
+
+      - name: Capture docker compose logs on failure
+        if: failure()
+        run: docker compose logs > performance-load-gate-logs.txt
+
+      - name: Upload performance load artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: performance-load-gate-artifacts
+          path: |
+            output/task-runs/*performance-load-gate*.json
+            output/task-runs/*performance-load-gate*.md
+            performance-load-gate-logs.txt
+          if-no-files-found: warn
+          retention-days: 14
+
   e2e-smoke:
     name: E2E Smoke
     if: >

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
-.PHONY: install lint typecheck architecture-guard monetary-float-guard ingestion-contract-gate no-alias-gate openapi-gate api-vocabulary-gate warning-gate migration-smoke migration-apply test test-unit test-unit-db test-integration-lite test-ops-contract test-buy-rfc test-sell-rfc test-e2e-smoke test-docker-smoke test-latency-gate security-audit check coverage-gate ci ci-local docker-build clean
+.PHONY: install lint typecheck architecture-guard monetary-float-guard ingestion-contract-gate no-alias-gate openapi-gate api-vocabulary-gate warning-gate migration-smoke migration-apply test test-unit test-unit-db test-integration-lite test-ops-contract test-buy-rfc test-sell-rfc test-e2e-smoke test-docker-smoke test-latency-gate test-performance-load-gate security-audit check coverage-gate ci ci-local docker-build clean
 
 install:
 	python scripts/bootstrap_dev.py
 
 lint:
 	python -m ruff check src/services/query_service/app src/services/ingestion_service/app/main.py src/libs/portfolio-common/portfolio_common/openapi_enrichment.py tests/unit/services/query_service tests/unit/libs/portfolio-common/test_openapi_enrichment.py tests/test_support tests/unit/test_support scripts/test_manifest.py scripts/coverage_gate.py scripts/openapi_quality_gate.py scripts/warning_budget_gate.py scripts/api_vocabulary_inventory.py scripts/no_alias_contract_guard.py scripts/ingestion_endpoint_contract_gate.py --ignore E501,I001
-	python -m ruff check scripts/docker_endpoint_smoke.py scripts/latency_profile.py --ignore E501,I001
-	python -m ruff format --check src/services/query_service/app/main.py src/services/ingestion_service/app/main.py src/libs/portfolio-common/portfolio_common/openapi_enrichment.py tests/unit/services/query_service/test_openapi_quality_gate.py tests/unit/services/query_service/test_api_vocabulary_inventory.py tests/unit/libs/portfolio-common/test_openapi_enrichment.py scripts/test_manifest.py scripts/coverage_gate.py scripts/openapi_quality_gate.py scripts/warning_budget_gate.py scripts/api_vocabulary_inventory.py scripts/no_alias_contract_guard.py scripts/docker_endpoint_smoke.py scripts/latency_profile.py scripts/ingestion_endpoint_contract_gate.py
+	python -m ruff check scripts/docker_endpoint_smoke.py scripts/latency_profile.py scripts/performance_load_gate.py --ignore E501,I001
+	python -m ruff format --check src/services/query_service/app/main.py src/services/ingestion_service/app/main.py src/libs/portfolio-common/portfolio_common/openapi_enrichment.py tests/unit/services/query_service/test_openapi_quality_gate.py tests/unit/services/query_service/test_api_vocabulary_inventory.py tests/unit/libs/portfolio-common/test_openapi_enrichment.py scripts/test_manifest.py scripts/coverage_gate.py scripts/openapi_quality_gate.py scripts/warning_budget_gate.py scripts/api_vocabulary_inventory.py scripts/no_alias_contract_guard.py scripts/docker_endpoint_smoke.py scripts/latency_profile.py scripts/performance_load_gate.py scripts/ingestion_endpoint_contract_gate.py
 	$(MAKE) monetary-float-guard
 	$(MAKE) ingestion-contract-gate
 
@@ -69,6 +69,9 @@ test-docker-smoke:
 
 test-latency-gate:
 	python scripts/latency_profile.py --build --enforce
+
+test-performance-load-gate:
+	python scripts/performance_load_gate.py --build --enforce
 
 security-audit:
 	python -m pip_audit -r tests/requirements.txt

--- a/docs/RFCs/RFC 066 - Institutional-Scale Production Readiness and Performance Assurance.md
+++ b/docs/RFCs/RFC 066 - Institutional-Scale Production Readiness and Performance Assurance.md
@@ -90,3 +90,27 @@ Functional correctness alone is insufficient for bank/fintech deployments. We mu
 
 ## 9. Implementation Notes
 RFC-065 remains the foundational scalability roadmap. RFC-066 is the production-readiness enforcement layer that turns those decisions into auditable, CI-gated operating guarantees.
+
+## 10. Progress (2026-03-04)
+
+### Slice A - Completed
+1. Deterministic docker smoke expanded to cover ingestion operations and policy/capacity contracts.
+2. Contract checks now fail explicitly on missing institutional policy fields or missing capacity signals.
+
+### Slice B - Completed in this change set
+1. Added deterministic load profile runner: `scripts/performance_load_gate.py`.
+2. Implemented three profiles:
+- `steady_state`
+- `burst`
+- `replay_storm`
+3. Added enforceable threshold evaluation with per-profile failure reasons:
+- throughput floor
+- backlog-age ceiling
+- DLQ pressure ceiling
+- replay pressure ceiling
+- backlog drain-time ceiling
+4. Added JSON/Markdown artifact generation:
+- `output/task-runs/*performance-load-gate*.json`
+- `output/task-runs/*performance-load-gate*.md`
+5. Added CI job `Performance Load Gate` in `.github/workflows/ci.yml`.
+6. Added make target `test-performance-load-gate` and wired lint/format coverage for the new script.

--- a/scripts/performance_load_gate.py
+++ b/scripts/performance_load_gate.py
@@ -1,0 +1,484 @@
+"""Deterministic load-profile gate for lotus-core institutional readiness.
+
+Runs three deterministic profiles against ingestion/query services:
+1. steady_state
+2. burst
+3. replay_storm
+
+Writes JSON/Markdown artifacts and optionally enforces profile thresholds.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import time
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import requests
+
+
+@dataclass(slots=True)
+class ProfileResult:
+    profile_name: str
+    started_at: str
+    ended_at: str
+    duration_seconds: float
+    records_submitted: int
+    batches_submitted: int
+    throughput_records_per_second: float
+    backlog_jobs_after_profile: int
+    backlog_age_seconds_after_profile: float
+    dlq_pressure_ratio_after_profile: float
+    replay_pressure_ratio_after_profile: float
+    drain_seconds_to_zero_backlog: float | None
+    checks_passed: bool
+    failed_checks: list[str]
+
+
+def _run(cmd: list[str], cwd: Path) -> None:
+    completed = subprocess.run(cmd, cwd=cwd, check=False, capture_output=True, text=True)
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"Command failed ({completed.returncode}): {' '.join(cmd)}\n"
+            f"stdout:\n{completed.stdout}\n"
+            f"stderr:\n{completed.stderr}"
+        )
+
+
+def _compose_up(*, repo_root: Path, compose_file: str, build: bool) -> None:
+    cmd = ["docker", "compose", "-f", compose_file, "up", "-d"]
+    if build:
+        cmd.append("--build")
+    _run(cmd, cwd=repo_root)
+
+
+def _wait_ready(*, ingestion_base_url: str, query_base_url: str, timeout_seconds: int) -> None:
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        try:
+            ing = requests.get(f"{ingestion_base_url}/health/ready", timeout=5)
+            qry = requests.get(f"{query_base_url}/health/ready", timeout=5)
+            if ing.status_code == 200 and qry.status_code == 200:
+                return
+        except requests.RequestException:
+            pass
+        time.sleep(2)
+    raise TimeoutError("Services did not become ready before timeout.")
+
+
+def _build_transaction_batch(
+    *, portfolio_id: str, batch_size: int, seed: str
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    base_ts = "2026-03-01T09:00:00Z"
+    for index in range(batch_size):
+        txn_suffix = f"{seed}-{index:04d}"
+        rows.append(
+            {
+                "transaction_id": f"TX_{txn_suffix}",
+                "portfolio_id": portfolio_id,
+                "instrument_id": f"INSTR_{index % 20:03d}",
+                "security_id": f"SEC_{index % 20:03d}",
+                "transaction_date": base_ts,
+                "transaction_type": "BUY",
+                "quantity": "10",
+                "price": "100.00",
+                "gross_transaction_amount": "1000.00",
+                "trade_currency": "USD",
+                "currency": "USD",
+            }
+        )
+    return rows
+
+
+def _ingest_transactions(
+    *,
+    ingestion_base_url: str,
+    portfolio_id: str,
+    batches: int,
+    batch_size: int,
+    sleep_seconds_between_batches: float,
+) -> tuple[int, int]:
+    total_records = 0
+    total_batches = 0
+    for batch_number in range(batches):
+        seed = f"{uuid4().hex[:8]}-{batch_number:03d}"
+        payload = {
+            "transactions": _build_transaction_batch(
+                portfolio_id=portfolio_id,
+                batch_size=batch_size,
+                seed=seed,
+            )
+        }
+        response = requests.post(
+            f"{ingestion_base_url}/ingest/transactions",
+            json=payload,
+            timeout=30,
+        )
+        if response.status_code != 202:
+            raise RuntimeError(
+                f"Transaction ingestion failed with status={response.status_code}: {response.text[:300]}"
+            )
+        total_records += batch_size
+        total_batches += 1
+        if sleep_seconds_between_batches > 0:
+            time.sleep(sleep_seconds_between_batches)
+    return total_records, total_batches
+
+
+def _trigger_replay_storm(
+    *,
+    ingestion_base_url: str,
+    transaction_ids: list[str],
+    bursts: int,
+    burst_size: int,
+) -> None:
+    if not transaction_ids:
+        return
+    for burst in range(bursts):
+        start = (burst * burst_size) % len(transaction_ids)
+        selected = transaction_ids[start : start + burst_size]
+        if not selected:
+            selected = transaction_ids[:burst_size]
+        response = requests.post(
+            f"{ingestion_base_url}/reprocess/transactions",
+            json={"transaction_ids": selected},
+            timeout=30,
+        )
+        if response.status_code not in {202, 409}:
+            raise RuntimeError(
+                f"Replay request failed with status={response.status_code}: {response.text[:300]}"
+            )
+
+
+def _get_health_snapshot(*, ingestion_base_url: str, ops_token: str) -> dict[str, Any]:
+    headers = {"X-Lotus-Ops-Token": ops_token}
+    summary = requests.get(
+        f"{ingestion_base_url}/ingestion/health/summary",
+        headers=headers,
+        timeout=20,
+    )
+    slo = requests.get(
+        f"{ingestion_base_url}/ingestion/health/slo?lookback_minutes=60",
+        headers=headers,
+        timeout=20,
+    )
+    error_budget = requests.get(
+        f"{ingestion_base_url}/ingestion/health/error-budget?lookback_minutes=60",
+        headers=headers,
+        timeout=20,
+    )
+    for response in (summary, slo, error_budget):
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"Health endpoint failed status={response.status_code}: {response.text[:200]}"
+            )
+    return {
+        "summary": summary.json(),
+        "slo": slo.json(),
+        "error_budget": error_budget.json(),
+    }
+
+
+def _wait_drain_to_zero_backlog(
+    *,
+    ingestion_base_url: str,
+    ops_token: str,
+    timeout_seconds: int,
+) -> float | None:
+    headers = {"X-Lotus-Ops-Token": ops_token}
+    started = time.time()
+    deadline = started + timeout_seconds
+    while time.time() < deadline:
+        response = requests.get(
+            f"{ingestion_base_url}/ingestion/health/summary",
+            headers=headers,
+            timeout=20,
+        )
+        if response.status_code == 200:
+            backlog_jobs = int(response.json().get("backlog_jobs", 0))
+            if backlog_jobs <= 0:
+                return round(time.time() - started, 3)
+        time.sleep(2)
+    return None
+
+
+def _evaluate_profile(
+    *,
+    profile_name: str,
+    records_submitted: int,
+    batches_submitted: int,
+    started_at: float,
+    ended_at: float,
+    health: dict[str, Any],
+    drain_seconds: float | None,
+    thresholds: dict[str, float],
+) -> ProfileResult:
+    duration = max(ended_at - started_at, 0.001)
+    throughput = records_submitted / duration
+    summary = health["summary"]
+    slo = health["slo"]
+    error_budget = health["error_budget"]
+    backlog_jobs = int(summary.get("backlog_jobs", 0))
+    backlog_age = float(slo.get("backlog_age_seconds", 0.0))
+    dlq_pressure = float(error_budget.get("dlq_pressure_ratio", 0.0))
+    replay_pressure = float(error_budget.get("replay_backlog_pressure_ratio", 0.0))
+
+    failed_checks: list[str] = []
+    if throughput < thresholds["min_throughput_rps"]:
+        failed_checks.append(
+            f"throughput {throughput:.2f} < min {thresholds['min_throughput_rps']:.2f}"
+        )
+    if backlog_age > thresholds["max_backlog_age_seconds"]:
+        failed_checks.append(
+            f"backlog_age {backlog_age:.2f} > max {thresholds['max_backlog_age_seconds']:.2f}"
+        )
+    if dlq_pressure > thresholds["max_dlq_pressure_ratio"]:
+        failed_checks.append(
+            f"dlq_pressure {dlq_pressure:.4f} > max {thresholds['max_dlq_pressure_ratio']:.4f}"
+        )
+    if replay_pressure > thresholds["max_replay_pressure_ratio"]:
+        failed_checks.append(
+            f"replay_pressure {replay_pressure:.4f} > max {thresholds['max_replay_pressure_ratio']:.4f}"
+        )
+    max_drain = thresholds.get("max_drain_seconds")
+    if max_drain is not None and (drain_seconds is None or drain_seconds > max_drain):
+        failed_checks.append(
+            f"drain_seconds {drain_seconds if drain_seconds is not None else 'timeout'} > max {max_drain:.2f}"
+        )
+
+    return ProfileResult(
+        profile_name=profile_name,
+        started_at=datetime.fromtimestamp(started_at, tz=UTC).isoformat(),
+        ended_at=datetime.fromtimestamp(ended_at, tz=UTC).isoformat(),
+        duration_seconds=round(duration, 3),
+        records_submitted=records_submitted,
+        batches_submitted=batches_submitted,
+        throughput_records_per_second=round(throughput, 3),
+        backlog_jobs_after_profile=backlog_jobs,
+        backlog_age_seconds_after_profile=round(backlog_age, 3),
+        dlq_pressure_ratio_after_profile=round(dlq_pressure, 6),
+        replay_pressure_ratio_after_profile=round(replay_pressure, 6),
+        drain_seconds_to_zero_backlog=drain_seconds,
+        checks_passed=not failed_checks,
+        failed_checks=failed_checks,
+    )
+
+
+def _write_report(
+    *,
+    output_dir: Path,
+    run_id: str,
+    results: list[ProfileResult],
+    enforce: bool,
+) -> tuple[Path, Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    overall_passed = all(item.checks_passed for item in results)
+    payload = {
+        "run_id": run_id,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "enforce": enforce,
+        "overall_passed": overall_passed,
+        "profiles": [asdict(item) for item in results],
+    }
+    json_path = output_dir / f"{run_id}-performance-load-gate.json"
+    md_path = output_dir / f"{run_id}-performance-load-gate.md"
+    json_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    lines = [
+        f"# Performance Load Gate {run_id}",
+        "",
+        f"- Overall passed: {overall_passed}",
+        f"- Enforce mode: {enforce}",
+        "",
+        "| Profile | Passed | Throughput rps | Backlog age sec | DLQ pressure | Replay pressure | Drain sec |",
+        "|---|---|---:|---:|---:|---:|---:|",
+    ]
+    for item in results:
+        lines.append(
+            "| {profile} | {passed} | {throughput:.3f} | {backlog_age:.3f} | {dlq:.6f} | {replay:.6f} | {drain} |".format(
+                profile=item.profile_name,
+                passed="yes" if item.checks_passed else "no",
+                throughput=item.throughput_records_per_second,
+                backlog_age=item.backlog_age_seconds_after_profile,
+                dlq=item.dlq_pressure_ratio_after_profile,
+                replay=item.replay_pressure_ratio_after_profile,
+                drain=(
+                    f"{item.drain_seconds_to_zero_backlog:.3f}"
+                    if item.drain_seconds_to_zero_backlog is not None
+                    else "timeout"
+                ),
+            )
+        )
+        if item.failed_checks:
+            lines.append("")
+            lines.append(f"Failure details ({item.profile_name}):")
+            for check in item.failed_checks:
+                lines.append(f"- {check}")
+            lines.append("")
+    md_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return json_path, md_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run deterministic performance load gate.")
+    parser.add_argument("--repo-root", default=".", help="Path to lotus-core repository root.")
+    parser.add_argument("--compose-file", default="docker-compose.yml")
+    parser.add_argument("--ingestion-base-url", default="http://localhost:8200")
+    parser.add_argument("--query-base-url", default="http://localhost:8201")
+    parser.add_argument("--ops-token", default="lotus-core-ops-local")
+    parser.add_argument("--output-dir", default="output/task-runs")
+    parser.add_argument("--build", action="store_true")
+    parser.add_argument("--skip-compose", action="store_true")
+    parser.add_argument("--ready-timeout-seconds", type=int, default=240)
+    parser.add_argument("--drain-timeout-seconds", type=int, default=180)
+    parser.add_argument("--enforce", action="store_true")
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve()
+    if not args.skip_compose:
+        _compose_up(repo_root=repo_root, compose_file=args.compose_file, build=args.build)
+    _wait_ready(
+        ingestion_base_url=args.ingestion_base_url,
+        query_base_url=args.query_base_url,
+        timeout_seconds=args.ready_timeout_seconds,
+    )
+
+    run_id = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    portfolio_id = f"PERF_LOAD_{run_id}"
+    all_results: list[ProfileResult] = []
+    profiles = [
+        {
+            "name": "steady_state",
+            "batches": 5,
+            "batch_size": 40,
+            "sleep_seconds": 0.5,
+            "thresholds": {
+                "min_throughput_rps": 10.0,
+                "max_backlog_age_seconds": 1200.0,
+                "max_dlq_pressure_ratio": 5.0,
+                "max_replay_pressure_ratio": 5.0,
+                "max_drain_seconds": 600.0,
+            },
+        },
+        {
+            "name": "burst",
+            "batches": 8,
+            "batch_size": 80,
+            "sleep_seconds": 0.0,
+            "thresholds": {
+                "min_throughput_rps": 20.0,
+                "max_backlog_age_seconds": 1800.0,
+                "max_dlq_pressure_ratio": 5.0,
+                "max_replay_pressure_ratio": 5.0,
+                "max_drain_seconds": 900.0,
+            },
+        },
+    ]
+
+    for profile in profiles:
+        started = time.time()
+        records_submitted, batches_submitted = _ingest_transactions(
+            ingestion_base_url=args.ingestion_base_url,
+            portfolio_id=portfolio_id,
+            batches=profile["batches"],
+            batch_size=profile["batch_size"],
+            sleep_seconds_between_batches=profile["sleep_seconds"],
+        )
+        ended = time.time()
+        health = _get_health_snapshot(
+            ingestion_base_url=args.ingestion_base_url,
+            ops_token=args.ops_token,
+        )
+        drain_seconds = _wait_drain_to_zero_backlog(
+            ingestion_base_url=args.ingestion_base_url,
+            ops_token=args.ops_token,
+            timeout_seconds=args.drain_timeout_seconds,
+        )
+        all_results.append(
+            _evaluate_profile(
+                profile_name=profile["name"],
+                records_submitted=records_submitted,
+                batches_submitted=batches_submitted,
+                started_at=started,
+                ended_at=ended,
+                health=health,
+                drain_seconds=drain_seconds,
+                thresholds=profile["thresholds"],
+            )
+        )
+
+    replay_started = time.time()
+    replay_source_transactions = _build_transaction_batch(
+        portfolio_id=portfolio_id,
+        batch_size=120,
+        seed=f"REPLAY-{uuid4().hex[:8]}",
+    )
+    replay_ids = [row["transaction_id"] for row in replay_source_transactions]
+    response = requests.post(
+        f"{args.ingestion_base_url}/ingest/transactions",
+        json={"transactions": replay_source_transactions},
+        timeout=30,
+    )
+    if response.status_code != 202:
+        raise RuntimeError(
+            f"Replay source ingestion failed status={response.status_code}: {response.text[:300]}"
+        )
+    _trigger_replay_storm(
+        ingestion_base_url=args.ingestion_base_url,
+        transaction_ids=replay_ids,
+        bursts=12,
+        burst_size=30,
+    )
+    replay_ended = time.time()
+    replay_health = _get_health_snapshot(
+        ingestion_base_url=args.ingestion_base_url,
+        ops_token=args.ops_token,
+    )
+    replay_drain_seconds = _wait_drain_to_zero_backlog(
+        ingestion_base_url=args.ingestion_base_url,
+        ops_token=args.ops_token,
+        timeout_seconds=max(args.drain_timeout_seconds, 240),
+    )
+    all_results.append(
+        _evaluate_profile(
+            profile_name="replay_storm",
+            records_submitted=120,
+            batches_submitted=13,
+            started_at=replay_started,
+            ended_at=replay_ended,
+            health=replay_health,
+            drain_seconds=replay_drain_seconds,
+            thresholds={
+                "min_throughput_rps": 8.0,
+                "max_backlog_age_seconds": 2400.0,
+                "max_dlq_pressure_ratio": 5.0,
+                "max_replay_pressure_ratio": 5.0,
+                "max_drain_seconds": 1200.0,
+            },
+        )
+    )
+
+    json_path, md_path = _write_report(
+        output_dir=(repo_root / args.output_dir),
+        run_id=run_id,
+        results=all_results,
+        enforce=args.enforce,
+    )
+    print(f"Wrote load gate JSON report: {json_path}")
+    print(f"Wrote load gate Markdown report: {md_path}")
+
+    overall_passed = all(item.checks_passed for item in all_results)
+    if args.enforce and not overall_passed:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add deterministic RFC-066 Slice-B load gate script with steady-state, burst, and replay-storm profiles
- add enforceable threshold checks and JSON/Markdown artifacts under `output/task-runs`
- wire new `make test-performance-load-gate` target
- add `Performance Load Gate` job in CI
- update RFC-066 progress section

## Validation
- `make lint typecheck test-unit`
- `python scripts/performance_load_gate.py --help`
- `make test-performance-load-gate` *(blocked locally: Docker Desktop Linux engine pipe unavailable in current shell)*
