### PR TITLE
fix(cashflow): make rule cache refresh race-safe

### DIFF
--- a/src/services/calculators/cashflow_calculator_service/app/consumers/transaction_consumer.py
+++ b/src/services/calculators/cashflow_calculator_service/app/consumers/transaction_consumer.py
@@ -1,4 +1,5 @@
 # services/calculators/cashflow_calculator_service/app/consumers/transaction_consumer.py
+import asyncio
 import json
 import logging
 import time
@@ -47,6 +48,7 @@ class CashflowRuleCacheState:
 
 # Module-level cache for cashflow rules.
 _cashflow_rule_cache_state: Optional[CashflowRuleCacheState] = None
+_cashflow_rule_cache_lock: Optional[asyncio.Lock] = None
 
 
 def invalidate_cashflow_rule_cache() -> None:
@@ -58,6 +60,13 @@ def invalidate_cashflow_rule_cache() -> None:
     """
     global _cashflow_rule_cache_state
     _cashflow_rule_cache_state = None
+
+
+def _get_cashflow_rule_cache_lock() -> asyncio.Lock:
+    global _cashflow_rule_cache_lock
+    if _cashflow_rule_cache_lock is None:
+        _cashflow_rule_cache_lock = asyncio.Lock()
+    return _cashflow_rule_cache_lock
 
 
 def _cache_is_fresh(cache_state: CashflowRuleCacheState) -> bool:
@@ -106,23 +115,33 @@ class CashflowCalculatorConsumer(BaseConsumer):
         """
         global _cashflow_rule_cache_state
 
-        if _cashflow_rule_cache_state is None or not _cache_is_fresh(_cashflow_rule_cache_state):
-            logger.info("Cashflow rules cache miss/stale; refreshing from database.")
-            _cashflow_rule_cache_state = await self._load_cashflow_rules_cache(db_session)
-
         transaction_type_key = transaction_type.upper()
-        rule = _cashflow_rule_cache_state.rules_by_transaction_type.get(transaction_type_key)
-        if rule is not None:
-            return rule
+        cache_state = _cashflow_rule_cache_state
+        if cache_state is not None and _cache_is_fresh(cache_state):
+            rule = cache_state.rules_by_transaction_type.get(transaction_type_key)
+            if rule is not None:
+                return rule
 
-        # Force one immediate refresh when a requested rule is missing.
-        # This supports near-real-time rule updates without waiting for TTL expiry.
-        logger.info(
-            "Cashflow rule '%s' not found in cache; forcing immediate refresh.",
-            transaction_type_key,
-        )
-        _cashflow_rule_cache_state = await self._load_cashflow_rules_cache(db_session)
-        return _cashflow_rule_cache_state.rules_by_transaction_type.get(transaction_type_key)
+        lock = _get_cashflow_rule_cache_lock()
+        async with lock:
+            cache_state = _cashflow_rule_cache_state
+            if cache_state is None or not _cache_is_fresh(cache_state):
+                logger.info("Cashflow rules cache miss/stale; refreshing from database.")
+                _cashflow_rule_cache_state = await self._load_cashflow_rules_cache(db_session)
+                cache_state = _cashflow_rule_cache_state
+
+            rule = cache_state.rules_by_transaction_type.get(transaction_type_key)
+            if rule is not None:
+                return rule
+
+            # Force one immediate refresh when a requested rule is missing.
+            # This supports near-real-time rule updates without waiting for TTL expiry.
+            logger.info(
+                "Cashflow rule '%s' not found in cache; forcing immediate refresh.",
+                transaction_type_key,
+            )
+            _cashflow_rule_cache_state = await self._load_cashflow_rules_cache(db_session)
+            return _cashflow_rule_cache_state.rules_by_transaction_type.get(transaction_type_key)
 
     async def process_message(self, msg: Message):
         await self._process_message_with_retry(msg)

--- a/tests/unit/services/calculators/cashflow_calculator_service/unit/consumers/test_cashflow_transaction_consumer.py
+++ b/tests/unit/services/calculators/cashflow_calculator_service/unit/consumers/test_cashflow_transaction_consumer.py
@@ -1,4 +1,5 @@
 # tests/unit/services/calculators/cashflow_calculator_service/unit/consumers/test_cashflow_transaction_consumer.py  # noqa: E501
+import asyncio
 from datetime import date, datetime
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -35,6 +36,7 @@ def reset_cache():
     )
 
     transaction_consumer._cashflow_rule_cache_state = None
+    transaction_consumer._cashflow_rule_cache_lock = None
     yield
 
 
@@ -312,7 +314,7 @@ async def test_get_rule_for_transaction_uses_ttl_cache_then_refreshes(
         ),
         patch(
             "src.services.calculators.cashflow_calculator_service.app.consumers.transaction_consumer.time.monotonic",
-            side_effect=[10.0, 20.0, 1200.0, 1210.0],
+            side_effect=[10.0, 11.0, 400.0, 401.0, 402.0, 403.0],
         ),
     ):
         first_rule = await cashflow_consumer._get_rule_for_transaction(mock_db_session, "BUY")
@@ -823,3 +825,42 @@ async def test_process_message_cash_consideration_missing_parent_reference_sends
     mock_outbox_repo.create_outbox_event.assert_not_called()
     mock_idempotency_repo.mark_event_processed.assert_not_called()
     cashflow_consumer._send_to_dlq_async.assert_awaited_once()
+
+
+async def test_get_rule_for_transaction_concurrent_refresh_loads_rules_once(
+    cashflow_consumer: CashflowCalculatorConsumer,
+):
+    from src.services.calculators.cashflow_calculator_service.app.consumers import (
+        transaction_consumer,
+    )
+
+    mock_db_session = AsyncMock(spec=AsyncSession)
+    rules_repo = AsyncMock(spec=CashflowRulesRepository)
+    rules_repo.get_all_rules.return_value = [
+        CashflowRule(
+            transaction_type="BUY",
+            classification="INVESTMENT_OUTFLOW",
+            timing="BOD",
+            is_position_flow=True,
+            is_portfolio_flow=False,
+        )
+    ]
+
+    with (
+        patch.object(transaction_consumer, "CASHFLOW_RULE_CACHE_TTL_SECONDS", 3600),
+        patch(
+            "src.services.calculators.cashflow_calculator_service.app.consumers.transaction_consumer.CashflowRulesRepository",
+            return_value=rules_repo,
+        ),
+        patch(
+            "src.services.calculators.cashflow_calculator_service.app.consumers.transaction_consumer.time.monotonic",
+            side_effect=[100.0, 101.0, 102.0, 103.0, 104.0, 105.0],
+        ),
+    ):
+        results = await asyncio.gather(
+            cashflow_consumer._get_rule_for_transaction(mock_db_session, "BUY"),
+            cashflow_consumer._get_rule_for_transaction(mock_db_session, "BUY"),
+        )
+        assert results[0] is not None
+        assert results[1] is not None
+        assert rules_repo.get_all_rules.await_count == 1


### PR DESCRIPTION
## Summary\n- add async lock around shared cashflow-rule cache refresh path\n- keep lazy TTL + forced-missing-rule refresh behavior unchanged\n- prevent concurrent message races from triggering duplicated rule reloads\n- add unit coverage proving concurrent callers perform a single repository load\n\n## Validation\n- ruff check on changed files\n- pytest:\n  - tests/unit/services/calculators/cashflow_calculator_service/unit/consumers/test_cashflow_transaction_consumer.py\n  - tests/unit/services/calculators/cashflow_calculator_service/unit/core/test_cashflow_logic.py\n  - tests/unit/services/calculators/cashflow_calculator_service/unit/repositories/test_cashflow_rules_repository.py