### PR TITLE
fix(issue-249): default benchmark assignment recorded time

### DIFF
--- a/src/services/ingestion_service/app/services/reference_data_ingestion_service.py
+++ b/src/services/ingestion_service/app/services/reference_data_ingestion_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import Depends
@@ -25,9 +25,16 @@ class ReferenceDataIngestionService:
         self._db = db
 
     async def upsert_portfolio_benchmark_assignments(self, records: list[dict[str, Any]]) -> None:
+        now = datetime.now(UTC)
+        normalized_records = []
+        for record in records:
+            row = dict(record)
+            if row.get("assignment_recorded_at") is None:
+                row["assignment_recorded_at"] = now
+            normalized_records.append(row)
         await self._upsert_many(
             model=PortfolioBenchmarkAssignment,
-            records=records,
+            records=normalized_records,
             conflict_columns=[
                 "portfolio_id",
                 "benchmark_id",
@@ -206,7 +213,7 @@ class ReferenceDataIngestionService:
         if not records:
             return
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         payload = []
         for record in records:
             row = dict(record)

--- a/tests/integration/services/ingestion_service/test_ingestion_routers.py
+++ b/tests/integration/services/ingestion_service/test_ingestion_routers.py
@@ -699,7 +699,14 @@ async def ingestion_test_harness(mock_kafka_producer: MagicMock):
         async def upsert_portfolio_benchmark_assignments(
             self, records: list[dict[str, object]]
         ) -> None:
-            self.persisted["benchmark_assignments"].extend(records)
+            now = datetime.now(UTC)
+            normalized = []
+            for record in records:
+                row = dict(record)
+                if row.get("assignment_recorded_at") is None:
+                    row["assignment_recorded_at"] = now
+                normalized.append(row)
+            self.persisted["benchmark_assignments"].extend(normalized)
 
         async def upsert_benchmark_definitions(
             self, records: list[dict[str, object]]
@@ -1095,6 +1102,33 @@ async def test_reference_data_ingest_reports_bookkeeping_failure_after_persist(
     failure_history = await event_replay_test_client.get(f"/ingestion/jobs/{job_id}/failures")
     assert failure_history.status_code == 200
     assert failure_history.json()["failures"][0]["failure_phase"] == "persist_bookkeeping"
+
+
+async def test_ingest_benchmark_assignments_defaults_assignment_recorded_at_when_omitted(
+    async_test_client: httpx.AsyncClient,
+    ingestion_test_harness,
+):
+    payload = {
+        "benchmark_assignments": [
+            {
+                "portfolio_id": "LIVE_REAL_005607",
+                "benchmark_id": "BMK_US_60_40_005607",
+                "effective_from": "2026-01-01",
+                "assignment_source": "benchmark_policy_engine",
+                "assignment_status": "active",
+                "source_system": "lotus-manage",
+            }
+        ]
+    }
+
+    response = await async_test_client.post("/ingest/benchmark-assignments", json=payload)
+
+    assert response.status_code == 202
+    persisted = ingestion_test_harness["fake_reference_data_service"].persisted[
+        "benchmark_assignments"
+    ]
+    assert len(persisted) == 1
+    assert persisted[0]["assignment_recorded_at"] is not None
 
 
 async def test_ingestion_job_retry_reports_bookkeeping_failure_after_replay_publish(

--- a/tests/unit/services/ingestion_service/test_reference_data_ingestion_service.py
+++ b/tests/unit/services/ingestion_service/test_reference_data_ingestion_service.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.services.ingestion_service.app.services.reference_data_ingestion_service import (
+    ReferenceDataIngestionService,
+)
+
+
+@pytest.mark.asyncio
+async def test_upsert_portfolio_benchmark_assignments_defaults_assignment_recorded_at() -> None:
+    db = AsyncMock(spec=AsyncSession)
+    service = ReferenceDataIngestionService(db)
+
+    await service.upsert_portfolio_benchmark_assignments(
+        [
+            {
+                "portfolio_id": "PORT_001",
+                "benchmark_id": "BMK_001",
+                "effective_from": "2026-01-01",
+                "assignment_source": "benchmark_policy_engine",
+                "assignment_status": "active",
+                "source_system": "lotus-manage",
+                "assignment_recorded_at": None,
+            }
+        ]
+    )
+
+    db.execute.assert_awaited_once()
+    compiled_params = db.execute.await_args.args[0].compile().params
+    assert isinstance(compiled_params["assignment_recorded_at_m0"], datetime)
+    db.commit.assert_awaited_once()


### PR DESCRIPTION
Fixes #249

## Summary
- default ssignment_recorded_at server-side when omitted on benchmark assignment ingestion
- keep timestamps UTC-aware in the ingestion service path
- add unit and integration coverage for omitted ssignment_recorded_at

## Validation
- python -m pytest tests/unit/services/ingestion_service/test_reference_data_ingestion_service.py tests/integration/services/ingestion_service/test_ingestion_routers.py -q
- python -m ruff check src/services/ingestion_service/app/services/reference_data_ingestion_service.py tests/unit/services/ingestion_service/test_reference_data_ingestion_service.py tests/integration/services/ingestion_service/test_ingestion_routers.py

## Note
- Issue #250 is already merged to main via PR #251; this PR is only for the remaining #249 fix.
