### PR TITLE
Fix E2E smoke support routing after query control-plane split

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,7 @@ _TEST_ENV_PROFILES = {
         "LOTUS_EVENT_REPLAY_HOST_PORT": "8209",
         "LOTUS_FINANCIAL_RECONCILIATION_HOST_PORT": "8210",
         "LOTUS_QUERY_HOST_PORT": "8201",
+        "LOTUS_QUERY_CONTROL_PLANE_HOST_PORT": "8202",
         "LOTUS_PERSISTENCE_HOST_PORT": "8080",
         "LOTUS_POSITION_CALCULATOR_HOST_PORT": "8081",
         "LOTUS_CASHFLOW_CALCULATOR_HOST_PORT": "8082",
@@ -54,6 +55,7 @@ _TEST_ENV_PROFILES = {
         "LOTUS_EVENT_REPLAY_HOST_PORT": "8309",
         "LOTUS_FINANCIAL_RECONCILIATION_HOST_PORT": "8310",
         "LOTUS_QUERY_HOST_PORT": "8301",
+        "LOTUS_QUERY_CONTROL_PLANE_HOST_PORT": "8302",
         "LOTUS_PERSISTENCE_HOST_PORT": "8180",
         "LOTUS_POSITION_CALCULATOR_HOST_PORT": "8181",
         "LOTUS_CASHFLOW_CALCULATOR_HOST_PORT": "8182",
@@ -71,6 +73,7 @@ _TEST_ENV_PROFILES = {
         "LOTUS_EVENT_REPLAY_HOST_PORT": "8409",
         "LOTUS_FINANCIAL_RECONCILIATION_HOST_PORT": "8410",
         "LOTUS_QUERY_HOST_PORT": "8401",
+        "LOTUS_QUERY_CONTROL_PLANE_HOST_PORT": "8402",
         "LOTUS_PERSISTENCE_HOST_PORT": "8280",
         "LOTUS_POSITION_CALCULATOR_HOST_PORT": "8281",
         "LOTUS_CASHFLOW_CALCULATOR_HOST_PORT": "8282",
@@ -95,6 +98,7 @@ _apply_test_env_profile_defaults()
 host_db_port = os.environ["LOTUS_POSTGRES_HOST_PORT"]
 ingestion_port = os.environ["LOTUS_INGESTION_HOST_PORT"]
 query_port = os.environ["LOTUS_QUERY_HOST_PORT"]
+query_control_plane_port = os.environ["LOTUS_QUERY_CONTROL_PLANE_HOST_PORT"]
 event_replay_port = os.environ["LOTUS_EVENT_REPLAY_HOST_PORT"]
 kafka_port = os.environ["LOTUS_KAFKA_EXTERNAL_PORT"]
 os.environ.setdefault(
@@ -108,6 +112,7 @@ os.environ.setdefault(
 os.environ.setdefault("E2E_INGESTION_URL", f"http://localhost:{ingestion_port}")
 os.environ.setdefault("E2E_EVENT_REPLAY_URL", f"http://localhost:{event_replay_port}")
 os.environ.setdefault("E2E_QUERY_URL", f"http://localhost:{query_port}")
+os.environ.setdefault("E2E_QUERY_CONTROL_PLANE_URL", f"http://localhost:{query_control_plane_port}")
 os.environ.setdefault("KAFKA_BOOTSTRAP_SERVERS", f"localhost:{kafka_port}")
 # Keep demo ingestion sidecar disabled for deterministic integration/e2e tests.
 os.environ.setdefault("DEMO_DATA_PACK_ENABLED", "false")
@@ -154,6 +159,7 @@ def docker_services(request):  # noqa: ARG001
             "event_replay_service",
             "financial_reconciliation_service",
             "query_service",
+            "query_control_plane_service",
             "persistence_service",
             "cost_calculator_service",
             "cashflow_calculator_service",
@@ -182,6 +188,10 @@ def docker_services(request):  # noqa: ARG001
         print("\n--- Waiting for API services to become healthy ---")
         ingestion_base_url = os.getenv("E2E_INGESTION_URL", "http://localhost:8200").rstrip("/")
         query_base_url = os.getenv("E2E_QUERY_URL", "http://localhost:8201").rstrip("/")
+        query_control_plane_base_url = os.getenv(
+            "E2E_QUERY_CONTROL_PLANE_URL",
+            "http://localhost:8202",
+        ).rstrip("/")
         services_to_check = {
             "ingestion_service": f"{ingestion_base_url}/health/ready",
             "event_replay_service": os.getenv(
@@ -194,6 +204,7 @@ def docker_services(request):  # noqa: ARG001
             )
             + "/health/ready",
             "query_service": f"{query_base_url}/health/ready",
+            "query_control_plane_service": f"{query_control_plane_base_url}/health/ready",
         }
 
         for service_name, health_url in services_to_check.items():
@@ -222,6 +233,7 @@ def e2e_api_client(docker_services) -> E2EApiClient:
     return E2EApiClient(
         ingestion_url=os.getenv("E2E_INGESTION_URL", "http://localhost:8200"),
         query_url=os.getenv("E2E_QUERY_URL", "http://localhost:8201"),
+        query_control_plane_url=os.getenv("E2E_QUERY_CONTROL_PLANE_URL", "http://localhost:8202"),
     )
 
 

--- a/tests/e2e/api_client.py
+++ b/tests/e2e/api_client.py
@@ -11,9 +11,10 @@ from requests.exceptions import RequestException
 class E2EApiClient:
     """A client for interacting with the system's APIs in E2E tests."""
 
-    def __init__(self, ingestion_url: str, query_url: str):
+    def __init__(self, ingestion_url: str, query_url: str, query_control_plane_url: str):
         self.ingestion_url = ingestion_url
         self.query_url = query_url
+        self.query_control_plane_url = query_control_plane_url
         self.session = requests.Session()
 
     @staticmethod
@@ -56,6 +57,13 @@ class E2EApiClient:
     def query(self, endpoint: str) -> requests.Response:
         """Retrieves data from a specified query endpoint."""
         url = f"{self.query_url}{endpoint}"
+        response = self.session.get(url, timeout=10)
+        response.raise_for_status()
+        return response
+
+    def query_control(self, endpoint: str) -> requests.Response:
+        """Retrieves data from a specified control-plane query endpoint."""
+        url = f"{self.query_control_plane_url}{endpoint}"
         response = self.session.get(url, timeout=10)
         response.raise_for_status()
         return response

--- a/tests/e2e/test_complex_portfolio_lifecycle.py
+++ b/tests/e2e/test_complex_portfolio_lifecycle.py
@@ -266,14 +266,14 @@ def test_complex_lifecycle_cross_api_consistency(
         assert review["code"] == "LOTUS_CORE_LEGACY_ENDPOINT_REMOVED"
         assert review["target_service"] == "lotus-report"
 
-    support_response = e2e_api_client.query(f"/support/portfolios/{portfolio_id}/overview")
+    support_response = e2e_api_client.query_control(f"/support/portfolios/{portfolio_id}/overview")
     support_data = support_response.json()
     assert support_response.status_code == 200
     assert support_data["portfolio_id"] == portfolio_id
     assert isinstance(support_data["pending_valuation_jobs"], int)
     assert isinstance(support_data["pending_aggregation_jobs"], int)
 
-    lineage_response = e2e_api_client.query(
+    lineage_response = e2e_api_client.query_control(
         f"/lineage/portfolios/{portfolio_id}/securities/{security_id}"
     )
     lineage_data = lineage_response.json()


### PR DESCRIPTION
## Summary
- route support and lineage E2E smoke checks to query_control_plane_service instead of query_service
- wire query control plane host/url into the shared E2E client and test fixture stack
- include query_control_plane_service in docker-backed E2E service bring-up and readiness checks

## Validation
- python -m pytest tests/unit/services/query_service/test_test_manifest.py -q
- python -m ruff check tests/conftest.py tests/e2e/api_client.py tests/e2e/test_complex_portfolio_lifecycle.py
- py_compile on touched E2E files

## Root cause
RFC 81 moved support/control-plane endpoints out of query_service, but the E2E smoke test was still calling /support/... and /lineage/... on the core query host (8401) instead of the query control-plane host (8402).