### PR TITLE
fix(ci): restore runtime build gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+
+      - name: Install CI tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements/ci-tooling.lock.txt
+
       - name: Restore Docker build cache
         uses: actions/cache@v4
         with:

--- a/src/services/persistence_service/Dockerfile
+++ b/src/services/persistence_service/Dockerfile
@@ -47,10 +47,13 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 FROM runtime-base AS final
 
 COPY --from=wheel-builder /wheels /wheels
+COPY alembic.ini /app/alembic.ini
+COPY alembic /app/alembic
+COPY tools/kafka_setup.py /app/tools/kafka_setup.py
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --no-index --find-links=/wheels /wheels/*.whl && \
     rm -rf /wheels && \
-    chown -R appuser:appuser /opt/venv
+    chown -R appuser:appuser /opt/venv /app
 
 USER appuser
 EXPOSE 8080


### PR DESCRIPTION
## Summary
- install CI tooling in the Docker build job before generating the runtime SBOM
- restore persistence-derived runtime image assets needed by migration-runner and kafka-topic-creator

## Evidence
- `python -m pytest tests/unit/test_support/test_docker_stack.py tests/unit/services/query_control_plane_service/routers/test_analytics_inputs_router.py tests/unit/services/query_control_plane_service/routers/test_integration_router.py -q` -> `40 passed`
- `python scripts/warning_budget_gate.py --suite unit --max-warnings 0 --quiet` -> `1130 passed, warnings=0`
- `docker build -f src/services/persistence_service/Dockerfile -t lotus-core/persistence-service:debug .` -> passed
- `docker run --rm --entrypoint alembic lotus-core/persistence-service:debug -c /app/alembic.ini history` -> passed
- `docker run --rm --entrypoint python lotus-core/persistence-service:debug -c "import tools.kafka_setup; print('kafka-setup-import-ok')"` -> passed
- `docker compose up -d postgres && docker compose run --rm migration-runner && docker compose down -v` -> passed
- workflow YAML parse -> passed
