### PR TITLE
fix(ci): repair main pipeline gates

### DIFF
--- a/src/services/query_control_plane_service/app/routers/analytics_inputs.py
+++ b/src/services/query_control_plane_service/app/routers/analytics_inputs.py
@@ -32,6 +32,7 @@ ANALYTICS_EXPORT_JOB_NOT_FOUND_EXAMPLE = {"detail": "Analytics export job JOB-AN
 ANALYTICS_EXPORT_INCOMPLETE_EXAMPLE = {
     "detail": "Analytics export job JOB-AN-0001 is not complete."
 }
+HTTP_422_UNPROCESSABLE_CONTENT = 422
 
 
 def get_analytics_timeseries_service(
@@ -46,9 +47,9 @@ def _raise_http_for_analytics_error(exc: AnalyticsInputError) -> NoReturn:
     if exc.code == "INVALID_REQUEST":
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
     if exc.code == "INSUFFICIENT_DATA":
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc))
+        raise HTTPException(status_code=HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc))
     if exc.code == "UNSUPPORTED_CONFIGURATION":
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc))
+        raise HTTPException(status_code=HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc))
     raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc))
 
 
@@ -64,7 +65,7 @@ def _raise_http_for_analytics_error(exc: AnalyticsInputError) -> NoReturn:
             "description": "Portfolio not found.",
             "content": {"application/json": {"example": PORTFOLIO_ANALYTICS_NOT_FOUND_EXAMPLE}},
         },
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {
+        HTTP_422_UNPROCESSABLE_CONTENT: {
             "description": "Insufficient data or unsupported configuration.",
             "content": {"application/json": {"example": ANALYTICS_INSUFFICIENT_DATA_EXAMPLE}},
         },
@@ -108,7 +109,7 @@ async def get_portfolio_analytics_timeseries(
             "description": "Portfolio not found.",
             "content": {"application/json": {"example": PORTFOLIO_ANALYTICS_NOT_FOUND_EXAMPLE}},
         },
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {
+        HTTP_422_UNPROCESSABLE_CONTENT: {
             "description": "Insufficient data or unsupported configuration.",
             "content": {"application/json": {"example": ANALYTICS_INSUFFICIENT_DATA_EXAMPLE}},
         },
@@ -189,7 +190,7 @@ async def get_portfolio_analytics_reference(
             "description": "Portfolio not found.",
             "content": {"application/json": {"example": PORTFOLIO_ANALYTICS_NOT_FOUND_EXAMPLE}},
         },
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {
+        HTTP_422_UNPROCESSABLE_CONTENT: {
             "description": "Insufficient source data or unsupported configuration.",
             "content": {"application/json": {"example": ANALYTICS_INSUFFICIENT_DATA_EXAMPLE}},
         },
@@ -253,7 +254,7 @@ async def get_analytics_export_job(
             "description": "Export job not found.",
             "content": {"application/json": {"example": ANALYTICS_EXPORT_JOB_NOT_FOUND_EXAMPLE}},
         },
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {
+        HTTP_422_UNPROCESSABLE_CONTENT: {
             "description": "Export job is incomplete or source payload unavailable.",
             "content": {"application/json": {"example": ANALYTICS_EXPORT_INCOMPLETE_EXAMPLE}},
         },

--- a/src/services/query_control_plane_service/app/routers/integration.py
+++ b/src/services/query_control_plane_service/app/routers/integration.py
@@ -68,6 +68,7 @@ BENCHMARK_ASSIGNMENT_NOT_FOUND_EXAMPLE = {
 BENCHMARK_DEFINITION_NOT_FOUND_EXAMPLE = {
     "detail": "No effective benchmark definition found for benchmark_id and as_of_date."
 }
+HTTP_422_UNPROCESSABLE_CONTENT = 422
 
 
 def get_integration_service(
@@ -136,7 +137,7 @@ async def get_effective_integration_policy(
             "description": "Simulation expected version mismatch or portfolio/session conflict.",
             "content": {"application/json": {"example": CORE_SNAPSHOT_CONFLICT_EXAMPLE}},
         },
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {
+        HTTP_422_UNPROCESSABLE_CONTENT: {
             "description": "Section cannot be fulfilled due to missing valuation dependencies.",
             "content": {"application/json": {"example": CORE_SNAPSHOT_UNAVAILABLE_EXAMPLE}},
         },
@@ -235,7 +236,7 @@ async def create_core_snapshot(
     except CoreSnapshotConflictError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
     except CoreSnapshotUnavailableSectionError as exc:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc))
+        raise HTTPException(status_code=HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc))
 
 
 @router.post(

--- a/tests/test_support/docker_stack.py
+++ b/tests/test_support/docker_stack.py
@@ -38,12 +38,14 @@ def ensure_docker_engine_available(
         ) from exc
 
 
-def _load_compose_images(compose_file: str) -> list[str]:
+def _load_compose_pull_images(compose_file: str) -> list[str]:
     compose_path = Path(compose_file)
     data = yaml.safe_load(compose_path.read_text(encoding="utf-8")) or {}
     services = data.get("services", {})
     images: list[str] = []
     for service in services.values():
+        if service.get("build"):
+            continue
         image = service.get("image")
         if image and image not in images:
             images.append(image)
@@ -63,7 +65,7 @@ def ensure_required_images_available(
         return
 
     missing_images: list[str] = []
-    for image in _load_compose_images(compose_file):
+    for image in _load_compose_pull_images(compose_file):
         result = runner(
             ["docker", "image", "inspect", image],
             check=False,

--- a/tests/unit/test_support/test_docker_stack.py
+++ b/tests/unit/test_support/test_docker_stack.py
@@ -111,7 +111,7 @@ def test_ensure_required_images_available_pulls_missing_image(
 ) -> None:
     compose_file = "docker-compose.yml"
     monkeypatch.setattr(
-        "tests.test_support.docker_stack._load_compose_images",
+        "tests.test_support.docker_stack._load_compose_pull_images",
         lambda _: ["postgres:16-alpine", "confluentinc/cp-zookeeper:7.5.0"],
     )
 
@@ -143,7 +143,7 @@ def test_ensure_required_images_available_raises_on_pull_failure(
 ) -> None:
     compose_file = "docker-compose.yml"
     monkeypatch.setattr(
-        "tests.test_support.docker_stack._load_compose_images",
+        "tests.test_support.docker_stack._load_compose_pull_images",
         lambda _: ["confluentinc/cp-zookeeper:7.5.0"],
     )
 
@@ -160,6 +160,37 @@ def test_ensure_required_images_available_raises_on_pull_failure(
 
     with pytest.raises(DockerStackError, match="Failed to pull required Docker image"):
         ensure_required_images_available(compose_file, runner)
+
+
+def test_ensure_required_images_available_skips_repo_built_images(
+    tmp_path,
+) -> None:
+    compose_file = tmp_path / "docker-compose.yml"
+    compose_file.write_text(
+        """
+services:
+  query-service:
+    image: lotus-core/query-service:local
+    build:
+      context: .
+      dockerfile: src/services/query_service/Dockerfile
+  postgres:
+    image: postgres:16-alpine
+""".strip(),
+        encoding="utf-8",
+    )
+
+    calls: list[list[str]] = []
+
+    def runner(args, **kwargs):  # noqa: ANN001
+        calls.append(list(args))
+        if args[0:3] == ["docker", "image", "inspect"]:
+            return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+        raise AssertionError(f"unexpected call: {args}")
+
+    ensure_required_images_available(str(compose_file), runner)
+
+    assert calls == [["docker", "image", "inspect", "postgres:16-alpine"]]
 
 
 def test_wait_for_migration_runner_success() -> None:


### PR DESCRIPTION
## Summary
- stop Docker-backed tests from trying to pull repo-built :local images from a registry
- remove deprecated 422 constant usage in the affected query control routers so the unit warning gate returns to zero

## Validation
- python -m pytest tests/unit/test_support/test_docker_stack.py tests/unit/services/query_control_plane_service/routers/test_analytics_inputs_router.py tests/unit/services/query_control_plane_service/routers/test_integration_router.py -q
- python scripts/warning_budget_gate.py --suite unit --max-warnings 0 --quiet
- python -m ruff check tests/test_support/docker_stack.py tests/unit/test_support/test_docker_stack.py src/services/query_control_plane_service/app/routers/analytics_inputs.py src/services/query_control_plane_service/app/routers/integration.py

## Notes
- This is a follow-up repair for mainline CI after build PR #228 auto-merged before the already-proven CI fix was included.
