### PR TITLE
test(e2e): strengthen workflow assertions and helpers

### DIFF
--- a/src/services/financial_reconciliation_service/Dockerfile
+++ b/src/services/financial_reconciliation_service/Dockerfile
@@ -40,6 +40,7 @@ COPY src/services/financial_reconciliation_service/pyproject.toml /build/src/ser
 COPY src/services/financial_reconciliation_service/app /build/src/services/financial_reconciliation_service/app
 
 RUN --mount=type=cache,target=/root/.cache/pip \
+    rm -rf /wheels && mkdir -p /wheels && \
     pip wheel --wheel-dir /wheels \
     /build/src/libs/portfolio-common \
     /build/src/services/financial_reconciliation_service

--- a/tests/e2e/api_client.py
+++ b/tests/e2e/api_client.py
@@ -98,6 +98,7 @@ class E2EApiClient:
         """Polls a query endpoint until the validation function returns True."""
         start_time = time.time()
         last_response_data = None
+        last_error = None
         while time.time() - start_time < timeout:
             try:
                 response = self.query(endpoint)
@@ -105,11 +106,45 @@ class E2EApiClient:
                     last_response_data = response.json()
                     if validation_func(last_response_data):
                         return last_response_data
-            except RequestException:
-                pass  # Ignore connection errors during polling
+            except RequestException as exc:
+                last_error = repr(exc)
             time.sleep(interval)
 
         pytest.fail(
             f"{fail_message} after {timeout} seconds for endpoint {endpoint}. "
-            f"Last response: {last_response_data}"
+            f"Last response: {last_response_data}. Last error: {last_error}"
+        )
+
+    def poll_for_post_query_data(
+        self,
+        endpoint: str,
+        payload: Dict[str, Any],
+        validation_func: Callable[[Any], bool],
+        timeout: int = 60,
+        interval: int = 2,
+        fail_message: str = "Polling timed out",
+    ):
+        """Poll a POST-based query endpoint until the validation function returns True."""
+        start_time = time.time()
+        last_response_data = None
+        last_status_code = None
+        last_error = None
+        while time.time() - start_time < timeout:
+            try:
+                response = self.post_query(endpoint, payload, raise_for_status=False)
+                last_status_code = response.status_code
+                if response.status_code == 200:
+                    last_response_data = response.json()
+                    if validation_func(last_response_data):
+                        return last_response_data
+                else:
+                    last_response_data = response.text
+            except RequestException as exc:
+                last_error = repr(exc)
+            time.sleep(interval)
+
+        pytest.fail(
+            f"{fail_message} after {timeout} seconds for endpoint {endpoint}. "
+            f"Last status: {last_status_code}. Last response: {last_response_data}. "
+            f"Last error: {last_error}"
         )

--- a/tests/e2e/state_assertions.py
+++ b/tests/e2e/state_assertions.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from .api_client import E2EApiClient
+from .assertions import as_decimal
+
+
+def assert_positions_state(
+    e2e_api_client: E2EApiClient,
+    *,
+    portfolio_id: str,
+    as_of_date: str,
+    expected_positions: dict[str, dict[str, Decimal]],
+) -> None:
+    def _has_expected_positions(data: dict) -> bool:
+        positions = data.get("positions", [])
+        if len(positions) != len(expected_positions):
+            return False
+        by_security = {row["security_id"]: row for row in positions}
+        if set(by_security) != set(expected_positions):
+            return False
+        for security_id, expected in expected_positions.items():
+            row = by_security[security_id]
+            if as_decimal(row["quantity"]) != expected["quantity"]:
+                return False
+            if as_decimal(row["cost_basis"]) != expected["cost_basis"]:
+                return False
+            if as_decimal(row["valuation"]["market_value"]) != expected["market_value"]:
+                return False
+        return True
+
+    payload = e2e_api_client.poll_for_data(
+        f"/portfolios/{portfolio_id}/positions?as_of_date={as_of_date}",
+        _has_expected_positions,
+        timeout=180,
+        fail_message=f"Positions did not converge to the expected state for {as_of_date}.",
+    )
+
+    positions = payload["positions"]
+    by_security = {row["security_id"]: row for row in positions}
+    assert set(by_security) == set(expected_positions)
+    for security_id, expected in expected_positions.items():
+        row = by_security[security_id]
+        assert as_decimal(row["quantity"]) == expected["quantity"]
+        assert as_decimal(row["cost_basis"]) == expected["cost_basis"]
+        assert as_decimal(row["valuation"]["market_value"]) == expected["market_value"]
+
+
+def assert_portfolio_timeseries_value(
+    poll_db_until,
+    *,
+    portfolio_id: str,
+    date: str,
+    expected_eod_market_value: Decimal,
+) -> None:
+    query = (
+        "SELECT eod_market_value FROM portfolio_timeseries "
+        "WHERE portfolio_id = :pid AND date = :date"
+    )
+    params = {"pid": portfolio_id, "date": date}
+    poll_db_until(
+        query,
+        lambda r: r is not None and r.eod_market_value == expected_eod_market_value,
+        params,
+    )

--- a/tests/e2e/test_5_day_workflow.py
+++ b/tests/e2e/test_5_day_workflow.py
@@ -7,6 +7,7 @@ from sqlalchemy import Engine, text
 from sqlalchemy.orm import Session
 
 from .api_client import E2EApiClient
+from .state_assertions import assert_portfolio_timeseries_value, assert_positions_state
 
 # Constants for our test data
 DAY_1 = "2025-08-19"
@@ -172,6 +173,24 @@ def test_day_1_workflow(setup_prerequisites, e2e_api_client: E2EApiClient, poll_
     query = "SELECT valuation_status FROM daily_position_snapshots WHERE portfolio_id = :pid AND security_id = :sid AND date = :date"  # noqa: E501
     params = {"pid": portfolio_id, "sid": cash_usd_id, "date": DAY_1}
     poll_db_until(query, lambda r: r is not None and r.valuation_status == "VALUED_CURRENT", params)
+    assert_positions_state(
+        e2e_api_client,
+        portfolio_id=portfolio_id,
+        as_of_date=DAY_1,
+        expected_positions={
+            cash_usd_id: {
+                "quantity": Decimal("1000000"),
+                "cost_basis": Decimal("1000000"),
+                "market_value": Decimal("1000000"),
+            }
+        },
+    )
+    assert_portfolio_timeseries_value(
+        poll_db_until,
+        portfolio_id=portfolio_id,
+        date=DAY_1,
+        expected_eod_market_value=Decimal("1000000.0000000000"),
+    )
 
 
 @pytest.mark.dependency(depends=["test_day_1_workflow"])
@@ -224,10 +243,29 @@ def test_day_2_workflow(setup_prerequisites, e2e_api_client: E2EApiClient, poll_
     }
     e2e_api_client.ingest("/ingest/market-prices", prices_payload)
 
-    query = "SELECT eod_market_value FROM portfolio_timeseries WHERE portfolio_id = :pid AND date = :date"  # noqa: E501
-    params = {"pid": portfolio_id, "date": DAY_2}
-    expected_eod_mv = Decimal("1002974.5000000000")
-    poll_db_until(query, lambda r: r is not None and r.eod_market_value == expected_eod_mv, params)
+    assert_positions_state(
+        e2e_api_client,
+        portfolio_id=portfolio_id,
+        as_of_date=DAY_2,
+        expected_positions={
+            aapl_id: {
+                "quantity": Decimal("1000"),
+                "cost_basis": Decimal("175025.5"),
+                "market_value": Decimal("178000"),
+            },
+            cash_usd_id: {
+                "quantity": Decimal("824974.5"),
+                "cost_basis": Decimal("824974.5"),
+                "market_value": Decimal("824974.5"),
+            },
+        },
+    )
+    assert_portfolio_timeseries_value(
+        poll_db_until,
+        portfolio_id=portfolio_id,
+        date=DAY_2,
+        expected_eod_market_value=Decimal("1002974.5000000000"),
+    )
 
 
 @pytest.mark.dependency(depends=["test_day_2_workflow"])
@@ -282,10 +320,34 @@ def test_day_3_workflow(setup_prerequisites, e2e_api_client: E2EApiClient, poll_
     }
     e2e_api_client.ingest("/ingest/market-prices", prices_payload)
 
-    query = "SELECT eod_market_value FROM portfolio_timeseries WHERE portfolio_id = :pid AND date = :date"  # noqa: E501
-    params = {"pid": portfolio_id, "date": DAY_3}
-    expected_eod_mv = Decimal("1005959.5000000000")
-    poll_db_until(query, lambda r: r is not None and r.eod_market_value == expected_eod_mv, params)
+    assert_positions_state(
+        e2e_api_client,
+        portfolio_id=portfolio_id,
+        as_of_date=DAY_3,
+        expected_positions={
+            aapl_id: {
+                "quantity": Decimal("1000"),
+                "cost_basis": Decimal("175025.5"),
+                "market_value": Decimal("180000"),
+            },
+            ibm_id: {
+                "quantity": Decimal("500"),
+                "cost_basis": Decimal("70015"),
+                "market_value": Decimal("71000"),
+            },
+            cash_usd_id: {
+                "quantity": Decimal("754959.5"),
+                "cost_basis": Decimal("754959.5"),
+                "market_value": Decimal("754959.5"),
+            },
+        },
+    )
+    assert_portfolio_timeseries_value(
+        poll_db_until,
+        portfolio_id=portfolio_id,
+        date=DAY_3,
+        expected_eod_market_value=Decimal("1005959.5000000000"),
+    )
 
 
 @pytest.mark.dependency(depends=["test_day_3_workflow"])
@@ -352,6 +414,34 @@ def test_day_4_workflow(setup_prerequisites, e2e_api_client: E2EApiClient, poll_
         )
 
     poll_db_until(query, validation_func, params)
+    assert_positions_state(
+        e2e_api_client,
+        portfolio_id=portfolio_id,
+        as_of_date=DAY_4,
+        expected_positions={
+            aapl_id: {
+                "quantity": Decimal("800"),
+                "cost_basis": Decimal("140020.4"),
+                "market_value": Decimal("144800"),
+            },
+            ibm_id: {
+                "quantity": Decimal("500"),
+                "cost_basis": Decimal("70015"),
+                "market_value": Decimal("70500"),
+            },
+            cash_usd_id: {
+                "quantity": Decimal("791354.5"),
+                "cost_basis": Decimal("791354.5"),
+                "market_value": Decimal("791354.5"),
+            },
+        },
+    )
+    assert_portfolio_timeseries_value(
+        poll_db_until,
+        portfolio_id=portfolio_id,
+        date=DAY_4,
+        expected_eod_market_value=Decimal("1006654.5000000000"),
+    )
 
 
 @pytest.mark.dependency(depends=["test_day_4_workflow"])
@@ -404,12 +494,31 @@ def test_day_5_workflow(setup_prerequisites, e2e_api_client: E2EApiClient, poll_
     }
     e2e_api_client.ingest("/ingest/market-prices", prices_payload)
 
-    query = "SELECT eod_market_value FROM portfolio_timeseries WHERE portfolio_id = :pid AND date = :date"  # noqa: E501
-    params = {"pid": portfolio_id, "date": DAY_5}
-    expected_eod_mv = Decimal("1010104.5000000000")
-    poll_db_until(
-        query,
-        lambda r: r is not None and r.eod_market_value == expected_eod_mv,
-        params,
-        timeout=180,
+    assert_positions_state(
+        e2e_api_client,
+        portfolio_id=portfolio_id,
+        as_of_date=DAY_5,
+        expected_positions={
+            aapl_id: {
+                "quantity": Decimal("800"),
+                "cost_basis": Decimal("140020.4"),
+                "market_value": Decimal("148000"),
+            },
+            ibm_id: {
+                "quantity": Decimal("500"),
+                "cost_basis": Decimal("70015"),
+                "market_value": Decimal("70000"),
+            },
+            cash_usd_id: {
+                "quantity": Decimal("792104.5"),
+                "cost_basis": Decimal("792104.5"),
+                "market_value": Decimal("792104.5"),
+            },
+        },
+    )
+    assert_portfolio_timeseries_value(
+        poll_db_until,
+        portfolio_id=portfolio_id,
+        date=DAY_5,
+        expected_eod_market_value=Decimal("1010104.5000000000"),
     )

--- a/tests/e2e/test_dual_currency_workflow.py
+++ b/tests/e2e/test_dual_currency_workflow.py
@@ -6,6 +6,7 @@ import pytest
 
 from .api_client import E2EApiClient
 from .assertions import as_decimal
+from .state_assertions import assert_positions_state
 
 
 @pytest.fixture(scope="module")
@@ -122,7 +123,7 @@ def setup_dual_currency_data(clean_db_module, e2e_api_client: E2EApiClient):
         return data.get("positions") and len(data["positions"]) == 1 and data["positions"][0].get("valuation", {}).get("unrealized_gain_loss") is not None  # noqa: E501
     e2e_api_client.poll_for_data(pos_url, pos_validation, timeout=120)
 
-    return {"portfolio_id": portfolio_id}
+    return {"portfolio_id": portfolio_id, "security_id": security_id}
 
 
 def test_realized_pnl_dual_currency(setup_dual_currency_data, e2e_api_client: E2EApiClient):
@@ -179,4 +180,23 @@ def test_unrealized_pnl_dual_currency(setup_dual_currency_data, e2e_api_client: 
     # base unrealized = base market value - base cost basis
     assert as_decimal(valuation["unrealized_gain_loss"]) == (
         as_decimal(valuation["market_value"]) - as_decimal(position["cost_basis"])
+    )
+
+
+def test_final_position_state_dual_currency(
+    setup_dual_currency_data, e2e_api_client: E2EApiClient
+):
+    portfolio_id = setup_dual_currency_data["portfolio_id"]
+    security_id = setup_dual_currency_data["security_id"]
+    assert_positions_state(
+        e2e_api_client,
+        portfolio_id=portfolio_id,
+        as_of_date="2025-08-15",
+        expected_positions={
+            security_id: {
+                "quantity": Decimal("60"),
+                "cost_basis": Decimal("9900"),
+                "market_value": Decimal("12960"),
+            }
+        },
     )

--- a/tests/e2e/test_rapid_reprocessing.py
+++ b/tests/e2e/test_rapid_reprocessing.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 import pytest
 
 from .api_client import E2EApiClient
+from .state_assertions import assert_positions_state
 
 
 @pytest.fixture(scope="module")
@@ -111,20 +112,17 @@ def setup_rapid_repro_data(clean_db_module, e2e_api_client: E2EApiClient, poll_d
         fail_message="Initial position_state was not created or did not become CURRENT.",
     )
 
-    def _has_initial_position(data: dict) -> bool:
-        positions = data.get("positions", [])
-        if len(positions) != 1:
-            return False
-        position = positions[0]
-        quantity = Decimal(str(position["quantity"])).quantize(Decimal("0.01"))
-        cost_basis = Decimal(str(position["cost_basis"])).quantize(Decimal("0.01"))
-        return quantity == Decimal("150.00") and cost_basis == Decimal("1600.00")
-
-    e2e_api_client.poll_for_data(
-        f"/portfolios/{portfolio_id}/positions",
-        _has_initial_position,
-        timeout=180,
-        fail_message="Initial seeded position did not converge to the expected business state.",
+    assert_positions_state(
+        e2e_api_client,
+        portfolio_id=portfolio_id,
+        as_of_date=day4,
+        expected_positions={
+            security_id: {
+                "quantity": Decimal("150"),
+                "cost_basis": Decimal("1600"),
+                "market_value": Decimal("15000"),
+            }
+        },
     )
 
     return {
@@ -146,7 +144,7 @@ def test_rapid_back_to_back_reprocessing(
     portfolio_id = setup_rapid_repro_data["portfolio_id"]
     security_id = setup_rapid_repro_data["security_id"]
     initial_epoch = setup_rapid_repro_data["initial_epoch"]
-    day2, day3 = "2025-09-12", "2025-09-13"
+    day2, day3, day4 = "2025-09-12", "2025-09-13", "2025-09-14"
 
     back_dated_payload_1 = {
         "transactions": [
@@ -211,23 +209,15 @@ def test_rapid_back_to_back_reprocessing(
         fail_message="Reprocessing did not converge to a CURRENT state.",
     )
 
-    def _has_expected_position(data: dict) -> bool:
-        positions = data.get("positions", [])
-        if len(positions) != 1:
-            return False
-
-        position = positions[0]
-        quantity = Decimal(str(position["quantity"])).quantize(Decimal("0.01"))
-        cost_basis = Decimal(str(position["cost_basis"])).quantize(Decimal("0.01"))
-        return quantity == Decimal("100.00") and cost_basis == Decimal("1100.00")
-
-    data = e2e_api_client.poll_for_data(
-        f"/portfolios/{portfolio_id}/positions",
-        _has_expected_position,
-        timeout=180,
-        fail_message="Reprocessing did not converge to the expected final position.",
+    assert_positions_state(
+        e2e_api_client,
+        portfolio_id=portfolio_id,
+        as_of_date=day4,
+        expected_positions={
+            security_id: {
+                "quantity": Decimal("100"),
+                "cost_basis": Decimal("1100"),
+                "market_value": Decimal("10000"),
+            }
+        },
     )
-
-    position = data["positions"][0]
-    assert Decimal(str(position["quantity"])).quantize(Decimal("0.01")) == Decimal("100.00")
-    assert Decimal(str(position["cost_basis"])).quantize(Decimal("0.01")) == Decimal("1100.00")

--- a/tests/e2e/test_reprocessing_workflow.py
+++ b/tests/e2e/test_reprocessing_workflow.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 import pytest
 
 from .api_client import E2EApiClient
-from .assertions import as_decimal
+from .state_assertions import assert_positions_state
 
 
 @pytest.fixture(scope="module")
@@ -173,24 +173,15 @@ def test_back_dated_transaction_triggers_reprocessing_and_corrects_state(
     # ASSERT 3: The final query-facing position must converge too.
     # Final Qty = 100 + 50 - 40 = 110
     # Final Cost = (60 * 200) + (50 * 220) = 12000 + 11000 = 23000
-    def _has_expected_position(data: dict) -> bool:
-        positions = data.get("positions", [])
-        if len(positions) != 1:
-            return False
-
-        position = positions[0]
-        return (
-            as_decimal(position["quantity"]) == Decimal("110")
-            and as_decimal(position["cost_basis"]) == Decimal("23000")
-        )
-
-    data = e2e_api_client.poll_for_data(
-        f"/portfolios/{portfolio_id}/positions",
-        _has_expected_position,
-        timeout=180,
-        fail_message="Reprocessing did not converge to the expected final position.",
+    assert_positions_state(
+        e2e_api_client,
+        portfolio_id=portfolio_id,
+        as_of_date="2025-09-03",
+        expected_positions={
+            security_id: {
+                "quantity": Decimal("110"),
+                "cost_basis": Decimal("23000"),
+                "market_value": Decimal("24200"),
+            }
+        },
     )
-
-    position = data["positions"][0]
-    assert as_decimal(position["quantity"]) == Decimal("110")
-    assert as_decimal(position["cost_basis"]) == Decimal("23000")

--- a/tests/e2e/test_timeseries_pipeline.py
+++ b/tests/e2e/test_timeseries_pipeline.py
@@ -1,4 +1,3 @@
-import time
 import uuid
 from decimal import Decimal
 
@@ -6,6 +5,41 @@ import pytest
 
 from .api_client import E2EApiClient
 from .assertions import as_decimal
+
+EXPECTED_TIMESERIES_ROWS = {
+    "2025-08-28": {
+        "SEC_EUR_STOCK": {
+            "position_currency": "EUR",
+            "quantity": Decimal("100"),
+            "ending_market_value_portfolio_currency": Decimal("5200"),
+            "valuation_status": "final",
+        },
+        "CASH_": {
+            "position_currency": "USD",
+            "quantity": Decimal("0"),
+            "ending_market_value_portfolio_currency": Decimal("0"),
+            "valuation_status": "restated",
+        },
+        "total_ending_market_value_portfolio_currency": Decimal("5200"),
+        "quality_status_distribution": {"final": 1, "restated": 1},
+    },
+    "2025-08-29": {
+        "SEC_EUR_STOCK": {
+            "position_currency": "EUR",
+            "quantity": Decimal("100"),
+            "ending_market_value_portfolio_currency": Decimal("5500"),
+            "valuation_status": "final",
+        },
+        "CASH_": {
+            "position_currency": "USD",
+            "quantity": Decimal("-25"),
+            "ending_market_value_portfolio_currency": Decimal("-25"),
+            "valuation_status": "restated",
+        },
+        "total_ending_market_value_portfolio_currency": Decimal("5475"),
+        "quality_status_distribution": {"final": 1, "restated": 1},
+    },
+}
 
 
 @pytest.fixture(scope="module")
@@ -204,24 +238,21 @@ def setup_timeseries_data(clean_db_module, e2e_api_client: E2EApiClient):
     )
     for valuation_date in ("2025-08-28", "2025-08-29"):
         payload = _position_timeseries_request(valuation_date)
-        start = time.time()
-        last_response = None
-        while time.time() - start < 180:
-            response = e2e_api_client.post_query(
-                f"/integration/portfolios/{portfolio_id}/analytics/position-timeseries",
-                payload,
-                raise_for_status=False,
-            )
-            if response.status_code == 200:
-                last_response = response.json()
-                if _has_stock_timeseries_row(last_response, valuation_date=valuation_date):
-                    break
-            time.sleep(2)
-        else:
-            pytest.fail(
+        e2e_api_client.poll_for_post_query_data(
+            f"/integration/portfolios/{portfolio_id}/analytics/position-timeseries",
+            payload,
+            lambda data: _has_expected_timeseries_rows(
+                data,
+                valuation_date=valuation_date,
+                stock_security_id=stock_security_id,
+                cash_security_id=cash_security_id,
+            ),
+            timeout=180,
+            fail_message=(
                 "Pipeline did not produce analytics position-timeseries rows for "
-                f"{valuation_date}. Last response: {last_response}"
-            )
+                f"{valuation_date}."
+            ),
+        )
     return {
         "portfolio_id": portfolio_id,
         "stock_security_id": stock_security_id,
@@ -249,16 +280,6 @@ def _sum_portfolio_currency(rows: list[dict]) -> Decimal:
     return total
 
 
-def _has_stock_timeseries_row(payload: dict, *, valuation_date: str) -> bool:
-    for row in payload.get("rows", []):
-        if (
-            row.get("security_id", "").startswith("SEC_EUR_STOCK_")
-            and row.get("valuation_date") == valuation_date
-        ):
-            return True
-    return False
-
-
 def _has_expected_positions(
     payload: dict,
     *,
@@ -273,7 +294,100 @@ def _has_expected_positions(
     cash_row = next((row for row in positions if row.get("security_id") == cash_security_id), None)
     if stock_row is None or cash_row is None:
         return False
-    return as_decimal(stock_row["quantity"]) == Decimal("100")
+    return (
+        as_decimal(stock_row["quantity"]) == Decimal("100")
+        and as_decimal(cash_row["quantity"]) == Decimal("-25")
+    )
+
+
+def _row_by_security_id(payload: dict, security_id: str) -> dict:
+    return next(row for row in payload["rows"] if row["security_id"] == security_id)
+
+
+def _expected_row_for_security(valuation_date: str, security_id: str) -> dict:
+    for prefix, expected in EXPECTED_TIMESERIES_ROWS[valuation_date].items():
+        if prefix == "total_ending_market_value_portfolio_currency":
+            continue
+        if security_id.startswith(prefix):
+            return expected
+    raise KeyError(f"No expected row configured for {valuation_date=} {security_id=}")
+
+
+def _assert_timeseries_payload(
+    payload: dict,
+    *,
+    valuation_date: str,
+    portfolio_id: str,
+    stock_security_id: str,
+    cash_security_id: str,
+) -> None:
+    expected_for_day = EXPECTED_TIMESERIES_ROWS[valuation_date]
+    assert payload["portfolio_id"] == portfolio_id
+    assert payload["portfolio_currency"] == "USD"
+    assert payload["reporting_currency"] == "USD"
+    assert payload["frequency"] == "daily"
+    assert payload["contract_version"] == "rfc_063_v1"
+    assert payload["calendar_id"] == "business_date_calendar"
+    assert payload["missing_observation_policy"] == "strict"
+    assert payload["resolved_window"] == {"start_date": valuation_date, "end_date": valuation_date}
+    assert payload["page"] == {"next_page_token": None}
+
+    diagnostics = payload["diagnostics"]
+    assert diagnostics["missing_dates_count"] == 0
+    assert diagnostics["stale_points_count"] == 0
+    assert diagnostics["quality_status_distribution"] == expected_for_day[
+        "quality_status_distribution"
+    ]
+
+    rows = payload["rows"]
+    assert len(rows) == 2
+    assert {row["security_id"] for row in rows} == {stock_security_id, cash_security_id}
+
+    for security_id in (stock_security_id, cash_security_id):
+        row = _row_by_security_id(payload, security_id)
+        expected = _expected_row_for_security(valuation_date, security_id)
+        assert row["valuation_date"] == valuation_date
+        assert row["position_currency"] == expected["position_currency"]
+        assert row["dimensions"] == {}
+        assert row["valuation_status"] == expected["valuation_status"]
+        assert as_decimal(row["quantity"]) == expected["quantity"]
+        assert (
+            as_decimal(row["ending_market_value_portfolio_currency"])
+            == expected["ending_market_value_portfolio_currency"]
+        )
+
+    assert _sum_portfolio_currency(rows) == expected_for_day[
+        "total_ending_market_value_portfolio_currency"
+    ]
+
+
+def _has_expected_timeseries_rows(
+    payload: dict,
+    *,
+    valuation_date: str,
+    stock_security_id: str,
+    cash_security_id: str,
+) -> bool:
+    try:
+        rows = payload.get("rows", [])
+        if len(rows) != 2:
+            return False
+        stock_row = _row_by_security_id(payload, stock_security_id)
+        cash_row = _row_by_security_id(payload, cash_security_id)
+        stock_expected = _expected_row_for_security(valuation_date, stock_security_id)
+        cash_expected = _expected_row_for_security(valuation_date, cash_security_id)
+        return (
+            stock_row["valuation_date"] == valuation_date
+            and cash_row["valuation_date"] == valuation_date
+            and as_decimal(stock_row["quantity"]) == stock_expected["quantity"]
+            and as_decimal(cash_row["quantity"]) == cash_expected["quantity"]
+            and as_decimal(stock_row["ending_market_value_portfolio_currency"])
+            == stock_expected["ending_market_value_portfolio_currency"]
+            and as_decimal(cash_row["ending_market_value_portfolio_currency"])
+            == cash_expected["ending_market_value_portfolio_currency"]
+        )
+    except (KeyError, StopIteration):
+        return False
 
 
 def test_analytics_input_timeseries_contract_day_1_returns_expected_rows(
@@ -285,18 +399,13 @@ def test_analytics_input_timeseries_contract_day_1_returns_expected_rows(
         _position_timeseries_request("2025-08-28"),
     )
     payload = response.json()
-    assert payload["portfolio_id"] == portfolio_id
-    assert "rows" in payload
-    assert payload["rows"]
-    stock_row = next(
-        row
-        for row in payload["rows"]
-        if row["security_id"] == setup_timeseries_data["stock_security_id"]
+    _assert_timeseries_payload(
+        payload,
+        valuation_date="2025-08-28",
+        portfolio_id=portfolio_id,
+        stock_security_id=setup_timeseries_data["stock_security_id"],
+        cash_security_id=setup_timeseries_data["cash_security_id"],
     )
-    assert as_decimal(stock_row["quantity"]) == Decimal("100")
-    assert as_decimal(stock_row["ending_market_value_portfolio_currency"]) > Decimal("0")
-    assert stock_row["valuation_date"] == "2025-08-28"
-    assert "diagnostics" in payload
 
 
 def test_analytics_input_timeseries_contract_day_2_returns_expected_rows(
@@ -308,18 +417,13 @@ def test_analytics_input_timeseries_contract_day_2_returns_expected_rows(
         _position_timeseries_request("2025-08-29"),
     )
     payload = response.json()
-    assert payload["portfolio_id"] == portfolio_id
-    assert "rows" in payload
-    assert payload["rows"]
-    stock_row = next(
-        row
-        for row in payload["rows"]
-        if row["security_id"] == setup_timeseries_data["stock_security_id"]
+    _assert_timeseries_payload(
+        payload,
+        valuation_date="2025-08-29",
+        portfolio_id=portfolio_id,
+        stock_security_id=setup_timeseries_data["stock_security_id"],
+        cash_security_id=setup_timeseries_data["cash_security_id"],
     )
-    assert as_decimal(stock_row["quantity"]) == Decimal("100")
-    assert as_decimal(stock_row["ending_market_value_portfolio_currency"]) > Decimal("0")
-    assert stock_row["valuation_date"] == "2025-08-29"
-    assert "diagnostics" in payload
 
 
 def test_analytics_input_position_timeseries_contract_day_2_returns_expected_rows(
@@ -336,19 +440,17 @@ def test_analytics_input_position_timeseries_contract_day_2_returns_expected_row
         _position_timeseries_request("2025-08-29"),
     )
     payload = response.json()
-    assert payload["portfolio_id"] == portfolio_id
-    assert payload["rows"]
-    day_1_stock = next(
-        row
-        for row in day_1_payload["rows"]
-        if row["security_id"] == setup_timeseries_data["stock_security_id"]
+    _assert_timeseries_payload(
+        day_1_payload,
+        valuation_date="2025-08-28",
+        portfolio_id=portfolio_id,
+        stock_security_id=setup_timeseries_data["stock_security_id"],
+        cash_security_id=setup_timeseries_data["cash_security_id"],
     )
-    day_2_stock = next(
-        row
-        for row in payload["rows"]
-        if row["security_id"] == setup_timeseries_data["stock_security_id"]
+    _assert_timeseries_payload(
+        payload,
+        valuation_date="2025-08-29",
+        portfolio_id=portfolio_id,
+        stock_security_id=setup_timeseries_data["stock_security_id"],
+        cash_security_id=setup_timeseries_data["cash_security_id"],
     )
-    assert as_decimal(day_2_stock["ending_market_value_portfolio_currency"]) > as_decimal(
-        day_1_stock["ending_market_value_portfolio_currency"]
-    )
-    assert "diagnostics" in payload


### PR DESCRIPTION
## Summary
- strengthen core E2E workflow assertions with exact business-state checks
- add shared E2E polling/state assertion helpers to reduce duplication and improve timeout diagnostics
- fix the local financial reconciliation image build blocker so the E2E stack can come up reliably

## Validation
- `python -m ruff check tests/e2e/api_client.py tests/e2e/state_assertions.py tests/e2e/test_timeseries_pipeline.py tests/e2e/test_5_day_workflow.py tests/e2e/test_dual_currency_workflow.py tests/e2e/test_reprocessing_workflow.py tests/e2e/test_rapid_reprocessing.py`
- `python -m pytest tests/e2e/test_timeseries_pipeline.py -q -s`
- `python -m pytest tests/e2e/test_5_day_workflow.py -q -s`
- `python -m pytest tests/e2e/test_5_day_workflow.py tests/e2e/test_dual_currency_workflow.py -q -s`
- `python -m pytest tests/e2e/test_reprocessing_workflow.py tests/e2e/test_rapid_reprocessing.py -q -s`
- `docker build -f src/services/financial_reconciliation_service/Dockerfile -t lotus-core-financial-reconciliation-buildcheck .`
- `docker build -f src/services/query_service/Dockerfile -t lotus-core-query-service-buildcheck .`

## Notes
- This is the first E2E quality slice; the next likely follow-up is making the default E2E ingest client strict about payload shape while keeping one explicit compatibility path for legacy aliases.
