### PR TITLE
refactor(rfc-081): centralize runtime supervision helper

### DIFF
--- a/docs/RFCs/RFC 081 - Lotus Core Microservice Boundary Optimization and Event-Orchestration Hardening.md
+++ b/docs/RFCs/RFC 081 - Lotus Core Microservice Boundary Optimization and Event-Orchestration Hardening.md
@@ -406,6 +406,10 @@ The highest-priority change is explicit event-gate orchestration. It delivers th
   gated/replay consumers, outbox dispatcher, and web server tasks.
 - Cost calculation runtime now applies fail-fast supervision for
   core/reprocessing consumers, outbox dispatcher, and web server tasks.
+- Runtime supervision logic is now centralized in shared
+  `portfolio_common.runtime_supervision.wait_for_shutdown_or_task_failure`,
+  removing duplicated lifecycle logic across service managers and reducing
+  maintenance and drift risk.
 
 ### 15.2 Current scope boundary
 

--- a/src/libs/portfolio-common/portfolio_common/runtime_supervision.py
+++ b/src/libs/portfolio-common/portfolio_common/runtime_supervision.py
@@ -1,0 +1,54 @@
+import asyncio
+import contextlib
+from collections.abc import Sequence
+
+
+async def wait_for_shutdown_or_task_failure(
+    *,
+    tasks: Sequence[asyncio.Task],
+    shutdown_event: asyncio.Event,
+    logger,
+) -> RuntimeError | None:
+    """
+    Wait until an explicit shutdown signal arrives or a critical runtime task exits.
+
+    Returns:
+    - None when shutdown was explicitly requested.
+    - RuntimeError when a critical task exited unexpectedly.
+    """
+    if not tasks:
+        await shutdown_event.wait()
+        return None
+
+    shutdown_wait_task = asyncio.create_task(shutdown_event.wait(), name="shutdown-wait")
+    try:
+        done, _ = await asyncio.wait(
+            [*tasks, shutdown_wait_task],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if shutdown_wait_task in done:
+            return None
+
+        failed_task = next(iter(done))
+        task_name = failed_task.get_name() or "unnamed-task"
+        if failed_task.cancelled():
+            runtime_error = RuntimeError(
+                f"Critical service task '{task_name}' was cancelled unexpectedly."
+            )
+        else:
+            task_error = failed_task.exception()
+            if task_error is None:
+                runtime_error = RuntimeError(
+                    f"Critical service task '{task_name}' exited unexpectedly."
+                )
+            else:
+                runtime_error = RuntimeError(f"Critical service task '{task_name}' failed.")
+                runtime_error.__cause__ = task_error
+
+        logger.error("Critical runtime task failure detected; initiating shutdown.")
+        shutdown_event.set()
+        return runtime_error
+    finally:
+        shutdown_wait_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await shutdown_wait_task

--- a/src/services/calculators/cashflow_calculator_service/app/consumer_manager.py
+++ b/src/services/calculators/cashflow_calculator_service/app/consumer_manager.py
@@ -12,6 +12,7 @@ from portfolio_common.config import (
 from portfolio_common.kafka_admin import ensure_topics_exist
 from portfolio_common.kafka_utils import get_kafka_producer
 from portfolio_common.outbox_dispatcher import OutboxDispatcher
+from portfolio_common.runtime_supervision import wait_for_shutdown_or_task_failure
 
 from .consumers.transaction_consumer import CashflowCalculatorConsumer
 from .web import app as web_app
@@ -68,31 +69,11 @@ class ConsumerManager:
         self.tasks.append(asyncio.create_task(server.serve()))
 
         logger.info("ConsumerManager is running. Press Ctrl+C to exit.")
-        shutdown_wait_task = asyncio.create_task(self._shutdown_event.wait())
-        runtime_error = None
-
-        done, _ = await asyncio.wait(
-            [*self.tasks, shutdown_wait_task],
-            return_when=asyncio.FIRST_COMPLETED,
+        runtime_error = await wait_for_shutdown_or_task_failure(
+            tasks=self.tasks,
+            shutdown_event=self._shutdown_event,
+            logger=logger,
         )
-        if shutdown_wait_task not in done:
-            failed_task = next(iter(done))
-            task_name = failed_task.get_name() or "unnamed-task"
-            if failed_task.cancelled():
-                runtime_error = RuntimeError(
-                    f"Critical service task '{task_name}' was cancelled unexpectedly."
-                )
-            else:
-                task_error = failed_task.exception()
-                if task_error is None:
-                    runtime_error = RuntimeError(
-                        f"Critical service task '{task_name}' exited unexpectedly."
-                    )
-                else:
-                    runtime_error = RuntimeError(f"Critical service task '{task_name}' failed.")
-                    runtime_error.__cause__ = task_error
-            logger.error("Critical runtime task failure detected; initiating shutdown.")
-            self._shutdown_event.set()
 
         logger.info("Shutdown event received. Stopping all tasks...")
         for consumer in self.consumers:
@@ -101,7 +82,6 @@ class ConsumerManager:
         self.dispatcher.stop()
         server.should_exit = True
 
-        shutdown_wait_task.cancel()
         await asyncio.gather(*self.tasks, return_exceptions=True)
         logger.info("All tasks have been successfully shut down.")
         if runtime_error is not None:

--- a/src/services/calculators/cost_calculator_service/app/consumer_manager.py
+++ b/src/services/calculators/cost_calculator_service/app/consumer_manager.py
@@ -12,6 +12,7 @@ from portfolio_common.config import (
 from portfolio_common.kafka_admin import ensure_topics_exist
 from portfolio_common.kafka_utils import get_kafka_producer
 from portfolio_common.outbox_dispatcher import OutboxDispatcher
+from portfolio_common.runtime_supervision import wait_for_shutdown_or_task_failure
 
 from .consumer import CostCalculatorConsumer
 from .consumers.reprocessing_consumer import REPROCESSING_REQUESTED_TOPIC, ReprocessingConsumer
@@ -80,30 +81,11 @@ class ConsumerManager:
         self.tasks.append(asyncio.create_task(server.serve()))
 
         logger.info("ConsumerManager is running. Press Ctrl+C to exit.")
-        shutdown_wait_task = asyncio.create_task(self._shutdown_event.wait())
-        runtime_error = None
-
-        done, _ = await asyncio.wait(
-            [*self.tasks, shutdown_wait_task], return_when=asyncio.FIRST_COMPLETED
+        runtime_error = await wait_for_shutdown_or_task_failure(
+            tasks=self.tasks,
+            shutdown_event=self._shutdown_event,
+            logger=logger,
         )
-        if shutdown_wait_task not in done:
-            failed_task = next(iter(done))
-            task_name = failed_task.get_name() or "unnamed-task"
-            if failed_task.cancelled():
-                runtime_error = RuntimeError(
-                    f"Critical service task '{task_name}' was cancelled unexpectedly."
-                )
-            else:
-                task_error = failed_task.exception()
-                if task_error is None:
-                    runtime_error = RuntimeError(
-                        f"Critical service task '{task_name}' exited unexpectedly."
-                    )
-                else:
-                    runtime_error = RuntimeError(f"Critical service task '{task_name}' failed.")
-                    runtime_error.__cause__ = task_error
-            logger.error("Critical runtime task failure detected; initiating shutdown.")
-            self._shutdown_event.set()
 
         logger.info("Shutdown event received. Stopping all tasks...")
         for consumer in self.consumers:
@@ -112,7 +94,6 @@ class ConsumerManager:
         self.dispatcher.stop()
         server.should_exit = True
 
-        shutdown_wait_task.cancel()
         await asyncio.gather(*self.tasks, return_exceptions=True)
         logger.info("All consumer and dispatcher tasks have been successfully shut down.")
         if runtime_error is not None:

--- a/src/services/calculators/position_calculator/app/consumer_manager.py
+++ b/src/services/calculators/position_calculator/app/consumer_manager.py
@@ -13,6 +13,7 @@ from portfolio_common.config import (
 from portfolio_common.kafka_admin import ensure_topics_exist
 from portfolio_common.kafka_utils import get_kafka_producer
 from portfolio_common.outbox_dispatcher import OutboxDispatcher
+from portfolio_common.runtime_supervision import wait_for_shutdown_or_task_failure
 
 from .consumers.transaction_event_consumer import TransactionEventConsumer
 from .web import app as web_app  # NEW IMPORT
@@ -81,30 +82,11 @@ class ConsumerManager:
         self.tasks.append(asyncio.create_task(server.serve()))
 
         logger.info("ConsumerManager is running. Press Ctrl+C to exit.")
-        shutdown_wait_task = asyncio.create_task(self._shutdown_event.wait())
-        runtime_error = None
-
-        done, _ = await asyncio.wait(
-            [*self.tasks, shutdown_wait_task], return_when=asyncio.FIRST_COMPLETED
+        runtime_error = await wait_for_shutdown_or_task_failure(
+            tasks=self.tasks,
+            shutdown_event=self._shutdown_event,
+            logger=logger,
         )
-        if shutdown_wait_task not in done:
-            failed_task = next(iter(done))
-            task_name = failed_task.get_name() or "unnamed-task"
-            if failed_task.cancelled():
-                runtime_error = RuntimeError(
-                    f"Critical service task '{task_name}' was cancelled unexpectedly."
-                )
-            else:
-                task_error = failed_task.exception()
-                if task_error is None:
-                    runtime_error = RuntimeError(
-                        f"Critical service task '{task_name}' exited unexpectedly."
-                    )
-                else:
-                    runtime_error = RuntimeError(f"Critical service task '{task_name}' failed.")
-                    runtime_error.__cause__ = task_error
-            logger.error("Critical runtime task failure detected; initiating shutdown.")
-            self._shutdown_event.set()
 
         logger.info("Shutdown event received. Stopping all tasks...")
         for consumer in self.consumers:
@@ -113,7 +95,6 @@ class ConsumerManager:
         self.dispatcher.stop()
         server.should_exit = True
 
-        shutdown_wait_task.cancel()
         await asyncio.gather(*self.tasks, return_exceptions=True)
         logger.info("All tasks have been successfully shut down.")
         if runtime_error is not None:

--- a/src/services/calculators/position_valuation_calculator/app/consumer_manager.py
+++ b/src/services/calculators/position_valuation_calculator/app/consumer_manager.py
@@ -13,6 +13,7 @@ from portfolio_common.config import (
 from portfolio_common.kafka_admin import ensure_topics_exist
 from portfolio_common.kafka_utils import get_kafka_producer
 from portfolio_common.outbox_dispatcher import OutboxDispatcher
+from portfolio_common.runtime_supervision import wait_for_shutdown_or_task_failure
 
 from .consumers.price_event_consumer import PriceEventConsumer
 
@@ -114,30 +115,11 @@ class ConsumerManager:
         self.tasks.append(asyncio.create_task(server.serve()))
 
         logger.info("ConsumerManager is running. Press Ctrl+C to exit.")
-        shutdown_wait_task = asyncio.create_task(self._shutdown_event.wait())
-        runtime_error = None
-
-        done, _ = await asyncio.wait(
-            [*self.tasks, shutdown_wait_task], return_when=asyncio.FIRST_COMPLETED
+        runtime_error = await wait_for_shutdown_or_task_failure(
+            tasks=self.tasks,
+            shutdown_event=self._shutdown_event,
+            logger=logger,
         )
-        if shutdown_wait_task not in done:
-            failed_task = next(iter(done))
-            task_name = failed_task.get_name() or "unnamed-task"
-            if failed_task.cancelled():
-                runtime_error = RuntimeError(
-                    f"Critical service task '{task_name}' was cancelled unexpectedly."
-                )
-            else:
-                task_error = failed_task.exception()
-                if task_error is None:
-                    runtime_error = RuntimeError(
-                        f"Critical service task '{task_name}' exited unexpectedly."
-                    )
-                else:
-                    runtime_error = RuntimeError(f"Critical service task '{task_name}' failed.")
-                    runtime_error.__cause__ = task_error
-            logger.error("Critical runtime task failure detected; initiating shutdown.")
-            self._shutdown_event.set()
 
         logger.info("Shutdown event received. Stopping all tasks...")
         for consumer in self.consumers:
@@ -149,7 +131,6 @@ class ConsumerManager:
         self.reprocessing_worker.stop()
         server.should_exit = True
 
-        shutdown_wait_task.cancel()
         await asyncio.gather(*self.tasks, return_exceptions=True)
         logger.info(
             "All consumer, dispatcher, and web server tasks have been successfully shut down."

--- a/src/services/persistence_service/app/consumer_manager.py
+++ b/src/services/persistence_service/app/consumer_manager.py
@@ -17,6 +17,7 @@ from portfolio_common.config import (
 from portfolio_common.kafka_admin import ensure_topics_exist
 from portfolio_common.kafka_utils import get_kafka_producer
 from portfolio_common.outbox_dispatcher import OutboxDispatcher
+from portfolio_common.runtime_supervision import wait_for_shutdown_or_task_failure
 
 from .consumers.business_date_consumer import BusinessDateConsumer
 from .consumers.fx_rate_consumer import FxRateConsumer
@@ -138,30 +139,11 @@ class ConsumerManager:
         self.tasks.append(asyncio.create_task(server.serve()))
 
         logger.info("ConsumerManager is running. Press Ctrl+C to exit.")
-        shutdown_wait_task = asyncio.create_task(self._shutdown_event.wait())
-        runtime_error = None
-
-        done, _ = await asyncio.wait(
-            [*self.tasks, shutdown_wait_task], return_when=asyncio.FIRST_COMPLETED
+        runtime_error = await wait_for_shutdown_or_task_failure(
+            tasks=self.tasks,
+            shutdown_event=self._shutdown_event,
+            logger=logger,
         )
-        if shutdown_wait_task not in done:
-            failed_task = next(iter(done))
-            task_name = failed_task.get_name() or "unnamed-task"
-            if failed_task.cancelled():
-                runtime_error = RuntimeError(
-                    f"Critical service task '{task_name}' was cancelled unexpectedly."
-                )
-            else:
-                task_error = failed_task.exception()
-                if task_error is None:
-                    runtime_error = RuntimeError(
-                        f"Critical service task '{task_name}' exited unexpectedly."
-                    )
-                else:
-                    runtime_error = RuntimeError(f"Critical service task '{task_name}' failed.")
-                    runtime_error.__cause__ = task_error
-            logger.error("Critical runtime task failure detected; initiating shutdown.")
-            self._shutdown_event.set()
 
         logger.info("Shutdown event received. Stopping all tasks...")
         for consumer in self.consumers:
@@ -170,7 +152,6 @@ class ConsumerManager:
         self.dispatcher.stop()
         server.should_exit = True
 
-        shutdown_wait_task.cancel()
         await asyncio.gather(*self.tasks, return_exceptions=True)
         logger.info(
             "All consumer, dispatcher, and web server tasks have been successfully shut down."

--- a/src/services/pipeline_orchestrator_service/app/consumer_manager.py
+++ b/src/services/pipeline_orchestrator_service/app/consumer_manager.py
@@ -14,6 +14,7 @@ from portfolio_common.config import (
 from portfolio_common.kafka_admin import ensure_topics_exist
 from portfolio_common.kafka_utils import get_kafka_producer
 from portfolio_common.outbox_dispatcher import OutboxDispatcher
+from portfolio_common.runtime_supervision import wait_for_shutdown_or_task_failure
 
 from .consumers.cashflow_stage_consumer import CashflowStageConsumer
 from .consumers.processed_transaction_stage_consumer import ProcessedTransactionStageConsumer
@@ -69,37 +70,17 @@ class ConsumerManager:
         self.tasks.append(asyncio.create_task(self.dispatcher.run()))
         self.tasks.append(asyncio.create_task(server.serve()))
 
-        shutdown_wait_task = asyncio.create_task(self._shutdown_event.wait())
-        runtime_error = None
-
-        done, _ = await asyncio.wait(
-            [*self.tasks, shutdown_wait_task], return_when=asyncio.FIRST_COMPLETED
+        runtime_error = await wait_for_shutdown_or_task_failure(
+            tasks=self.tasks,
+            shutdown_event=self._shutdown_event,
+            logger=logger,
         )
-        if shutdown_wait_task not in done:
-            failed_task = next(iter(done))
-            task_name = failed_task.get_name() or "unnamed-task"
-            if failed_task.cancelled():
-                runtime_error = RuntimeError(
-                    f"Critical service task '{task_name}' was cancelled unexpectedly."
-                )
-            else:
-                task_error = failed_task.exception()
-                if task_error is None:
-                    runtime_error = RuntimeError(
-                        f"Critical service task '{task_name}' exited unexpectedly."
-                    )
-                else:
-                    runtime_error = RuntimeError(f"Critical service task '{task_name}' failed.")
-                    runtime_error.__cause__ = task_error
-            logger.error("Critical runtime task failure detected; initiating shutdown.")
-            self._shutdown_event.set()
 
         for consumer in self.consumers:
             consumer.shutdown()
         self.dispatcher.stop()
         server.should_exit = True
 
-        shutdown_wait_task.cancel()
         await asyncio.gather(*self.tasks, return_exceptions=True)
         if runtime_error is not None:
             raise runtime_error

--- a/src/services/timeseries_generator_service/app/consumer_manager.py
+++ b/src/services/timeseries_generator_service/app/consumer_manager.py
@@ -15,6 +15,7 @@ from portfolio_common.config import (
 from portfolio_common.kafka_admin import ensure_topics_exist
 from portfolio_common.kafka_utils import get_kafka_producer
 from portfolio_common.outbox_dispatcher import OutboxDispatcher
+from portfolio_common.runtime_supervision import wait_for_shutdown_or_task_failure
 
 from .consumers.portfolio_timeseries_consumer import PortfolioTimeseriesConsumer
 from .consumers.position_timeseries_consumer import PositionTimeseriesConsumer
@@ -100,30 +101,11 @@ class ConsumerManager:
         self.tasks.append(asyncio.create_task(server.serve()))
 
         logger.info("ConsumerManager is running. Press Ctrl+C to exit.")
-        shutdown_wait_task = asyncio.create_task(self._shutdown_event.wait())
-        runtime_error = None
-
-        done, _ = await asyncio.wait(
-            [*self.tasks, shutdown_wait_task], return_when=asyncio.FIRST_COMPLETED
+        runtime_error = await wait_for_shutdown_or_task_failure(
+            tasks=self.tasks,
+            shutdown_event=self._shutdown_event,
+            logger=logger,
         )
-        if shutdown_wait_task not in done:
-            failed_task = next(iter(done))
-            task_name = failed_task.get_name() or "unnamed-task"
-            if failed_task.cancelled():
-                runtime_error = RuntimeError(
-                    f"Critical service task '{task_name}' was cancelled unexpectedly."
-                )
-            else:
-                task_error = failed_task.exception()
-                if task_error is None:
-                    runtime_error = RuntimeError(
-                        f"Critical service task '{task_name}' exited unexpectedly."
-                    )
-                else:
-                    runtime_error = RuntimeError(f"Critical service task '{task_name}' failed.")
-                    runtime_error.__cause__ = task_error
-            logger.error("Critical runtime task failure detected; initiating shutdown.")
-            self._shutdown_event.set()
 
         logger.info("Shutdown event received. Stopping all tasks...")
         for consumer in self.consumers:
@@ -132,7 +114,6 @@ class ConsumerManager:
         self.dispatcher.stop()
         server.should_exit = True
 
-        shutdown_wait_task.cancel()
         await asyncio.gather(*self.tasks, return_exceptions=True)
         logger.info("All tasks have been successfully shut down.")
         if runtime_error is not None:

--- a/tests/unit/libs/portfolio-common/test_runtime_supervision.py
+++ b/tests/unit/libs/portfolio-common/test_runtime_supervision.py
@@ -1,0 +1,41 @@
+import asyncio
+import logging
+
+import pytest
+from portfolio_common.runtime_supervision import wait_for_shutdown_or_task_failure
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_returns_none_on_explicit_shutdown():
+    shutdown_event = asyncio.Event()
+    shutdown_event.set()
+    logger = logging.getLogger("test-runtime-supervision")
+
+    result = await wait_for_shutdown_or_task_failure(
+        tasks=[],
+        shutdown_event=shutdown_event,
+        logger=logger,
+    )
+
+    assert result is None
+
+
+async def test_returns_runtime_error_when_task_fails():
+    shutdown_event = asyncio.Event()
+    logger = logging.getLogger("test-runtime-supervision")
+
+    async def _failing():
+        raise ValueError("boom")
+
+    failing_task = asyncio.create_task(_failing(), name="failing-task")
+    result = await wait_for_shutdown_or_task_failure(
+        tasks=[failing_task],
+        shutdown_event=shutdown_event,
+        logger=logger,
+    )
+
+    assert isinstance(result, RuntimeError)
+    assert "Critical service task 'failing-task' failed." in str(result)
+    assert isinstance(result.__cause__, ValueError)
+    assert shutdown_event.is_set() is True


### PR DESCRIPTION
Summary: extract shared runtime supervision helper (portfolio_common.runtime_supervision) and refactor all hardening-updated service managers (cashflow, orchestrator, valuation, timeseries, persistence, position, cost) to use one canonical fail-fast lifecycle path. Added unit coverage for the shared helper and updated RFC 81 progress notes. Validation: uv run ruff check on all changed modules; uv run pytest -q runtime-supervision and service-manager runtime tests.