### PR TITLE
feat(rfc-081): add race-safe valuation readiness trigger path

### DIFF
--- a/docs/RFCs/RFC 081 - Lotus Core Microservice Boundary Optimization and Event-Orchestration Hardening.md
+++ b/docs/RFCs/RFC 081 - Lotus Core Microservice Boundary Optimization and Event-Orchestration Hardening.md
@@ -348,6 +348,8 @@ The highest-priority change is explicit event-gate orchestration. It delivers th
 - Added durable stage-state model:
   - `pipeline_stage_state` table + Alembic migration
   - repository upsert/merge behavior for independent prerequisite signals
+  - explicit collision guard to reject cross-portfolio key reuse
+    for `(stage_name, transaction_id, epoch)` before state mutation.
   - concurrency-safe claim transition to prevent duplicate readiness emission.
 - Added explicit event contract:
   - `TransactionProcessingCompletedEvent` in canonical event model.
@@ -360,6 +362,20 @@ The highest-priority change is explicit event-gate orchestration. It delivers th
   - gate epoch is applied before position calculation for deterministic replay alignment.
   - replay compatibility retained by continuing to accept `processed_transactions_completed`
     for epoch-based reprocessing emissions.
+- Added valuation-readiness trigger path:
+  - orchestrator emits `portfolio_day_ready_for_valuation` alongside transaction completion
+  - valuation service consumes readiness events and idempotently upserts valuation jobs.
+
+### 15.4 Race-condition safeguards applied in this slice
+
+- Stage completion emission remains single-claim via conditional transition
+  (`mark_stage_completed_if_pending`), preventing duplicate readiness publication.
+- Stage-state repository rejects cross-portfolio collision on shared
+  `(stage_name, transaction_id, epoch)` keys to avoid silent cross-talk.
+- Consumer idempotency (`processed_events`) is enforced before any state mutation
+  in orchestrator and valuation-readiness consumers.
+- Valuation readiness job creation is race-safe via `upsert_job` with
+  `ON CONFLICT DO UPDATE`, making duplicate readiness signals harmless.
 
 ### 15.2 Current scope boundary
 

--- a/src/services/pipeline_orchestrator_service/app/repositories/pipeline_stage_repository.py
+++ b/src/services/pipeline_orchestrator_service/app/repositories/pipeline_stage_repository.py
@@ -40,7 +40,7 @@ class PipelineStageRepository:
             .on_conflict_do_update(
                 index_elements=["stage_name", "transaction_id", "epoch"],
                 set_={
-                    "portfolio_id": portfolio_id,
+                    "portfolio_id": PipelineStageState.portfolio_id,
                     "security_id": security_id,
                     "business_date": business_date,
                     "cost_event_seen": PipelineStageState.cost_event_seen | cost_event_seen,
@@ -62,6 +62,12 @@ class PipelineStageRepository:
             .execution_options(populate_existing=True)
         )
         stage = result.scalar_one()
+        if stage.portfolio_id != portfolio_id:
+            raise ValueError(
+                "Pipeline stage key collision detected for different portfolios: "
+                f"{stage_name}/{transaction_id}/{epoch} "
+                f"existing={stage.portfolio_id} incoming={portfolio_id}"
+            )
         await self.db.refresh(stage)
         return stage
 

--- a/tests/integration/services/pipeline_orchestrator_service/test_int_pipeline_stage_repository.py
+++ b/tests/integration/services/pipeline_orchestrator_service/test_int_pipeline_stage_repository.py
@@ -75,3 +75,35 @@ async def test_mark_stage_completed_if_pending_is_idempotent(
     assert persisted is not None
     assert persisted.status == "COMPLETED"
     assert persisted.ready_emitted_at is not None
+
+
+async def test_upsert_stage_flags_rejects_cross_portfolio_collision(
+    async_db_session: AsyncSession, clean_db
+):
+    repo = PipelineStageRepository(async_db_session)
+
+    first = await repo.upsert_stage_flags(
+        stage_name="TRANSACTION_PROCESSING",
+        transaction_id="TXN-COLLIDE-1",
+        portfolio_id="PORT-INT-A",
+        security_id="SEC-INT-1",
+        business_date=date(2026, 3, 7),
+        epoch=0,
+        source_event_type="processed_transaction",
+        cost_event_seen=True,
+        cashflow_event_seen=False,
+    )
+    with pytest.raises(ValueError, match="Pipeline stage key collision detected"):
+        await repo.upsert_stage_flags(
+            stage_name="TRANSACTION_PROCESSING",
+            transaction_id="TXN-COLLIDE-1",
+            portfolio_id="PORT-INT-B",
+            security_id="SEC-INT-1",
+            business_date=date(2026, 3, 7),
+            epoch=0,
+            source_event_type="cashflow_calculated",
+            cost_event_seen=False,
+            cashflow_event_seen=True,
+        )
+    await async_db_session.commit()
+    assert first.id is not None


### PR DESCRIPTION
## Summary
Follow-up RFC 081 slice focused on race-safe valuation readiness triggering.

- emit `portfolio_day_ready_for_valuation` from pipeline orchestrator when transaction stage is completed
- add `PortfolioDayReadyForValuationEvent` canonical contract
- add valuation readiness consumer to upsert valuation jobs idempotently
- keep existing valuation scheduler logic intact (additive rollout)
- add unit coverage for new consumer and updated orchestrator emission behavior

## Race-condition safeguards
- single-claim stage completion transition remains enforced in orchestrator
- consumer idempotency guard at ingress (`processed_events`)
- valuation job creation is `ON CONFLICT DO UPDATE` idempotent upsert

## Validation
1. `python -m ruff check src/services/pipeline_orchestrator_service src/services/calculators/position_valuation_calculator src/libs/portfolio-common/portfolio_common tests/unit/services/pipeline_orchestrator_service tests/unit/services/calculators/position_valuation_calculator/consumers`
2. `python -m pytest -q tests/unit/services/pipeline_orchestrator_service/services/test_pipeline_orchestrator_service.py tests/unit/services/calculators/position_valuation_calculator/consumers/test_valuation_readiness_consumer.py`