### PR TITLE
fix(ci): harden demo loader readiness gate

### DIFF
--- a/scripts/latency_profile.py
+++ b/scripts/latency_profile.py
@@ -16,7 +16,7 @@ import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import requests
 
@@ -75,6 +75,40 @@ def _run_compose_up(build: bool) -> None:
     subprocess.run(cmd, check=True)
 
 
+def _raise_if_compose_service_failed(
+    service_name: str,
+) -> None:
+    ps = subprocess.run(
+        ["docker", "compose", "ps", "-a", "-q", service_name],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    container_id = ps.stdout.strip()
+    if not container_id:
+        return
+
+    inspect = subprocess.run(
+        [
+            "docker",
+            "inspect",
+            "--format",
+            "{{.State.Status}}|{{.State.ExitCode}}",
+            container_id,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    status, _, exit_code = inspect.stdout.strip().partition("|")
+    if status == "exited" and exit_code != "0":
+        raise RuntimeError(
+            "Compose service "
+            f"'{service_name}' exited with status {exit_code} "
+            "before latency profiling."
+        )
+
+
 def _pick_identifier_from_payload(payload: Any, keys: tuple[str, ...]) -> str | None:
     if isinstance(payload, dict):
         for key in keys:
@@ -101,6 +135,7 @@ def _resolve_runtime_ids(
     portfolio_id: str,
     benchmark_id: str,
     timeout_seconds: int,
+    progress_check: Callable[[], None] | None = None,
 ) -> tuple[str, str]:
     resolved_portfolio_id = portfolio_id
     resolved_benchmark_id = benchmark_id
@@ -151,6 +186,8 @@ def _resolve_runtime_ids(
 
     deadline = time.time() + timeout_seconds
     while time.time() < deadline:
+        if progress_check is not None:
+            progress_check()
         candidate_ids: list[str] = [portfolio_id]
         try:
             response = session.get(f"{query_base_url}/lookups/portfolios?limit=50", timeout=10)
@@ -530,6 +567,11 @@ def main() -> int:
         portfolio_id=args.portfolio_id,
         benchmark_id=args.benchmark_id,
         timeout_seconds=args.ready_timeout_seconds,
+        progress_check=(
+            None
+            if args.skip_compose
+            else lambda: _raise_if_compose_service_failed("demo_data_loader")
+        ),
     )
 
     results = run_profile(

--- a/src/services/persistence_service/Dockerfile
+++ b/src/services/persistence_service/Dockerfile
@@ -50,6 +50,7 @@ COPY --from=wheel-builder /wheels /wheels
 COPY alembic.ini /app/alembic.ini
 COPY alembic /app/alembic
 COPY tools/kafka_setup.py /app/tools/kafka_setup.py
+COPY tools/demo_data_pack.py /app/tools/demo_data_pack.py
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --no-index --find-links=/wheels /wheels/*.whl && \
     rm -rf /wheels && \

--- a/tests/unit/scripts/test_latency_profile.py
+++ b/tests/unit/scripts/test_latency_profile.py
@@ -1,9 +1,11 @@
+from subprocess import CompletedProcess
 from unittest.mock import MagicMock
 
 from scripts.latency_profile import (
     _enforce_gate,
     _percentile_ms,
     _pick_identifier_from_payload,
+    _raise_if_compose_service_failed,
     _resolve_runtime_ids,
 )
 
@@ -90,3 +92,30 @@ def test_resolve_runtime_ids_overrides_from_catalogs() -> None:
 
     assert portfolio_id == "PORT_123"
     assert benchmark_id == "BMK_ABC"
+
+
+def test_raise_if_compose_service_failed_ignores_running_service(monkeypatch) -> None:
+    def _fake_run(cmd, check=False, capture_output=False, text=False):  # noqa: ARG001
+        if cmd[:5] == ["docker", "compose", "ps", "-a", "-q"]:
+            return CompletedProcess(cmd, 0, stdout="container-123\n", stderr="")
+        return CompletedProcess(cmd, 0, stdout="running|0\n", stderr="")
+
+    monkeypatch.setattr("scripts.latency_profile.subprocess.run", _fake_run)
+
+    _raise_if_compose_service_failed("demo_data_loader")
+
+
+def test_raise_if_compose_service_failed_raises_on_failure(monkeypatch) -> None:
+    def _fake_run(cmd, check=False, capture_output=False, text=False):  # noqa: ARG001
+        if cmd[:5] == ["docker", "compose", "ps", "-a", "-q"]:
+            return CompletedProcess(cmd, 0, stdout="container-123\n", stderr="")
+        return CompletedProcess(cmd, 0, stdout="exited|1\n", stderr="")
+
+    monkeypatch.setattr("scripts.latency_profile.subprocess.run", _fake_run)
+
+    try:
+        _raise_if_compose_service_failed("demo_data_loader")
+    except RuntimeError as exc:
+        assert "exited with status 1" in str(exc)
+    else:
+        raise AssertionError("Expected _raise_if_compose_service_failed to raise.")


### PR DESCRIPTION
## Summary
- restore 	ools.demo_data_pack in the wheel-based persistence image used by demo_data_loader
- fail the latency gate fast if demo_data_loader exits non-zero during setup
- let latency profiling proceed once runtime IDs become queryable instead of waiting for the loader's full verification pass to finish

## Validation
- python -m pytest tests/unit/scripts/test_latency_profile.py -q
- python -m ruff check scripts/latency_profile.py tests/unit/scripts/test_latency_profile.py
- python scripts/latency_profile.py --build --enforce
- docker build -f src/services/persistence_service/Dockerfile -t lotus-core/demo-data-loader:local .
