### PR TITLE
feat(rfc-081): add valuation readiness gate wiring

### DIFF
--- a/docs/RFCs/RFC 081 - Lotus Core Microservice Boundary Optimization and Event-Orchestration Hardening.md
+++ b/docs/RFCs/RFC 081 - Lotus Core Microservice Boundary Optimization and Event-Orchestration Hardening.md
@@ -379,13 +379,15 @@ The highest-priority change is explicit event-gate orchestration. It delivers th
 
 ### 15.2 Current scope boundary
 
-- Implemented gate in this slice is `transaction_processing_completed` based on:
+- Implemented gates in this slice are:
+  - `transaction_processing_completed` based on:
   - processed transaction signal present
   - cashflow signal present.
-- Valuation-day and timeseries-day gate events remain in planned follow-on slices.
+  - `portfolio_day_ready_for_valuation` for security-scoped stage completions.
+- Valuation-day and timeseries-day completion gates remain in planned follow-on slices.
 
 ### 15.3 Remaining roadmap alignment
 
-- Keep `portfolio_day_ready_for_valuation`, `valuation_day_completed`,
-  `position_timeseries_day_completed`, and `portfolio_aggregation_day_completed`
+- Keep `valuation_day_completed`, `position_timeseries_day_completed`,
+  and `portfolio_aggregation_day_completed`
   as next-stage gates for subsequent RFC-081 slices.

--- a/docs/architecture/microservice-boundaries-and-trigger-matrix.md
+++ b/docs/architecture/microservice-boundaries-and-trigger-matrix.md
@@ -11,9 +11,9 @@ Source authority: RFC 081
 | `persistence_service` | Canonical persistence and completion publication | `portfolios`, `transactions`, `instruments`, `market_prices`, `fx_rates`, `business_dates` | Raw domain topics | `raw_transactions_completed`, `market_price_persisted` | Event |
 | `cost_calculator_service` | Cost basis and lot-state authority | `transaction_costs`, `position_lot_state`, `accrued_income_offset_state`, `position_state` | `raw_transactions_completed`, `transactions_reprocessing_requested` | `processed_transactions_completed` | Event |
 | `cashflow_calculator_service` | Cashflow rule/classification authority | `cashflows`, `cashflow_rules` | `raw_transactions_completed` | `cashflow_calculated` | Event |
-| `pipeline_orchestrator_service` | Stage-gate orchestrator for deterministic downstream readiness | `pipeline_stage_state` | `processed_transactions_completed`, `cashflow_calculated` | `transaction_processing_completed` | Event |
+| `pipeline_orchestrator_service` | Stage-gate orchestrator for deterministic downstream readiness | `pipeline_stage_state` | `processed_transactions_completed`, `cashflow_calculated` | `transaction_processing_completed`, `portfolio_day_ready_for_valuation` | Event |
 | `position_calculator_service` | Position history and snapshot materialization | `position_history`, `daily_position_snapshots`, `position_state` | `transaction_processing_completed`, `processed_transactions_completed` (replay path) | `daily_position_snapshot_persisted`, `transactions_reprocessing_requested` | Event |
-| `position_valuation_calculator` | Valuation scheduling and valuation computation | `portfolio_valuation_jobs`, `instrument_reprocessing_state`, `reprocessing_jobs` | `daily_position_snapshot_persisted`, `market_price_persisted`, `valuation_required` | `position_valued`, `valuation_required` | Event + scheduler |
+| `position_valuation_calculator` | Valuation scheduling and valuation computation | `portfolio_valuation_jobs`, `instrument_reprocessing_state`, `reprocessing_jobs` | `daily_position_snapshot_persisted`, `market_price_persisted`, `valuation_required`, `portfolio_day_ready_for_valuation` | `position_valued`, `valuation_required` | Event + scheduler |
 | `timeseries_generator_service` | Position and portfolio timeseries generation | `position_timeseries`, `portfolio_timeseries`, `portfolio_aggregation_jobs` | `position_valued`, `portfolio_aggregation_required` | `position_timeseries_generated`, `portfolio_timeseries_generated`, `portfolio_aggregation_required` | Event + scheduler |
 | `query_service` | Read-plane APIs and operational diagnostics | Read-only over canonical/calculator tables | HTTP API | N/A | API |
 
@@ -23,12 +23,12 @@ Source authority: RFC 081
 2. `cost_calculator_service` emits `processed_transactions_completed`.
 3. `cashflow_calculator_service` emits `cashflow_calculated`.
 4. `pipeline_orchestrator_service` waits until both signals are observed for `(stage_name, transaction_id, epoch)` and emits `transaction_processing_completed`.
+5. For security-scoped transactions, orchestrator also emits `portfolio_day_ready_for_valuation` to stage valuation jobs deterministically.
 
 ## Stage Gate Sequence (Planned in RFC 081)
 
-1. Extend orchestrator to emit `portfolio_day_ready_for_valuation`.
-2. Route valuation/timeseries stage transitions through orchestrator-issued readiness events.
-3. Keep all downstream calculators blind to source mode; calculators only react to canonical gate events.
+1. Route valuation/timeseries stage transitions through orchestrator-issued readiness events.
+2. Keep all downstream calculators blind to source mode; calculators only react to canonical gate events.
 
 ## Reliability Rules
 

--- a/src/libs/portfolio-common/portfolio_common/events.py
+++ b/src/libs/portfolio-common/portfolio_common/events.py
@@ -290,3 +290,19 @@ class TransactionProcessingCompletedEvent(BaseModel):
     stage_name: str = "TRANSACTION_PROCESSING"
     readiness_reason: str = "cost_and_cashflow_completed"
     correlation_id: Optional[str] = None
+
+
+class PortfolioDayReadyForValuationEvent(BaseModel):
+    """
+    Stage-gate event emitted when a portfolio-security business day is ready
+    for valuation scheduling.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    portfolio_id: str
+    security_id: str
+    valuation_date: date
+    epoch: int = 0
+    readiness_reason: str = "transaction_processing_completed"
+    correlation_id: Optional[str] = None

--- a/src/services/calculators/position_valuation_calculator/app/consumer_manager.py
+++ b/src/services/calculators/position_valuation_calculator/app/consumer_manager.py
@@ -7,6 +7,7 @@ import uvicorn
 from portfolio_common.config import (
     KAFKA_BOOTSTRAP_SERVERS,
     KAFKA_MARKET_PRICE_PERSISTED_TOPIC,
+    KAFKA_PORTFOLIO_DAY_READY_FOR_VALUATION_TOPIC,
     KAFKA_VALUATION_REQUIRED_TOPIC,
 )
 from portfolio_common.kafka_admin import ensure_topics_exist
@@ -17,6 +18,7 @@ from .consumers.price_event_consumer import PriceEventConsumer
 
 # --- END NEW IMPORTS ---
 from .consumers.valuation_consumer import ValuationConsumer
+from .consumers.valuation_readiness_consumer import ValuationReadinessConsumer
 
 # --- NEW IMPORTS ---
 from .core.reprocessing_worker import ReprocessingWorker
@@ -45,6 +47,14 @@ class ConsumerManager:
                 bootstrap_servers=KAFKA_BOOTSTRAP_SERVERS,
                 topic=KAFKA_VALUATION_REQUIRED_TOPIC,
                 group_id=f"{group_id}_jobs",
+                service_prefix=service_prefix,
+            )
+        )
+        self.consumers.append(
+            ValuationReadinessConsumer(
+                bootstrap_servers=KAFKA_BOOTSTRAP_SERVERS,
+                topic=KAFKA_PORTFOLIO_DAY_READY_FOR_VALUATION_TOPIC,
+                group_id=f"{group_id}_readiness",
                 service_prefix=service_prefix,
             )
         )

--- a/src/services/calculators/position_valuation_calculator/app/consumers/valuation_readiness_consumer.py
+++ b/src/services/calculators/position_valuation_calculator/app/consumers/valuation_readiness_consumer.py
@@ -1,0 +1,62 @@
+import json
+import logging
+
+from confluent_kafka import Message
+from portfolio_common.db import get_async_db_session
+from portfolio_common.events import PortfolioDayReadyForValuationEvent
+from portfolio_common.idempotency_repository import IdempotencyRepository
+from portfolio_common.kafka_consumer import BaseConsumer
+from portfolio_common.logging_utils import correlation_id_var
+from portfolio_common.valuation_job_repository import ValuationJobRepository
+from pydantic import ValidationError
+from sqlalchemy.exc import DBAPIError, IntegrityError
+from tenacity import before_log, retry, retry_if_exception_type, stop_after_attempt, wait_fixed
+
+logger = logging.getLogger(__name__)
+SERVICE_NAME = "valuation-readiness-consumer"
+
+
+class ValuationReadinessConsumer(BaseConsumer):
+    @retry(
+        wait=wait_fixed(2),
+        stop=stop_after_attempt(8),
+        before=before_log(logger, logging.INFO),
+        retry=retry_if_exception_type((DBAPIError, IntegrityError)),
+        reraise=True,
+    )
+    async def process_message(self, msg: Message):
+        value = msg.value().decode("utf-8")
+        event_id = f"{msg.topic()}-{msg.partition()}-{msg.offset()}"
+        correlation_id = correlation_id_var.get()
+
+        try:
+            event = PortfolioDayReadyForValuationEvent.model_validate(json.loads(value))
+
+            async for db in get_async_db_session():
+                async with db.begin():
+                    idempotency_repo = IdempotencyRepository(db)
+                    if await idempotency_repo.is_event_processed(event_id, SERVICE_NAME):
+                        return
+
+                    await ValuationJobRepository(db).upsert_job(
+                        portfolio_id=event.portfolio_id,
+                        security_id=event.security_id,
+                        valuation_date=event.valuation_date,
+                        epoch=event.epoch,
+                        correlation_id=correlation_id,
+                    )
+                    await idempotency_repo.mark_event_processed(
+                        event_id,
+                        event.portfolio_id,
+                        SERVICE_NAME,
+                        correlation_id,
+                    )
+        except (json.JSONDecodeError, ValidationError):
+            logger.error("Invalid valuation readiness payload; sending to DLQ.", exc_info=True)
+            await self._send_to_dlq_async(msg, ValueError("invalid payload"))
+        except (DBAPIError, IntegrityError):
+            logger.warning("DB error in valuation readiness consumer; retrying.")
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Unexpected valuation readiness consumer error.", exc_info=True)
+            await self._send_to_dlq_async(msg, exc)

--- a/src/services/pipeline_orchestrator_service/app/consumer_manager.py
+++ b/src/services/pipeline_orchestrator_service/app/consumer_manager.py
@@ -7,6 +7,7 @@ from portfolio_common.config import (
     KAFKA_BOOTSTRAP_SERVERS,
     KAFKA_CASHFLOW_CALCULATED_TOPIC,
     KAFKA_PERSISTENCE_DLQ_TOPIC,
+    KAFKA_PORTFOLIO_DAY_READY_FOR_VALUATION_TOPIC,
     KAFKA_PROCESSED_TRANSACTIONS_COMPLETED_TOPIC,
     KAFKA_TRANSACTION_PROCESSING_COMPLETED_TOPIC,
 )
@@ -55,6 +56,7 @@ class ConsumerManager:
     async def run(self):
         required_topics = [consumer.topic for consumer in self.consumers]
         required_topics.append(KAFKA_TRANSACTION_PROCESSING_COMPLETED_TOPIC)
+        required_topics.append(KAFKA_PORTFOLIO_DAY_READY_FOR_VALUATION_TOPIC)
         ensure_topics_exist(required_topics)
 
         signal.signal(signal.SIGINT, self._signal_handler)

--- a/src/services/pipeline_orchestrator_service/app/services/pipeline_orchestrator_service.py
+++ b/src/services/pipeline_orchestrator_service/app/services/pipeline_orchestrator_service.py
@@ -1,6 +1,10 @@
-from portfolio_common.config import KAFKA_TRANSACTION_PROCESSING_COMPLETED_TOPIC
+from portfolio_common.config import (
+    KAFKA_PORTFOLIO_DAY_READY_FOR_VALUATION_TOPIC,
+    KAFKA_TRANSACTION_PROCESSING_COMPLETED_TOPIC,
+)
 from portfolio_common.events import (
     CashflowCalculatedEvent,
+    PortfolioDayReadyForValuationEvent,
     TransactionEvent,
     TransactionProcessingCompletedEvent,
 )
@@ -76,3 +80,22 @@ class PipelineOrchestratorService:
             payload=completion_event.model_dump(mode="json"),
             correlation_id=correlation_id,
         )
+
+        if stage.security_id:
+            readiness_event = PortfolioDayReadyForValuationEvent(
+                portfolio_id=stage.portfolio_id,
+                security_id=stage.security_id,
+                valuation_date=stage.business_date,
+                epoch=stage.epoch,
+                correlation_id=correlation_id,
+            )
+            await self.outbox_repo.create_outbox_event(
+                aggregate_type="ValuationReadiness",
+                aggregate_id=(
+                    f"{stage.portfolio_id}:{stage.security_id}:{stage.business_date}:{stage.epoch}"
+                ),
+                event_type="PortfolioDayReadyForValuation",
+                topic=KAFKA_PORTFOLIO_DAY_READY_FOR_VALUATION_TOPIC,
+                payload=readiness_event.model_dump(mode="json"),
+                correlation_id=correlation_id,
+            )

--- a/tests/unit/services/calculators/position_valuation_calculator/consumers/test_valuation_readiness_consumer.py
+++ b/tests/unit/services/calculators/position_valuation_calculator/consumers/test_valuation_readiness_consumer.py
@@ -1,0 +1,132 @@
+import json
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from portfolio_common.events import PortfolioDayReadyForValuationEvent
+from portfolio_common.idempotency_repository import IdempotencyRepository
+from portfolio_common.valuation_job_repository import ValuationJobRepository
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from services.calculators.position_valuation_calculator.app.consumers.valuation_readiness_consumer import (  # noqa: E501
+    SERVICE_NAME,
+    ValuationReadinessConsumer,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def consumer() -> ValuationReadinessConsumer:
+    c = ValuationReadinessConsumer(
+        bootstrap_servers="mock_server",
+        topic="portfolio_day_ready_for_valuation",
+        group_id="test_group",
+    )
+    c._send_to_dlq_async = AsyncMock()
+    return c
+
+
+@pytest.fixture
+def mock_event() -> PortfolioDayReadyForValuationEvent:
+    return PortfolioDayReadyForValuationEvent(
+        portfolio_id="PORT-VAL-1",
+        security_id="SEC-VAL-1",
+        valuation_date=date(2026, 3, 7),
+        epoch=0,
+    )
+
+
+@pytest.fixture
+def mock_kafka_message(mock_event: PortfolioDayReadyForValuationEvent) -> MagicMock:
+    msg = MagicMock()
+    msg.value.return_value = mock_event.model_dump_json().encode("utf-8")
+    msg.key.return_value = b"PORT-VAL-1:SEC-VAL-1"
+    msg.topic.return_value = "portfolio_day_ready_for_valuation"
+    msg.partition.return_value = 0
+    msg.offset.return_value = 1
+    msg.headers.return_value = []
+    return msg
+
+
+@pytest.fixture
+def mock_dependencies():
+    mock_idempotency_repo = AsyncMock(spec=IdempotencyRepository)
+    mock_job_repo = AsyncMock(spec=ValuationJobRepository)
+    mock_db_session = AsyncMock(spec=AsyncSession)
+    mock_db_session.begin.return_value = AsyncMock()
+
+    async def get_session_gen():
+        yield mock_db_session
+
+    with (
+        patch(
+            "services.calculators.position_valuation_calculator.app.consumers.valuation_readiness_consumer.get_async_db_session",  # noqa: E501
+            new=get_session_gen,
+        ),
+        patch(
+            "services.calculators.position_valuation_calculator.app.consumers.valuation_readiness_consumer.IdempotencyRepository",  # noqa: E501
+            return_value=mock_idempotency_repo,
+        ),
+        patch(
+            "services.calculators.position_valuation_calculator.app.consumers.valuation_readiness_consumer.ValuationJobRepository",  # noqa: E501
+            return_value=mock_job_repo,
+        ),
+    ):
+        yield {"idempotency_repo": mock_idempotency_repo, "job_repo": mock_job_repo}
+
+
+async def test_readiness_event_upserts_valuation_job_and_marks_idempotency(
+    consumer: ValuationReadinessConsumer,
+    mock_kafka_message: MagicMock,
+    mock_event: PortfolioDayReadyForValuationEvent,
+    mock_dependencies: dict,
+):
+    mock_idempotency_repo = mock_dependencies["idempotency_repo"]
+    mock_job_repo = mock_dependencies["job_repo"]
+    mock_idempotency_repo.is_event_processed.return_value = False
+
+    await consumer.process_message(mock_kafka_message)
+
+    mock_job_repo.upsert_job.assert_awaited_once()
+    job_kwargs = mock_job_repo.upsert_job.await_args.kwargs
+    assert job_kwargs["portfolio_id"] == mock_event.portfolio_id
+    assert job_kwargs["security_id"] == mock_event.security_id
+    assert job_kwargs["valuation_date"] == mock_event.valuation_date
+    assert job_kwargs["epoch"] == mock_event.epoch
+    assert isinstance(job_kwargs["correlation_id"], str)
+
+    mock_idempotency_repo.mark_event_processed.assert_awaited_once()
+    mark_args = mock_idempotency_repo.mark_event_processed.await_args.args
+    assert mark_args[0] == "portfolio_day_ready_for_valuation-0-1"
+    assert mark_args[1] == mock_event.portfolio_id
+    assert mark_args[2] == SERVICE_NAME
+
+
+async def test_readiness_event_is_noop_when_already_processed(
+    consumer: ValuationReadinessConsumer,
+    mock_kafka_message: MagicMock,
+    mock_dependencies: dict,
+):
+    mock_idempotency_repo = mock_dependencies["idempotency_repo"]
+    mock_job_repo = mock_dependencies["job_repo"]
+    mock_idempotency_repo.is_event_processed.return_value = True
+
+    await consumer.process_message(mock_kafka_message)
+
+    mock_job_repo.upsert_job.assert_not_called()
+    mock_idempotency_repo.mark_event_processed.assert_not_called()
+
+
+async def test_invalid_payload_is_sent_to_dlq(consumer: ValuationReadinessConsumer):
+    msg = MagicMock()
+    msg.value.return_value = json.dumps({"portfolio_id": "x"}).encode("utf-8")
+    msg.key.return_value = b"bad"
+    msg.topic.return_value = "portfolio_day_ready_for_valuation"
+    msg.partition.return_value = 0
+    msg.offset.return_value = 2
+    msg.headers.return_value = []
+
+    await consumer.process_message(msg)
+
+    consumer._send_to_dlq_async.assert_awaited_once()

--- a/tests/unit/services/pipeline_orchestrator_service/services/test_pipeline_orchestrator_service.py
+++ b/tests/unit/services/pipeline_orchestrator_service/services/test_pipeline_orchestrator_service.py
@@ -111,11 +111,15 @@ async def test_cost_and_cashflow_signals_emit_single_completion_event():
     await service.register_processed_transaction(_txn_event(), correlation_id="corr-2")
     await service.register_cashflow_calculated(_cashflow_event(), correlation_id="corr-2")
 
-    outbox_repo.create_outbox_event.assert_awaited_once()
-    payload = outbox_repo.create_outbox_event.await_args.kwargs["payload"]
-    assert payload["transaction_id"] == "TXN-PIPE-1"
-    assert payload["stage_name"] == "TRANSACTION_PROCESSING"
-    assert payload["readiness_reason"] == "cost_and_cashflow_completed"
+    assert outbox_repo.create_outbox_event.await_count == 2
+    calls = outbox_repo.create_outbox_event.await_args_list
+    completion_payload = calls[0].kwargs["payload"]
+    readiness_payload = calls[1].kwargs["payload"]
+    assert completion_payload["transaction_id"] == "TXN-PIPE-1"
+    assert completion_payload["stage_name"] == "TRANSACTION_PROCESSING"
+    assert completion_payload["readiness_reason"] == "cost_and_cashflow_completed"
+    assert readiness_payload["portfolio_id"] == "PORT-1"
+    assert readiness_payload["security_id"] == "SEC-1"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary\n- restore and formalize portfolio_day_ready_for_valuation stage-gate event contract\n- emit valuation-readiness outbox event from pipeline orchestrator after transaction gate claim\n- add valuation readiness consumer to stage valuation jobs idempotently via upsert\n- wire consumer into valuation service manager and ensure topic creation\n- update RFC 081 + trigger matrix docs to reflect current implementation\n\n## Race-condition safeguards\n- readiness emission remains protected by single-claim stage transition\n- consumer-level idempotency check before any mutation\n- valuation job staging uses upsert semantics (ON CONFLICT)\n\n## Validation\n- ruff check on changed modules\n- pytest:\n  - tests/unit/services/pipeline_orchestrator_service/services/test_pipeline_orchestrator_service.py\n  - tests/unit/services/calculators/position_valuation_calculator/consumers/test_valuation_readiness_consumer.py\n  - tests/unit/services/calculators/position_calculator/consumers/test_position_calculator_consumer.py