### PR TITLE
docs: mark RFC-066 as implemented

### DIFF
--- a/docs/RFCs/RFC 066 - Institutional-Scale Production Readiness and Performance Assurance.md
+++ b/docs/RFCs/RFC 066 - Institutional-Scale Production Readiness and Performance Assurance.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 | --- | --- |
-| Status | Partially Implemented |
+| Status | Implemented |
 | Created | 2026-03-04 |
 | Last Updated | 2026-03-04 |
 | Owners | lotus-core engineering; lotus-platform governance |


### PR DESCRIPTION
Updates RFC 066 status field from Partially Implemented to Implemented after completion and merge of implementation work.