### PR TITLE
fix(issue-250): preserve dual-leg position flow semantics

### DIFF
--- a/src/services/calculators/cashflow_calculator_service/app/consumers/transaction_consumer.py
+++ b/src/services/calculators/cashflow_calculator_service/app/consumers/transaction_consumer.py
@@ -97,7 +97,6 @@ class LinkedCashLegError(ValueError):
 
 
 ADJUSTMENT_TRANSACTION_TYPE = "ADJUSTMENT"
-LINKED_CASHFLOW_SKIP_TRANSACTION_TYPES = {"BUY", "SELL", "DIVIDEND", "INTEREST"}
 NON_CASHFLOW_EFFECTIVE_PROCESSING_TYPES = {"FX_CONTRACT_OPEN", "FX_CONTRACT_CLOSE"}
 
 
@@ -257,31 +256,6 @@ class CashflowCalculatorConsumer(BaseConsumer):
                                 "UPSTREAM_PROVIDED product leg requires "
                                 "external_cash_transaction_id."
                             )
-                        if (
-                            event_transaction_type in LINKED_CASHFLOW_SKIP_TRANSACTION_TYPES
-                            and has_linked_cash_leg
-                        ):
-                            logger.info(
-                                "Skipping product-leg cashflow creation because "
-                                "linked ADJUSTMENT cash leg is authoritative.",
-                                extra={
-                                    "transaction_id": event.transaction_id,
-                                    "transaction_type": event_transaction_type,
-                                    "external_cash_transaction_id": (
-                                        event.external_cash_transaction_id
-                                    ),
-                                    "economic_event_id": event.economic_event_id,
-                                    "linked_transaction_group_id": (
-                                        event.linked_transaction_group_id
-                                    ),
-                                },
-                            )
-                            await idempotency_repo.mark_event_processed(
-                                event_id, event.portfolio_id, SERVICE_NAME, correlation_id
-                            )
-                            await db.commit()
-                            return
-
                         if event_transaction_type in NON_CASHFLOW_EFFECTIVE_PROCESSING_TYPES:
                             logger.info(
                                 "Skipping cashflow creation for non-cash FX contract lifecycle "

--- a/src/services/timeseries_generator_service/app/core/position_timeseries_logic.py
+++ b/src/services/timeseries_generator_service/app/core/position_timeseries_logic.py
@@ -16,6 +16,18 @@ class PositionTimeseriesLogic:
     """
 
     @staticmethod
+    def _normalize_position_flow_amount(cf: Cashflow) -> Decimal:
+        """
+        Cashflows are stored using actual cash-movement direction for cash ledgers.
+        Position-timeseries needs product-leg flows from the position perspective so
+        linked product and cash legs net to zero across positions.
+        """
+        amount = Decimal(cf.amount)
+        if cf.classification in {"INVESTMENT_OUTFLOW", "INVESTMENT_INFLOW", "INCOME"}:
+            return -amount
+        return amount
+
+    @staticmethod
     def calculate_daily_record(
         current_snapshot: DailyPositionSnapshot,
         previous_snapshot: DailyPositionSnapshot | None,
@@ -42,10 +54,13 @@ class PositionTimeseriesLogic:
 
         for cf in cashflows:
             if cf.is_position_flow:
+                normalized_position_amount = (
+                    PositionTimeseriesLogic._normalize_position_flow_amount(cf)
+                )
                 if cf.timing == "BOD":
-                    bod_cf_pos += cf.amount
+                    bod_cf_pos += normalized_position_amount
                 else:  # EOD
-                    eod_cf_pos += cf.amount
+                    eod_cf_pos += normalized_position_amount
 
             if cf.is_portfolio_flow:
                 if cf.timing == "BOD":

--- a/tests/e2e/test_transaction_type_coverage.py
+++ b/tests/e2e/test_transaction_type_coverage.py
@@ -428,3 +428,73 @@ def test_dual_leg_upstream_settlement_cashflow_authority(
     assert tx_by_id[cash_txn_id]["originating_transaction_id"] == buy_txn_id
     assert tx_by_id[buy_txn_id]["cash_entry_mode"] == "UPSTREAM_PROVIDED"
     assert tx_by_id[cash_txn_id]["transaction_type"] == "ADJUSTMENT"
+
+
+def test_dual_leg_upstream_settlement_position_timeseries_flows_net_to_zero(
+    setup_dual_leg_settlement_scenario, e2e_api_client: E2EApiClient
+):
+    portfolio_id = setup_dual_leg_settlement_scenario["portfolio_id"]
+
+    e2e_api_client.ingest(
+        "/ingest/business-dates",
+        {"business_dates": [{"business_date": "2026-03-02"}]},
+    )
+    e2e_api_client.ingest(
+        "/ingest/market-prices",
+        {
+            "market_prices": [
+                {
+                    "security_id": "SEC_DUAL",
+                    "price_date": "2026-03-02",
+                    "price": "100",
+                    "currency": "USD",
+                },
+                {
+                    "security_id": "CASH_USD_DUAL",
+                    "price_date": "2026-03-02",
+                    "price": "1",
+                    "currency": "USD",
+                },
+            ]
+        },
+    )
+
+    payload = {
+        "as_of_date": "2026-03-02",
+        "window": {"start_date": "2026-03-02", "end_date": "2026-03-02"},
+        "consumer_system": "lotus-performance",
+        "frequency": "daily",
+        "dimensions": [],
+        "include_cash_flows": True,
+        "filters": {},
+        "page": {"page_size": 50},
+    }
+
+    response_payload = e2e_api_client.poll_for_post_query_data(
+        f"/integration/portfolios/{portfolio_id}/analytics/position-timeseries",
+        payload,
+        lambda data: len(data.get("rows", [])) >= 2
+        and {
+            row.get("security_id")
+            for row in data.get("rows", [])
+            if row.get("valuation_date") == "2026-03-02"
+        }
+        >= {"SEC_DUAL", "CASH_USD_DUAL"},
+        timeout=240,
+        fail_message=(
+            "Dual-leg position-timeseries rows were not available for acquisition-day validation."
+        ),
+    )
+
+    row_by_security = {row["security_id"]: row for row in response_payload["rows"]}
+    stock_row = row_by_security["SEC_DUAL"]
+    cash_row = row_by_security["CASH_USD_DUAL"]
+
+    stock_flow_total = sum(Decimal(str(flow["amount"])) for flow in stock_row["cash_flows"])
+    cash_flow_total = sum(Decimal(str(flow["amount"])) for flow in cash_row["cash_flows"])
+
+    assert Decimal(str(stock_row["beginning_market_value_position_currency"])) == Decimal("0")
+    assert Decimal(str(stock_row["ending_market_value_position_currency"])) == Decimal("1000")
+    assert stock_flow_total == Decimal("1000")
+    assert cash_flow_total == Decimal("-1000")
+    assert stock_flow_total + cash_flow_total == Decimal("0")

--- a/tests/unit/services/calculators/cashflow_calculator_service/unit/consumers/test_cashflow_transaction_consumer.py
+++ b/tests/unit/services/calculators/cashflow_calculator_service/unit/consumers/test_cashflow_transaction_consumer.py
@@ -556,7 +556,7 @@ async def test_process_message_skips_non_cash_fx_contract_lifecycle_components(
     cashflow_consumer._send_to_dlq_async.assert_not_called()
 
 
-async def test_process_message_dividend_external_mode_skips_auto_cashflow_creation(
+async def test_process_message_dividend_external_mode_still_creates_product_cashflow(
     cashflow_consumer: CashflowCalculatorConsumer,
     mock_kafka_message: MagicMock,
     mock_dependencies: dict,
@@ -586,6 +586,30 @@ async def test_process_message_dividend_external_mode_skips_auto_cashflow_creati
     mock_kafka_message.value.return_value = event.model_dump_json().encode("utf-8")
 
     mock_idempotency_repo.is_event_processed.return_value = False
+    mock_rules_repo.get_all_rules.return_value = [
+        CashflowRule(
+            transaction_type="DIVIDEND",
+            classification="INCOME",
+            timing="EOD",
+            is_position_flow=True,
+            is_portfolio_flow=False,
+        )
+    ]
+    mock_cashflow_repo.create_cashflow.return_value = Cashflow(
+        id=21,
+        transaction_id=event.transaction_id,
+        portfolio_id=event.portfolio_id,
+        security_id=event.security_id,
+        cashflow_date=date(2025, 8, 1),
+        amount=Decimal("1000"),
+        currency="USD",
+        classification="INCOME",
+        timing="EOD",
+        calculation_type="NET",
+        is_position_flow=True,
+        is_portfolio_flow=False,
+        epoch=1,
+    )
 
     with patch(
         "src.services.calculators.cashflow_calculator_service.app.consumers.transaction_consumer.EpochFencer"
@@ -596,9 +620,9 @@ async def test_process_message_dividend_external_mode_skips_auto_cashflow_creati
 
         await cashflow_consumer.process_message(mock_kafka_message)
 
-    mock_rules_repo.get_all_rules.assert_not_awaited()
-    mock_cashflow_repo.create_cashflow.assert_not_called()
-    mock_outbox_repo.create_outbox_event.assert_not_called()
+    mock_rules_repo.get_all_rules.assert_awaited_once()
+    mock_cashflow_repo.create_cashflow.assert_called_once()
+    mock_outbox_repo.create_outbox_event.assert_called_once()
     mock_idempotency_repo.mark_event_processed.assert_awaited_once()
     cashflow_consumer._send_to_dlq_async.assert_not_called()
 
@@ -652,7 +676,7 @@ async def test_process_message_dividend_external_mode_without_link_sends_to_dlq(
     assert isinstance(dlq_error_arg, LinkedCashLegError)
 
 
-async def test_process_message_interest_external_mode_skips_auto_cashflow_creation(
+async def test_process_message_interest_external_mode_still_creates_product_cashflow(
     cashflow_consumer: CashflowCalculatorConsumer,
     mock_kafka_message: MagicMock,
     mock_dependencies: dict,
@@ -682,6 +706,30 @@ async def test_process_message_interest_external_mode_skips_auto_cashflow_creati
     mock_kafka_message.value.return_value = event.model_dump_json().encode("utf-8")
 
     mock_idempotency_repo.is_event_processed.return_value = False
+    mock_rules_repo.get_all_rules.return_value = [
+        CashflowRule(
+            transaction_type="INTEREST",
+            classification="INCOME",
+            timing="EOD",
+            is_position_flow=True,
+            is_portfolio_flow=False,
+        )
+    ]
+    mock_cashflow_repo.create_cashflow.return_value = Cashflow(
+        id=22,
+        transaction_id=event.transaction_id,
+        portfolio_id=event.portfolio_id,
+        security_id=event.security_id,
+        cashflow_date=date(2025, 8, 1),
+        amount=Decimal("1000"),
+        currency="USD",
+        classification="INCOME",
+        timing="EOD",
+        calculation_type="NET",
+        is_position_flow=True,
+        is_portfolio_flow=False,
+        epoch=1,
+    )
 
     with patch(
         "src.services.calculators.cashflow_calculator_service.app.consumers.transaction_consumer.EpochFencer"
@@ -692,9 +740,9 @@ async def test_process_message_interest_external_mode_skips_auto_cashflow_creati
 
         await cashflow_consumer.process_message(mock_kafka_message)
 
-    mock_rules_repo.get_all_rules.assert_not_awaited()
-    mock_cashflow_repo.create_cashflow.assert_not_called()
-    mock_outbox_repo.create_outbox_event.assert_not_called()
+    mock_rules_repo.get_all_rules.assert_awaited_once()
+    mock_cashflow_repo.create_cashflow.assert_called_once()
+    mock_outbox_repo.create_outbox_event.assert_called_once()
     mock_idempotency_repo.mark_event_processed.assert_awaited_once()
     cashflow_consumer._send_to_dlq_async.assert_not_called()
 
@@ -748,7 +796,7 @@ async def test_process_message_interest_external_mode_without_link_sends_to_dlq(
     assert isinstance(dlq_error_arg, LinkedCashLegError)
 
 
-async def test_process_message_buy_with_linked_cash_leg_skips_product_cashflow(
+async def test_process_message_buy_with_linked_cash_leg_still_creates_product_cashflow(
     cashflow_consumer: CashflowCalculatorConsumer,
     mock_kafka_message: MagicMock,
     mock_dependencies: dict,
@@ -778,6 +826,30 @@ async def test_process_message_buy_with_linked_cash_leg_skips_product_cashflow(
     mock_kafka_message.value.return_value = event.model_dump_json().encode("utf-8")
 
     mock_idempotency_repo.is_event_processed.return_value = False
+    mock_rules_repo.get_all_rules.return_value = [
+        CashflowRule(
+            transaction_type="BUY",
+            classification="INVESTMENT_OUTFLOW",
+            timing="BOD",
+            is_position_flow=True,
+            is_portfolio_flow=False,
+        )
+    ]
+    mock_cashflow_repo.create_cashflow.return_value = Cashflow(
+        id=23,
+        transaction_id=event.transaction_id,
+        portfolio_id=event.portfolio_id,
+        security_id=event.security_id,
+        cashflow_date=date(2025, 8, 1),
+        amount=Decimal("-1005"),
+        currency="USD",
+        classification="INVESTMENT_OUTFLOW",
+        timing="BOD",
+        calculation_type="NET",
+        is_position_flow=True,
+        is_portfolio_flow=False,
+        epoch=1,
+    )
 
     with patch(
         "src.services.calculators.cashflow_calculator_service.app.consumers.transaction_consumer.EpochFencer"
@@ -788,9 +860,9 @@ async def test_process_message_buy_with_linked_cash_leg_skips_product_cashflow(
 
         await cashflow_consumer.process_message(mock_kafka_message)
 
-    mock_rules_repo.get_all_rules.assert_not_awaited()
-    mock_cashflow_repo.create_cashflow.assert_not_called()
-    mock_outbox_repo.create_outbox_event.assert_not_called()
+    mock_rules_repo.get_all_rules.assert_awaited_once()
+    mock_cashflow_repo.create_cashflow.assert_called_once()
+    mock_outbox_repo.create_outbox_event.assert_called_once()
     mock_idempotency_repo.mark_event_processed.assert_awaited_once()
     cashflow_consumer._send_to_dlq_async.assert_not_called()
 

--- a/tests/unit/services/timeseries_generator_service/timeseries-generator-service/core/test_position_timeseries_logic.py
+++ b/tests/unit/services/timeseries_generator_service/timeseries-generator-service/core/test_position_timeseries_logic.py
@@ -89,3 +89,42 @@ def test_logic_with_portfolio_and_position_flows(current_snapshot, previous_day_
     assert new_record.bod_cashflow_portfolio == Decimal("0")
     assert new_record.eod_cashflow_position == Decimal("-50")
     assert new_record.eod_cashflow_portfolio == Decimal("-50")
+
+
+def test_logic_normalizes_product_leg_position_flow_signs_for_attribution(
+    current_snapshot, previous_day_snapshot
+):
+    cashflows = [
+        Cashflow(
+            amount=Decimal("-1000"),
+            classification="INVESTMENT_OUTFLOW",
+            timing="BOD",
+            is_position_flow=True,
+            is_portfolio_flow=False,
+        ),
+        Cashflow(
+            amount=Decimal("250"),
+            classification="INCOME",
+            timing="EOD",
+            is_position_flow=True,
+            is_portfolio_flow=False,
+        ),
+        Cashflow(
+            amount=Decimal("-1000"),
+            classification="TRANSFER",
+            timing="EOD",
+            is_position_flow=True,
+            is_portfolio_flow=False,
+        ),
+    ]
+
+    new_record = PositionTimeseriesLogic.calculate_daily_record(
+        current_snapshot=current_snapshot,
+        previous_snapshot=previous_day_snapshot,
+        cashflows=cashflows,
+        epoch=0,
+    )
+
+    assert new_record.bod_cashflow_position == Decimal("1000")
+    # income is a position credit on the product leg; cash settlement remains transfer-signed
+    assert new_record.eod_cashflow_position == Decimal("-1250")


### PR DESCRIPTION
Fixes #250

## Summary
- stop dropping product-leg cashflows for linked dual-leg economic events
- normalize product-leg position flow signs in position-timeseries so product and cash legs net to zero across positions
- add regression coverage for cashflow consumer, position-timeseries logic, and dual-leg E2E analytics contract

## Validation
- python -m pytest tests/unit/services/calculators/cashflow_calculator_service/unit/consumers/test_cashflow_transaction_consumer.py tests/unit/services/timeseries_generator_service/timeseries-generator-service/core/test_position_timeseries_logic.py -q
- python -m ruff check src/services/calculators/cashflow_calculator_service/app/consumers/transaction_consumer.py src/services/timeseries_generator_service/app/core/position_timeseries_logic.py tests/unit/services/calculators/cashflow_calculator_service/unit/consumers/test_cashflow_transaction_consumer.py tests/unit/services/timeseries_generator_service/timeseries-generator-service/core/test_position_timeseries_logic.py tests/e2e/test_transaction_type_coverage.py
- $env:LOTUS_TESTS_DOCKER_BUILD='1'; python -m pytest tests/e2e/test_transaction_type_coverage.py -k dual_leg -q -s
