### PR TITLE
test: deduplicate RFC-070 interest validation cases

### DIFF
--- a/tests/unit/libs/portfolio_common/test_interest_validation.py
+++ b/tests/unit/libs/portfolio_common/test_interest_validation.py
@@ -107,72 +107,6 @@ def test_validate_interest_transaction_accepts_reconciled_net_interest_amount() 
     )
 
 
-def test_validate_interest_transaction_rejects_unknown_direction() -> None:
-    txn = _base_txn().model_copy(update={"interest_direction": "UNKNOWN"})
-    issues = validate_interest_transaction(txn)
-    assert any(
-        i.code == InterestValidationReasonCode.INVALID_INTEREST_DIRECTION
-        for i in issues
-    )
-
-
-def test_validate_interest_transaction_accepts_expense_direction() -> None:
-    txn = _base_txn().model_copy(update={"interest_direction": "EXPENSE"})
-    issues = validate_interest_transaction(txn)
-    assert not any(
-        i.code == InterestValidationReasonCode.INVALID_INTEREST_DIRECTION
-        for i in issues
-    )
-
-
-def test_validate_interest_transaction_rejects_negative_withholding_tax() -> None:
-    txn = _base_txn().model_copy(update={"withholding_tax_amount": Decimal("-1")})
-    issues = validate_interest_transaction(txn)
-    assert any(
-        i.code == InterestValidationReasonCode.NEGATIVE_WITHHOLDING_TAX for i in issues
-    )
-
-
-def test_validate_interest_transaction_rejects_negative_other_deductions() -> None:
-    txn = _base_txn().model_copy(
-        update={"other_interest_deductions_amount": Decimal("-1")}
-    )
-    issues = validate_interest_transaction(txn)
-    assert any(
-        i.code == InterestValidationReasonCode.NEGATIVE_OTHER_DEDUCTIONS for i in issues
-    )
-
-
-def test_validate_interest_transaction_rejects_net_reconciliation_mismatch() -> None:
-    txn = _base_txn().model_copy(
-        update={
-            "withholding_tax_amount": Decimal("10"),
-            "other_interest_deductions_amount": Decimal("5"),
-            "net_interest_amount": Decimal("120"),
-        }
-    )
-    issues = validate_interest_transaction(txn)
-    assert any(
-        i.code == InterestValidationReasonCode.NET_INTEREST_RECONCILIATION_MISMATCH
-        for i in issues
-    )
-
-
-def test_validate_interest_transaction_accepts_reconciled_net_interest_amount() -> None:
-    txn = _base_txn().model_copy(
-        update={
-            "withholding_tax_amount": Decimal("10"),
-            "other_interest_deductions_amount": Decimal("5"),
-            "net_interest_amount": Decimal("108.45"),
-        }
-    )
-    issues = validate_interest_transaction(txn)
-    assert not any(
-        i.code == InterestValidationReasonCode.NET_INTEREST_RECONCILIATION_MISMATCH
-        for i in issues
-    )
-
-
 def test_validate_interest_transaction_detects_invalid_date_order() -> None:
     txn = _base_txn().model_copy(update={"transaction_date": datetime(2026, 3, 8, 10, 0, 0)})
     issues = validate_interest_transaction(txn)
@@ -217,16 +151,4 @@ def test_validate_interest_transaction_requires_settlement_cash_account_for_auto
     )
 
 
-def test_validate_interest_transaction_requires_settlement_cash_account_for_auto_mode() -> None:
-    txn = _base_txn().model_copy(
-        update={
-            "cash_entry_mode": "AUTO_GENERATE",
-            "settlement_cash_account_id": None,
-        }
-    )
-    issues = validate_interest_transaction(txn)
-    assert any(
-        i.code == InterestValidationReasonCode.MISSING_SETTLEMENT_CASH_ACCOUNT
-        for i in issues
-    )
 


### PR DESCRIPTION
## Summary
- remove duplicated interest validation test blocks introduced by overlap merges
- keep full coverage of direction, withholding, deductions, reconciliation, strict metadata, and cash-linkage checks
- improves test signal quality and avoids silent overwrite of duplicate test names

## Validation
- make lint
- make typecheck
- pytest tests/unit/libs/portfolio_common/test_interest_validation.py tests/unit/libs/portfolio_common/test_interest_linkage.py -q
