### PR TITLE
fix(ci): make failure-recovery gate robust to compose container naming

### DIFF
--- a/scripts/failure_recovery_gate.py
+++ b/scripts/failure_recovery_gate.py
@@ -44,6 +44,10 @@ class RecoveryResult:
 
 
 def _run(cmd: list[str], cwd: Path) -> None:
+    _run_capture(cmd, cwd=cwd)
+
+
+def _run_capture(cmd: list[str], cwd: Path) -> str:
     completed = subprocess.run(cmd, cwd=cwd, check=False, capture_output=True, text=True)
     if completed.returncode != 0:
         raise RuntimeError(
@@ -51,6 +55,7 @@ def _run(cmd: list[str], cwd: Path) -> None:
             f"stdout:\n{completed.stdout}\n"
             f"stderr:\n{completed.stderr}"
         )
+    return completed.stdout
 
 
 def _compose_up(*, repo_root: Path, compose_file: str, build: bool) -> None:
@@ -175,12 +180,32 @@ def _get_backlog_jobs(*, ingestion_base_url: str, ops_token: str) -> int:
     return int(response.json().get("backlog_jobs", 0))
 
 
-def _pause_container(container_name: str) -> None:
-    _run(["docker", "pause", container_name], cwd=Path.cwd())
+def _resolve_interruption_container(
+    *, repo_root: Path, compose_file: str, interruption_container: str
+) -> str:
+    """
+    Resolve interruption target using docker compose service lookup first.
+    Falls back to the original argument to preserve manual container-name usage.
+    """
+    target = interruption_container.strip()
+    if not target:
+        raise ValueError("interruption container cannot be empty")
+    try:
+        container_id = _run_capture(
+            ["docker", "compose", "-f", compose_file, "ps", "-q", target],
+            cwd=repo_root,
+        ).strip()
+    except RuntimeError:
+        container_id = ""
+    return container_id or target
 
 
-def _unpause_container(container_name: str) -> None:
-    _run(["docker", "unpause", container_name], cwd=Path.cwd())
+def _pause_container(container_name: str, repo_root: Path) -> None:
+    _run(["docker", "pause", container_name], cwd=repo_root)
+
+
+def _unpause_container(container_name: str, repo_root: Path) -> None:
+    _run(["docker", "unpause", container_name], cwd=repo_root)
 
 
 def _wait_drain_to_target_backlog(
@@ -279,7 +304,12 @@ def main() -> int:
         sleep_seconds_between_batches=0.1,
     )
 
-    _pause_container(args.interruption_container)
+    interruption_target = _resolve_interruption_container(
+        repo_root=repo_root,
+        compose_file=args.compose_file,
+        interruption_container=args.interruption_container,
+    )
+    _pause_container(interruption_target, repo_root=repo_root)
     peak_backlog = baseline_backlog_jobs
     try:
         interruption_deadline = time.time() + args.interruption_seconds
@@ -298,7 +328,7 @@ def main() -> int:
             peak_backlog = max(peak_backlog, current_backlog)
             time.sleep(1)
     finally:
-        _unpause_container(args.interruption_container)
+        _unpause_container(interruption_target, repo_root=repo_root)
 
     drain_seconds = _wait_drain_to_target_backlog(
         ingestion_base_url=args.ingestion_base_url,
@@ -341,7 +371,7 @@ def main() -> int:
         run_id=run_id,
         started_at=datetime.fromtimestamp(started, tz=UTC).isoformat(),
         ended_at=datetime.fromtimestamp(ended, tz=UTC).isoformat(),
-        interruption_container=args.interruption_container,
+        interruption_container=interruption_target,
         interruption_seconds=args.interruption_seconds,
         baseline_backlog_jobs=baseline_backlog_jobs,
         peak_backlog_jobs_during_interruption=peak_backlog,

--- a/tests/unit/scripts/test_failure_recovery_gate.py
+++ b/tests/unit/scripts/test_failure_recovery_gate.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+import pytest
+
+from scripts.failure_recovery_gate import (
+    _pause_container,
+    _resolve_interruption_container,
+    _unpause_container,
+)
+
+
+def test_resolve_interruption_container_prefers_compose_resolved_container_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "scripts.failure_recovery_gate._run_capture",
+        lambda cmd, cwd: "abc123containerid\n",
+    )
+
+    resolved = _resolve_interruption_container(
+        repo_root=Path("."),
+        compose_file="docker-compose.yml",
+        interruption_container="persistence_service",
+    )
+
+    assert resolved == "abc123containerid"
+
+
+def test_resolve_interruption_container_falls_back_to_raw_input_when_service_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "scripts.failure_recovery_gate._run_capture",
+        lambda cmd, cwd: "",
+    )
+
+    resolved = _resolve_interruption_container(
+        repo_root=Path("."),
+        compose_file="docker-compose.yml",
+        interruption_container="persistence_service",
+    )
+
+    assert resolved == "persistence_service"
+
+
+def test_resolve_interruption_container_rejects_empty_value() -> None:
+    with pytest.raises(ValueError, match="cannot be empty"):
+        _resolve_interruption_container(
+            repo_root=Path("."),
+            compose_file="docker-compose.yml",
+            interruption_container=" ",
+        )
+
+
+def test_pause_and_unpause_use_repo_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[list[str], Path]] = []
+
+    def _fake_run(cmd: list[str], cwd: Path) -> None:
+        calls.append((cmd, cwd))
+
+    monkeypatch.setattr("scripts.failure_recovery_gate._run", _fake_run)
+
+    repo_root = Path("/tmp/repo")
+    _pause_container("container-id", repo_root=repo_root)
+    _unpause_container("container-id", repo_root=repo_root)
+
+    assert calls == [
+        (["docker", "pause", "container-id"], repo_root),
+        (["docker", "unpause", "container-id"], repo_root),
+    ]


### PR DESCRIPTION
## Problem
Main pipeline failed in job **Failure Recovery Gate** because the script attempted to pause a hardcoded container name (`persistence_service`). In GitHub Actions, compose prefixes container names (for example `lotus-core-persistence_service-1`), so `docker pause persistence_service` failed with "No such container".

## Fix
- Added `_resolve_interruption_container(...)` to resolve the interruption target via `docker compose -f <compose-file> ps -q <service>`.
- Falls back to the provided raw value for backward compatibility with explicit container IDs/names.
- Updated pause/unpause helpers to run in repo root context and use resolved target.
- Result now records the effective interruption target used.

## Tests
- Added `tests/unit/scripts/test_failure_recovery_gate.py` covering:
  - compose resolution success path
  - fallback path when no compose match
  - empty-input validation
  - pause/unpause command wiring
- Local checks run:
  - `python -m pytest -q tests/unit/scripts/test_failure_recovery_gate.py`
  - `make lint`
