### PR TITLE
Rename transaction CI suite labels to clean contract names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,8 @@ jobs:
           - suite: unit-db
           - suite: integration-lite
           - suite: ops-contract
-          - suite: buy-rfc
-          - suite: sell-rfc
+          - suite: transaction-buy-contract
+          - suite: transaction-sell-contract
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint typecheck architecture-guard monetary-float-guard ingestion-contract-gate no-alias-gate openapi-gate api-vocabulary-gate warning-gate migration-smoke migration-apply test test-unit test-unit-db test-integration-lite test-ops-contract test-buy-rfc test-sell-rfc test-e2e-smoke test-docker-smoke test-latency-gate test-performance-load-gate test-performance-load-gate-full security-audit check coverage-gate ci ci-local docker-build clean
+.PHONY: install lint typecheck architecture-guard monetary-float-guard ingestion-contract-gate no-alias-gate openapi-gate api-vocabulary-gate warning-gate migration-smoke migration-apply test test-unit test-unit-db test-integration-lite test-ops-contract test-transaction-buy-contract test-transaction-sell-contract test-buy-rfc test-sell-rfc test-e2e-smoke test-docker-smoke test-latency-gate test-performance-load-gate test-performance-load-gate-full security-audit check coverage-gate ci ci-local docker-build clean
 
 install:
 	python scripts/bootstrap_dev.py
@@ -55,11 +55,15 @@ test-integration-lite:
 test-ops-contract:
 	python scripts/test_manifest.py --suite ops-contract --quiet
 
-test-buy-rfc:
-	python scripts/test_manifest.py --suite buy-rfc --quiet
+test-transaction-buy-contract:
+	python scripts/test_manifest.py --suite transaction-buy-contract --quiet
 
-test-sell-rfc:
-	python scripts/test_manifest.py --suite sell-rfc --quiet
+test-buy-rfc: test-transaction-buy-contract
+
+test-transaction-sell-contract:
+	python scripts/test_manifest.py --suite transaction-sell-contract --quiet
+
+test-sell-rfc: test-transaction-sell-contract
 
 test-e2e-smoke:
 	python scripts/test_manifest.py --suite e2e-smoke --quiet

--- a/scripts/test_manifest.py
+++ b/scripts/test_manifest.py
@@ -31,7 +31,7 @@ SUITES: dict[str, list[str]] = {
         "tests/e2e/test_query_service_observability.py",
         "tests/e2e/test_complex_portfolio_lifecycle.py",
     ],
-    "buy-rfc": [
+    "transaction-buy-contract": [
         "tests/unit/transaction_specs/test_buy_slice0_characterization.py",
         "tests/unit/libs/portfolio_common/test_buy_validation.py",
         "tests/unit/libs/portfolio_common/test_transaction_metadata_contract.py",
@@ -44,7 +44,7 @@ SUITES: dict[str, list[str]] = {
         "tests/integration/services/calculators/cost_calculator_service/test_int_cost_repository_lot_offset.py",
         "tests/integration/services/query_service/test_buy_state_router.py",
     ],
-    "sell-rfc": [
+    "transaction-sell-contract": [
         "tests/unit/transaction_specs/test_sell_slice0_characterization.py",
         "tests/unit/libs/portfolio_common/test_sell_validation.py",
         "tests/unit/libs/portfolio_common/test_sell_linkage.py",
@@ -55,6 +55,10 @@ SUITES: dict[str, list[str]] = {
         "tests/integration/services/query_service/test_sell_state_router.py",
     ],
 }
+
+# Backward-compatible aliases for previous suite names.
+SUITES["buy-rfc"] = SUITES["transaction-buy-contract"]
+SUITES["sell-rfc"] = SUITES["transaction-sell-contract"]
 
 SOURCE = "src/services/query_service/app"
 SUITE_PYTEST_ARGS: dict[str, list[str]] = {


### PR DESCRIPTION
## Summary
- rename CI matrix suite labels from uy-rfc/sell-rfc to 	ransaction-buy-contract/	ransaction-sell-contract
- add canonical Make targets: 	est-transaction-buy-contract, 	est-transaction-sell-contract
- keep backward-compatible aliases (uy-rfc, sell-rfc) in test manifest and Makefile

## Why
- cleaner, domain-driven CI naming without losing compatibility

## Validation
- make lint typecheck test-unit