### PR TITLE
ci: adopt standard PR and main test tiering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,65 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  e2e-smoke:
+    name: E2E Smoke
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request'
+    needs: [quality]
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Restore Docker build cache
+        uses: actions/cache@v4
+        with:
+          path: .buildx-cache
+          key: ${{ runner.os }}-buildx-${{ hashFiles('docker-compose.yml', 'requirements/shared-runtime.lock.txt', 'src/**/Dockerfile', 'src/**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+
+      - name: Install Tooling and Project Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          make install
+
+      - name: Prebuild compose images with cache
+        run: python scripts/prebuild_ci_images.py --cache-dir .buildx-cache --group e2e-smoke
+
+      - name: Run E2E smoke suite
+        env:
+          LOTUS_TEST_ENV_PROFILE: e2e
+          E2E_INGESTION_URL: http://localhost:8400
+          E2E_QUERY_URL: http://localhost:8401
+          HOST_DATABASE_URL: postgresql://user:password@localhost:57432/portfolio_db
+        run: make test-e2e-smoke
+
+      - name: Capture docker compose logs on failure
+        if: failure()
+        run: docker compose logs > e2e-smoke-logs.txt
+
+      - name: Upload E2E smoke diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-smoke-artifacts
+          path: e2e-smoke-logs.txt
+          if-no-files-found: warn
+          retention-days: 14
+
   docker-smoke-contract:
     name: Docker Smoke Contract
     if: >
@@ -482,7 +541,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main')
-    needs: [quality, coverage-gate, integration-all, performance-load-gate-full]
+    needs: [quality]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/scripts/ci_service_sets.py
+++ b/scripts/ci_service_sets.py
@@ -39,9 +39,26 @@ PERFORMANCE_GATE_SERVICES: tuple[str, ...] = (
 
 FAILURE_RECOVERY_GATE_SERVICES: tuple[str, ...] = PERFORMANCE_GATE_SERVICES
 
+E2E_SMOKE_SERVICES: tuple[str, ...] = (
+    "ingestion_service",
+    "event_replay_service",
+    "query_service",
+    "query_control_plane_service",
+    "persistence_service",
+    "cost_calculator_service",
+    "cashflow_calculator_service",
+    "position_calculator_service",
+    "pipeline_orchestrator_service",
+    "position_valuation_calculator",
+    "timeseries_generator_service",
+    "valuation_orchestrator_service",
+    "portfolio_aggregation_service",
+)
+
 PREBUILD_GROUPS: dict[str, tuple[str, ...]] = {
     "query-only": QUERY_BUILD_SERVICES,
     "docker-smoke": DOCKER_SMOKE_SERVICES,
+    "e2e-smoke": E2E_SMOKE_SERVICES,
     "latency-gate": LATENCY_GATE_SERVICES,
     "performance-gate": PERFORMANCE_GATE_SERVICES,
     "failure-recovery-gate": FAILURE_RECOVERY_GATE_SERVICES,


### PR DESCRIPTION
## Summary
- add an `E2E Smoke` job for PR and push validation using the existing `e2e-smoke` suite
- let `E2E Full` on `main` run after `quality` instead of waiting behind unrelated heavy jobs
- add an explicit `e2e-smoke` prebuild service group so CI behavior is predictable

## Why
This matches the common industry split:
- PRs run fast, meaningful checks including a narrow end-to-end slice
- `main` runs the exhaustive end-to-end suite
- heavy jobs on `main` run in parallel unless they have a real artifact dependency

## Validation
- `python scripts/test_manifest.py --suite e2e-smoke --validate-only`
- `python -m ruff check scripts/ci_service_sets.py`
- YAML parse of `.github/workflows/ci.yml`
- verified `scripts.ci_service_sets.PREBUILD_GROUPS['e2e-smoke']`
