### PR TITLE
fix(ci): stabilize stale valuation job fixture

### DIFF
--- a/tests/integration/services/calculators/position_valuation_calculator/test_int_valuation_repo.py
+++ b/tests/integration/services/calculators/position_valuation_calculator/test_int_valuation_repo.py
@@ -37,8 +37,8 @@ class _FixedDateTime(datetime):
         return FIXED_STALE_NOW.astimezone(tz)
 
 
-@pytest.fixture(scope="function")
-def setup_stale_job_data(clean_db, db_engine):
+@pytest_asyncio.fixture(scope="function")
+async def setup_stale_job_data(clean_db, session_factory: async_sessionmaker):
     """
     Sets up a variety of valuation jobs in the database:
     - One recent 'PROCESSING' job (should not be reset).
@@ -46,7 +46,7 @@ def setup_stale_job_data(clean_db, db_engine):
     - One stale 'PENDING' job (should not be reset).
     - One stale 'COMPLETE' job (should not be reset).
     """
-    with Session(db_engine) as session:
+    async with session_factory() as session:
         now = FIXED_STALE_NOW
         stale_time = now - timedelta(minutes=30)
 
@@ -81,7 +81,7 @@ def setup_stale_job_data(clean_db, db_engine):
             ),
         ]
         session.add_all(jobs)
-        session.commit()
+        await session.commit()
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
## Summary
- move the stale valuation-job integration seed onto the async session path used by the repository assertions
- remove the sync/async session mismatch that could wobble in the full integration suite

## Validation
- `python -m pytest tests/integration/services/calculators/position_valuation_calculator/test_int_valuation_repo.py -k "test_find_and_reset_stale_jobs or test_find_and_reset_stale_jobs_marks_over_limit_rows_failed or test_find_and_reset_stale_jobs_does_not_overwrite_completed_rows" -q`
- `python -m ruff check tests/integration/services/calculators/position_valuation_calculator/test_int_valuation_repo.py`
