### PR TITLE
fix(ci): harden latency and outbox gates

### DIFF
--- a/scripts/latency_profile.py
+++ b/scripts/latency_profile.py
@@ -100,6 +100,7 @@ def _resolve_runtime_ids(
     query_control_plane_base_url: str,
     portfolio_id: str,
     benchmark_id: str,
+    timeout_seconds: int,
 ) -> tuple[str, str]:
     resolved_portfolio_id = portfolio_id
     resolved_benchmark_id = benchmark_id
@@ -148,7 +149,7 @@ def _resolve_runtime_ids(
                 return False
         return True
 
-    deadline = time.time() + 60
+    deadline = time.time() + timeout_seconds
     while time.time() < deadline:
         candidate_ids: list[str] = [portfolio_id]
         try:
@@ -528,6 +529,7 @@ def main() -> int:
         query_control_plane_base_url=args.query_control_plane_base_url,
         portfolio_id=args.portfolio_id,
         benchmark_id=args.benchmark_id,
+        timeout_seconds=args.ready_timeout_seconds,
     )
 
     results = run_profile(

--- a/tests/integration/libs/portfolio-common/test_outbox_dispatcher.py
+++ b/tests/integration/libs/portfolio-common/test_outbox_dispatcher.py
@@ -201,28 +201,30 @@ def test_dispatcher_recovers_after_failure(db_engine, clean_db, smart_mock_kafka
             )
 
     call_count = 0
+    pending_deliveries: list[dict[str, object]] = []
+
+    def _publish_message(**kwargs):
+        pending_deliveries.append(kwargs)
 
     def stateful_flush_side_effect(*args, **kwargs):
         nonlocal call_count
         call_count += 1
 
         if call_count == 1:
-            for call in smart_mock_kafka_producer.publish_message.call_args_list:
-                kwargs = call.kwargs
-                cb = kwargs.get("on_delivery")
-                outbox_id = kwargs.get("outbox_id")
+            for queued in pending_deliveries:
+                cb = queued.get("on_delivery")
+                outbox_id = queued.get("outbox_id")
                 if cb and outbox_id:
                     cb(outbox_id, False, "Kafka is down!")
-            smart_mock_kafka_producer.publish_message.call_args_list.clear()
         else:
-            for call in smart_mock_kafka_producer.publish_message.call_args_list:
-                kwargs = call.kwargs
-                cb = kwargs.get("on_delivery")
-                outbox_id = kwargs.get("outbox_id")
+            for queued in pending_deliveries:
+                cb = queued.get("on_delivery")
+                outbox_id = queued.get("outbox_id")
                 if cb and outbox_id:
                     cb(outbox_id, True, None)
-            smart_mock_kafka_producer.publish_message.call_args_list.clear()
+        pending_deliveries.clear()
 
+    smart_mock_kafka_producer.publish_message.side_effect = _publish_message
     smart_mock_kafka_producer.flush.side_effect = stateful_flush_side_effect
 
     dispatcher = OutboxDispatcher(

--- a/tests/unit/scripts/test_latency_profile.py
+++ b/tests/unit/scripts/test_latency_profile.py
@@ -85,6 +85,7 @@ def test_resolve_runtime_ids_overrides_from_catalogs() -> None:
         query_control_plane_base_url="http://localhost:8202",
         portfolio_id="DEMO_DPM_EUR_001",
         benchmark_id="BMK_GLOBAL_BALANCED_60_40",
+        timeout_seconds=5,
     )
 
     assert portfolio_id == "PORT_123"


### PR DESCRIPTION
## Summary
- harden the outbox recovery integration test so it tracks queued callbacks deterministically instead of mutating `MagicMock.call_args_list`
- let the latency harness use the configured ready timeout while waiting for seeded runtime ids instead of a hardcoded 60s window

## Validation
- `python -m pytest tests/integration/libs/portfolio-common/test_outbox_dispatcher.py -k test_dispatcher_recovers_after_failure -q`
- `python -m pytest tests/unit/scripts/test_latency_profile.py -q`
- `python scripts/latency_profile.py --build --enforce`
- `python -m ruff check scripts/latency_profile.py tests/unit/scripts/test_latency_profile.py tests/integration/libs/portfolio-common/test_outbox_dispatcher.py`