### PR TITLE
CI: cancel superseded main push runs only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,9 @@ on:
     - cron: "0 2 * * *"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Collapse only push-to-main runs into one queue so newer merges cancel older in-flight main runs.
+  # Keep PR/merge_group/scheduled/manual runs independent to avoid cross-canceling validation work.
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'main' || github.run_id }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Summary
- tune workflow concurrency grouping in .github/workflows/ci.yml
- only push events on main now share a concurrency group
- newer main merges cancel older in-flight main runs
- PR, merge_group, schedule, and manual runs remain independent (no cross-cancel)

## Why
- reduces noise/cost on busy merge days while preserving PR validation isolation.