### PR TITLE
fix(ci): make outbox dispatcher test thread-safe

### DIFF
--- a/tests/integration/libs/portfolio-common/test_outbox_dispatcher.py
+++ b/tests/integration/libs/portfolio-common/test_outbox_dispatcher.py
@@ -3,6 +3,7 @@ import asyncio
 import json
 import uuid
 from datetime import datetime, timedelta, timezone
+from threading import Lock
 from unittest.mock import MagicMock
 
 import pytest
@@ -23,16 +24,26 @@ def smart_mock_kafka_producer() -> MagicMock:
     and simulates successful delivery callbacks when flush is called.
     """
     mock = MagicMock(spec=KafkaProducer)
+    pending_deliveries: list[dict[str, object]] = []
+    delivery_lock = Lock()
+
+    def _publish_message(**kwargs):
+        with delivery_lock:
+            pending_deliveries.append(kwargs)
 
     def _flush(timeout=10):
-        # Simulate successful delivery for all captured calls to publish_message
-        for call in mock.publish_message.call_args_list:
-            kwargs = call.kwargs
+        # Drain a stable snapshot so concurrent dispatcher threads don't race on call_args_list.
+        with delivery_lock:
+            queued_deliveries = list(pending_deliveries)
+            pending_deliveries.clear()
+
+        for kwargs in queued_deliveries:
             cb = kwargs.get("on_delivery")
             outbox_id = kwargs.get("outbox_id")
             if cb and outbox_id:
                 cb(outbox_id, True, None)  # Simulate success
 
+    mock.publish_message.side_effect = _publish_message
     mock.flush.side_effect = _flush
     return mock
 


### PR DESCRIPTION
This PR fixes the current `main` Integration Full failure in `tests/integration/libs/portfolio-common/test_outbox_dispatcher.py::test_dispatcher_is_concurrent_safe`.

Why it was failing:
- the shared `smart_mock_kafka_producer` fixture used `MagicMock.call_args_list` as a pseudo delivery queue
- the concurrent dispatcher test runs two dispatcher loops in parallel threads via `asyncio.to_thread(...)`
- `call_args_list` is fine for assertions, but it is not a stable synchronization boundary for concurrent delivery simulation
- under load, the test could observe zero processed events even though the dispatcher path itself was not the issue

What changed:
- keep `publish_message` as a mock for assertions
- add an explicit thread-safe pending-delivery queue guarded by `Lock`
- make `flush()` drain that stable queue and invoke callbacks from the drained snapshot

Local validation:
- `python -m pytest tests/integration/libs/portfolio-common/test_outbox_dispatcher.py -k test_dispatcher_is_concurrent_safe -q`
- `python -m pytest tests/integration/libs/portfolio-common/test_outbox_dispatcher.py -q`
- `python -m ruff check tests/integration/libs/portfolio-common/test_outbox_dispatcher.py`
