### PR TITLE
feat(query): add pbwm portfolio workspace source contracts

### DIFF
--- a/alembic/versions/b1c2d3e4f5a6_feat_add_cash_account_master_and_lookthrough_tables.py
+++ b/alembic/versions/b1c2d3e4f5a6_feat_add_cash_account_master_and_lookthrough_tables.py
@@ -1,0 +1,214 @@
+"""add cash account master and lookthrough tables
+
+Revision ID: b1c2d3e4f5a6
+Revises: rev_a1d9c8b7e6f5
+Create Date: 2026-03-28 16:55:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b1c2d3e4f5a6"
+down_revision: str | None = "rev_a1d9c8b7e6f5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "cash_account_masters",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("cash_account_id", sa.String(), nullable=False),
+        sa.Column("portfolio_id", sa.String(), nullable=False),
+        sa.Column("security_id", sa.String(), nullable=False),
+        sa.Column("display_name", sa.String(), nullable=False),
+        sa.Column("account_currency", sa.String(length=3), nullable=False),
+        sa.Column("account_role", sa.String(), nullable=True),
+        sa.Column(
+            "lifecycle_status",
+            sa.String(),
+            nullable=False,
+            server_default="ACTIVE",
+        ),
+        sa.Column("opened_on", sa.Date(), nullable=True),
+        sa.Column("closed_on", sa.Date(), nullable=True),
+        sa.Column("source_system", sa.String(), nullable=True),
+        sa.Column("source_record_id", sa.String(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["portfolio_id"], ["portfolios.portfolio_id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("cash_account_id", name="_cash_account_master_id_uc"),
+    )
+    op.create_index(
+        "ix_cash_account_masters_cash_account_id",
+        "cash_account_masters",
+        ["cash_account_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_cash_account_masters_portfolio_id",
+        "cash_account_masters",
+        ["portfolio_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_cash_account_masters_security_id",
+        "cash_account_masters",
+        ["security_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_cash_account_masters_account_currency",
+        "cash_account_masters",
+        ["account_currency"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_cash_account_masters_account_role",
+        "cash_account_masters",
+        ["account_role"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_cash_account_masters_lifecycle_status",
+        "cash_account_masters",
+        ["lifecycle_status"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_cash_account_masters_opened_on",
+        "cash_account_masters",
+        ["opened_on"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_cash_account_masters_closed_on",
+        "cash_account_masters",
+        ["closed_on"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_cash_account_master_portfolio_effective_window",
+        "cash_account_masters",
+        ["portfolio_id", "opened_on", "closed_on"],
+        unique=False,
+    )
+
+    op.create_table(
+        "instrument_lookthrough_components",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("parent_security_id", sa.String(), nullable=False),
+        sa.Column("component_security_id", sa.String(), nullable=False),
+        sa.Column("effective_from", sa.Date(), nullable=False),
+        sa.Column("effective_to", sa.Date(), nullable=True),
+        sa.Column("component_weight", sa.Numeric(18, 10), nullable=False),
+        sa.Column("source_system", sa.String(), nullable=True),
+        sa.Column("source_record_id", sa.String(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "parent_security_id",
+            "component_security_id",
+            "effective_from",
+            name="_instrument_lookthrough_component_effective_uc",
+        ),
+    )
+    op.create_index(
+        "ix_instrument_lookthrough_components_parent_security_id",
+        "instrument_lookthrough_components",
+        ["parent_security_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_instrument_lookthrough_components_component_security_id",
+        "instrument_lookthrough_components",
+        ["component_security_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_instrument_lookthrough_components_effective_from",
+        "instrument_lookthrough_components",
+        ["effective_from"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_instrument_lookthrough_components_effective_to",
+        "instrument_lookthrough_components",
+        ["effective_to"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_instrument_lookthrough_parent_effective_window",
+        "instrument_lookthrough_components",
+        ["parent_security_id", "effective_from", "effective_to"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_instrument_lookthrough_parent_effective_window",
+        table_name="instrument_lookthrough_components",
+    )
+    op.drop_index(
+        "ix_instrument_lookthrough_components_effective_to",
+        table_name="instrument_lookthrough_components",
+    )
+    op.drop_index(
+        "ix_instrument_lookthrough_components_effective_from",
+        table_name="instrument_lookthrough_components",
+    )
+    op.drop_index(
+        "ix_instrument_lookthrough_components_component_security_id",
+        table_name="instrument_lookthrough_components",
+    )
+    op.drop_index(
+        "ix_instrument_lookthrough_components_parent_security_id",
+        table_name="instrument_lookthrough_components",
+    )
+    op.drop_table("instrument_lookthrough_components")
+
+    op.drop_index(
+        "ix_cash_account_master_portfolio_effective_window",
+        table_name="cash_account_masters",
+    )
+    op.drop_index("ix_cash_account_masters_closed_on", table_name="cash_account_masters")
+    op.drop_index("ix_cash_account_masters_opened_on", table_name="cash_account_masters")
+    op.drop_index(
+        "ix_cash_account_masters_lifecycle_status", table_name="cash_account_masters"
+    )
+    op.drop_index("ix_cash_account_masters_account_role", table_name="cash_account_masters")
+    op.drop_index(
+        "ix_cash_account_masters_account_currency", table_name="cash_account_masters"
+    )
+    op.drop_index("ix_cash_account_masters_security_id", table_name="cash_account_masters")
+    op.drop_index("ix_cash_account_masters_portfolio_id", table_name="cash_account_masters")
+    op.drop_index(
+        "ix_cash_account_masters_cash_account_id", table_name="cash_account_masters"
+    )
+    op.drop_table("cash_account_masters")

--- a/alembic/versions/c9e0f1a2b3c4_feat_add_cash_account_master_and_lookthrough_tables.py
+++ b/alembic/versions/c9e0f1a2b3c4_feat_add_cash_account_master_and_lookthrough_tables.py
@@ -1,7 +1,7 @@
 """add cash account master and lookthrough tables
 
-Revision ID: b1c2d3e4f5a6
-Revises: rev_a1d9c8b7e6f5
+Revision ID: c9e0f1a2b3c4
+Revises: b8d9e0f1a2b3
 Create Date: 2026-03-28 16:55:00.000000
 """
 
@@ -11,8 +11,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "b1c2d3e4f5a6"
-down_revision: str | None = "rev_a1d9c8b7e6f5"
+revision: str = "c9e0f1a2b3c4"
+down_revision: str | None = "b8d9e0f1a2b3"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/docs/RFCs/RFC 084 - PB-WM Wealth Reporting and Ledger Query APIs.md
+++ b/docs/RFCs/RFC 084 - PB-WM Wealth Reporting and Ledger Query APIs.md
@@ -4,10 +4,10 @@
 | --- | --- |
 | Status | Implemented |
 | Created | 2026-03-27 |
-| Last Updated | 2026-03-27 |
+| Last Updated | 2026-03-28 |
 | Owners | lotus-core query-service maintainers |
 | Depends On | RFC 035, RFC 057, RFC 067, RFC 068 |
-| Scope | Gold-standard PB/WM query APIs for portfolio discovery, transaction ledgers, AUM, asset allocation, cash balances, income summaries, and activity summaries |
+| Scope | Gold-standard PB/WM query APIs for portfolio discovery, transaction ledgers, AUM, historical portfolio snapshots, holdings, allocation, cash-account master data, cash balances, income summaries, and activity summaries |
 
 ## Executive Summary
 
@@ -20,11 +20,14 @@ The implementation delivers:
 3. A typed wealth-reporting contract family for:
    - assets under management
    - asset allocation
+   - portfolio summary
+   - holdings snapshot
    - cash balances
    - income summaries
    - activity summaries
-4. Performance-aware query design using bounded scope semantics, latest-snapshot resolution, FX caching,
-   and new query-hotspot indexes.
+4. A canonical cash-account master ingestion and query surface for PB/WM onboarding and reporting.
+5. Performance-aware query design using bounded scope semantics, true historical as-of snapshot
+   resolution, FX caching, and new query-hotspot indexes.
 
 Classification: `Fully implemented and aligned`.
 
@@ -61,6 +64,11 @@ The requested scope for this RFC family was:
    - inflows, outflows, fees, taxes
    - requested date range plus year-to-date view
    - values in portfolio currency and reporting currency
+9. Portfolio workspace follow-up gaps
+   - reporting-currency restatement support for summary and holdings views
+   - true historical as-of portfolio snapshot contracts
+   - region and look-through allocation support
+   - canonical cash-account master ingestion and query
 
 ## Architecture Decision
 
@@ -121,9 +129,16 @@ operationally portfolio-centric.
 
 - `POST /reporting/assets-under-management/query`
 - `POST /reporting/asset-allocation/query`
+- `POST /reporting/portfolio-summary/query`
+- `POST /reporting/holdings-snapshot/query`
 - `POST /reporting/cash-balances/query`
 - `POST /reporting/income-summary/query`
 - `POST /reporting/activity-summary/query`
+
+### Cash Account Master
+
+- `POST /ingest/reference/cash-accounts`
+- `GET /portfolios/{portfolio_id}/cash-accounts`
 
 Request scope model:
 
@@ -144,6 +159,7 @@ Asset allocation dimensions:
 - `currency`
 - `sector`
 - `country`
+- `region`
 - `product_type`
 - `rating`
 - `issuer_id`
@@ -151,11 +167,52 @@ Asset allocation dimensions:
 - `ultimate_parent_issuer_id`
 - `ultimate_parent_issuer_name`
 
+Asset allocation look-through:
+
+- `look_through_mode = direct_only`
+- `look_through_mode = prefer_look_through`
+- response includes a `look_through` block that reports:
+  - requested mode
+  - applied mode
+  - support flag
+  - decomposed position count
+  - limitation reason when partial or unavailable
+
+Portfolio-summary semantics:
+
+- single-portfolio, true historical as-of contract
+- total market value, cash balance, and invested market value
+- returned in portfolio currency and reporting currency
+- includes operational snapshot metadata:
+  - resolved snapshot date
+  - position count
+  - cash-account count
+  - valued / unvalued counts
+
+Holdings-snapshot semantics:
+
+- single-portfolio, true historical as-of contract
+- holdings returned in portfolio currency and reporting currency
+- includes region classification
+- supports excluding cash positions for investment-only views
+
 Cash-balance semantics:
 
 - portfolio-scoped only
 - returns native account balances, portfolio-currency balances, and reporting-currency balances
 - returns totals in both portfolio and reporting currency
+- resolves account identity from cash-account master data first
+- falls back to latest settlement-cash linkage only as a migration path
+- includes zero-balance master accounts so the account inventory is complete
+
+Cash-account master semantics:
+
+- source-owned account identity and lifecycle contract
+- explicit linkage between:
+  - portfolio
+  - cash account
+  - cash security / instrument
+- query contract returns account metadata without requiring transaction inference
 
 Income-summary semantics:
 
@@ -217,12 +274,14 @@ The implementation was designed for interactive PB/WM use, not naive unbounded s
 1. Reporting queries resolve the latest non-zero snapshot per `(portfolio_id, security_id)` as of the
    requested date.
 2. Snapshot selection is handled in SQL via window functions.
-3. Only current-epoch state is used.
+3. Historical as-of contracts are not pinned to current epoch only.
 4. FX conversion is cached per request in the service layer.
 5. BU and portfolio-list reporting stays scope-bounded through explicit scope resolution.
 6. Income and activity summaries aggregate in SQL over bounded transaction-date windows rather than
    materializing raw ledger rows into Python.
 7. Additional hot-path indexes support portfolio/date/type filters for income and flow summaries.
+8. Look-through decomposition is only applied when component weights form a complete source-owned set,
+   which preserves valuation totals.
 
 This is appropriate for:
 
@@ -239,19 +298,28 @@ Implementation:
 - `src/services/query_service/app/routers/portfolios.py`
 - `src/services/query_service/app/routers/transactions.py`
 - `src/services/query_service/app/routers/reporting.py`
+- `src/services/query_service/app/routers/cash_accounts.py`
 - `src/services/query_service/app/services/portfolio_service.py`
 - `src/services/query_service/app/services/transaction_service.py`
 - `src/services/query_service/app/services/reporting_service.py`
+- `src/services/query_service/app/services/cash_account_service.py`
+- `src/services/query_service/app/services/reporting_classification.py`
 - `src/services/query_service/app/repositories/portfolio_repository.py`
 - `src/services/query_service/app/repositories/transaction_repository.py`
 - `src/services/query_service/app/repositories/reporting_repository.py`
+- `src/services/query_service/app/repositories/cash_account_repository.py`
 - `src/services/query_service/app/repositories/date_filters.py`
 - `src/services/query_service/app/dtos/portfolio_dto.py`
 - `src/services/query_service/app/dtos/transaction_dto.py`
 - `src/services/query_service/app/dtos/reporting_dto.py`
+- `src/services/query_service/app/dtos/cash_account_dto.py`
 - `src/libs/portfolio-common/portfolio_common/database_models.py`
 - `alembic/versions/a7c8d9e0f1a2_perf_add_wealth_query_indexes.py`
 - `alembic/versions/b8d9e0f1a2b3_perf_add_income_activity_reporting_indexes.py`
+- `alembic/versions/b1c2d3e4f5a6_feat_add_cash_account_master_and_lookthrough_tables.py`
+- `src/services/ingestion_service/app/DTOs/reference_data_dto.py`
+- `src/services/ingestion_service/app/services/reference_data_ingestion_service.py`
+- `src/services/ingestion_service/app/routers/reference_data.py`
 
 Docs:
 
@@ -265,12 +333,16 @@ Validation:
 - `tests/unit/services/query_service/repositories/test_transaction_repository.py`
 - `tests/unit/services/query_service/repositories/test_query_portfolio_repository.py`
 - `tests/unit/services/query_service/services/test_reporting_service.py`
+- `tests/unit/services/query_service/services/test_cash_account_service.py`
 - `tests/unit/services/query_service/services/test_transaction_service.py`
 - `tests/unit/services/query_service/services/test_portfolio_service.py`
 - `tests/integration/services/query_service/test_reporting_router.py`
+- `tests/integration/services/query_service/test_cash_accounts_router.py`
 - `tests/integration/services/query_service/test_transactions_router.py`
 - `tests/integration/services/query_service/test_portfolios_router_dependency.py`
 - `tests/integration/services/query_service/test_main_app.py`
+- `tests/unit/services/ingestion_service/test_reference_data_ingestion_service.py`
+- `tests/integration/services/ingestion_service/test_ingestion_routers.py`
 
 ## Requirement-to-Implementation Traceability
 
@@ -281,7 +353,11 @@ Validation:
 | AUM query for portfolio, portfolio list, BU | Implemented | reporting DTO/service/router |
 | Asset allocation by PB/WM dimensions | Implemented | allocation DTO/service |
 | Portfolio API supports BU and explicit portfolio list | Implemented | portfolios router/service/repository |
+| Portfolio summary and holdings support source-owned historical as-of snapshots | Implemented | reporting DTO/service/router + tests |
 | Cash balances with native/portfolio/reporting currency | Implemented | cash balances DTO/service/router |
+| Reporting-currency restatement for portfolio workspace source views | Implemented | reporting DTO/service/router + tests |
+| Region and look-through allocation support | Implemented | allocation DTO/service/repository + tests |
+| Canonical cash-account master ingestion and query | Implemented | ingestion + cash-account query contracts + tests |
 | Income summary with requested-window and YTD currency views | Implemented | reporting DTO/service/repository/router + tests |
 | Activity summary with portfolio-level flow buckets and YTD currency views | Implemented | reporting DTO/service/repository/router + tests |
 | Performance-aware design | Implemented | date-range predicates, latest-snapshot query, hot-path indexes, tests |
@@ -291,14 +367,9 @@ Validation:
 The implementation passed:
 
 1. Focused touched-surface lint.
-2. Focused query-service contract pack:
-   - `82 passed`
-3. Full query-service unit suite:
-   - `468 passed`
-4. Full query-service integration suite:
-   - `90 passed`
-5. Focused income/activity reporting contract pack:
-   - `83 passed`
+2. Focused PB/WM workspace and reference-data pack:
+   - `129 passed`
+3. Existing query-service unit and integration suites remained green on the earlier base slice.
 
 Alembic head is clean with the new migration registered.
 
@@ -308,6 +379,8 @@ Alembic head is clean with the new migration registered.
    reporting APIs or define export-specific envelope metadata?
 2. Should BU scope later broaden beyond `booking_center_code` into an explicit enterprise business-unit
    hierarchy contract?
+3. Does the platform want additional region taxonomy overrides beyond the current source-owned
+   country-to-region mapping helper?
 
 ## Next Actions
 

--- a/docs/features/query_service/WEALTH-REPORTING-API-GUIDE.md
+++ b/docs/features/query_service/WEALTH-REPORTING-API-GUIDE.md
@@ -12,6 +12,14 @@ This guide documents the gold-standard PB/WM reporting APIs exposed by `lotus-co
 The design goal is to keep canonical ledger and discovery reads simple while giving
 wealth-reporting use cases stronger, typed contracts.
 
+This guide also covers the portfolio-workspace follow-up contracts that make historical
+portfolio workspaces trustworthy for PB/WM consumers:
+
+- canonical cash-account master ingestion and query
+- true historical as-of portfolio summary and holdings snapshot contracts
+- reporting-currency restatement for portfolio workspace modules
+- region and look-through allocation support
+
 ## API Surface
 
 ### Portfolio discovery
@@ -58,6 +66,25 @@ The response includes both canonical transaction attributes and reporting-releva
 - trade currency
 - linked cashflow details
 - detailed transaction costs
+
+### Cash account master
+
+- `GET /portfolios/{portfolio_id}/cash-accounts`
+
+Use this contract for canonical cash-account identity and lifecycle metadata.
+
+Inputs:
+
+- `portfolio_id`
+- optional `as_of_date`
+
+Behavior:
+
+- returns source-owned cash-account master rows
+- filters accounts by `opened_on` / `closed_on` when `as_of_date` is provided
+- does not infer account identity from transactions
+
+This is the master-data contract that reporting cash-balance queries build on top of.
 
 ## Why AUM and Cash Balances Are Separate
 
@@ -144,6 +171,7 @@ Supported dimensions:
 - `currency`
 - `sector`
 - `country`
+- `region`
 - `product_type`
 - `rating`
 - `issuer_id`
@@ -151,10 +179,70 @@ Supported dimensions:
 - `ultimate_parent_issuer_id`
 - `ultimate_parent_issuer_name`
 
+Look-through behavior:
+
+- `look_through_mode = direct_only`
+  - keep parent holdings intact
+- `look_through_mode = prefer_look_through`
+  - decompose eligible parent instruments when a fully weighted source-owned component set exists
+  - preserve direct holdings for the remaining positions
+  - return a `look_through` capability / limitation block in the response
+
 Behavior:
 
 - returns one allocation view per requested dimension
 - every bucket includes reporting-currency market value, weight, and position count
+- region is derived from country-of-risk using the source-owned Lotus classification helper
+
+### Portfolio Summary
+
+- `POST /reporting/portfolio-summary/query`
+
+Inputs:
+
+- `portfolio_id`
+- `as_of_date`
+- optional `reporting_currency`
+
+Behavior:
+
+- returns a true historical as-of portfolio snapshot summary
+- returns totals in:
+  - portfolio currency
+  - reporting currency
+- separates:
+  - total market value
+  - cash balance
+  - invested market value
+- returns snapshot metadata including:
+  - resolved snapshot date
+  - position count
+  - cash-account count
+  - valued / unvalued counts
+
+### Holdings Snapshot
+
+- `POST /reporting/holdings-snapshot/query`
+
+Inputs:
+
+- `portfolio_id`
+- `as_of_date`
+- optional `reporting_currency`
+- `include_cash_positions`
+
+Behavior:
+
+- returns a true historical as-of holdings snapshot
+- returns each holding in:
+  - portfolio currency
+  - reporting currency
+- returns portfolio-workspace classifications including:
+  - asset class
+  - sector
+  - country
+  - region
+- supports excluding cash positions for pure investment holdings views
 
 ### Cash Balances
 
@@ -169,6 +257,8 @@ Inputs:
 Behavior:
 
 - defaults `reporting_currency` to portfolio currency
+- resolves accounts from canonical cash-account master data first
+- falls back to latest settlement-cash transaction linkage only when no master row exists
 - returns each cash account in:
   - account currency
   - portfolio currency
@@ -176,9 +266,10 @@ Behavior:
 - returns portfolio totals in:
   - portfolio currency
   - reporting currency
+- includes zero-balance master accounts so the workspace sees the full account inventory
 
-Cash account identity is resolved from the latest known settlement-cash mapping when available.
-If no explicit account mapping is available, the API falls back to the cash instrument identity.
+If no explicit account master or linkage is available, the API falls back to the cash instrument
+identity as the last-resort identifier.
 
 ### Income Summary
 
@@ -279,15 +370,16 @@ very large reporting jobs without weakening the main ledger contract.
 ### Reporting APIs
 
 The reporting APIs use the latest non-zero snapshot per `(portfolio_id, security_id)` as of the
-requested date. This keeps the query bounded and aligned with PB/WM as-of reporting semantics.
+requested date. This keeps the query bounded while preserving true historical as-of semantics.
 
 Important characteristics:
 
 - latest-snapshot resolution is handled in SQL with a window function
-- only current-epoch position state is used
+- historical queries are not pinned to current epoch only
 - FX conversion is cached per request in the service layer
 - scope-wide reporting is based on the resolved portfolio set instead of repeated per-portfolio
   round trips
+- look-through decomposition is only applied when source-owned component weights form a complete set
 
 This makes the APIs suitable for:
 
@@ -312,15 +404,18 @@ These APIs follow a few rules consistently:
 - canonical discovery reads stay in `query_service`
 - higher-order reporting uses typed `POST` contracts
 - portfolio currency and reporting currency semantics are explicit
+- true historical `as_of_date` semantics are explicit for snapshot-backed views
 - scope resolution is part of the request contract, not implicit server behavior
 - responses echo resolved dates and effective currencies
+- canonical account identity comes from source-owned master data, not downstream inference
 
 ## Testing Standard
 
 The supporting tests are intended to lock real domain behavior:
 
 - DTO tests cover scope and currency rules
-- service tests cover aggregation, FX conversion, and cash-account behavior
+- service tests cover aggregation, FX conversion, historical snapshot behavior, look-through, and
+  cash-account behavior
 - repository tests cover SQL shape for scope filters, latest-snapshot resolution, and
   index-friendly date predicates
 - integration tests cover FastAPI routing and OpenAPI contract visibility

--- a/docs/standards/api-vocabulary/lotus-core-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-core-api-vocabulary.v1.json
@@ -13,7 +13,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-03-27T10:00:55.939881+00:00",
+  "generatedAt": "2026-03-28T09:26:05.498419+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.accepted_count",
@@ -40,7 +40,22 @@
         "body"
       ],
       "observedTypes": [
+        "object",
         "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.account_role",
+      "canonicalTerm": "account_role",
+      "preferredName": "account_role",
+      "description": "Optional cash-account role classification.",
+      "example": "OPERATING_CASH",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
       ]
     },
     {
@@ -135,6 +150,20 @@
       "preferredName": "amount_reporting_currency",
       "description": "Flow amount translated to the effective reporting currency.",
       "example": "USD",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.applied_mode",
+      "canonicalTerm": "applied_mode",
+      "preferredName": "applied_mode",
+      "description": "Look-through mode actually applied to the response.",
+      "example": "direct_only",
       "type": "string",
       "locations": [
         "body"
@@ -704,7 +733,7 @@
       "semanticId": "lotus.cash_account_id",
       "canonicalTerm": "cash_account_id",
       "preferredName": "cash_account_id",
-      "description": "Lotus cash account identifier. Resolved from the latest known settlement cash account mapping when available, otherwise from the cash instrument identity.",
+      "description": "Canonical Lotus cash account identifier.",
       "example": "CASH_ACCOUNT_001",
       "type": "string",
       "locations": [
@@ -718,17 +747,19 @@
       "semanticId": "lotus.cash_accounts",
       "canonicalTerm": "cash_accounts",
       "preferredName": "cash_accounts",
-      "description": "Resolved cash accounts and balances for the portfolio.",
+      "description": "Canonical cash accounts linked to the portfolio.",
       "example": [
         {
-          "cash_account_id": "CASH_ACCOUNT_001",
-          "instrument_id": "EQ_US_AAPL",
-          "security_id": "AAPL",
+          "cash_account_id": "CASH-ACC-USD-001",
+          "portfolio_id": "PORT-001",
+          "security_id": "CASH_USD",
+          "display_name": "USD Operating Cash",
           "account_currency": "USD",
-          "instrument_name": "example_instrument_name",
-          "balance_account_currency": "USD",
-          "balance_portfolio_currency": "USD",
-          "balance_reporting_currency": "USD"
+          "account_role": "OPERATING_CASH",
+          "lifecycle_status": "ACTIVE",
+          "opened_on": "2026-01-01",
+          "closed_on": "2026-12-31",
+          "source_system": "lotus-manage"
         }
       ],
       "type": "array",
@@ -737,6 +768,34 @@
       ],
       "observedTypes": [
         "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.cash_balance_portfolio_currency",
+      "canonicalTerm": "cash_balance_portfolio_currency",
+      "preferredName": "cash_balance_portfolio_currency",
+      "description": "Cash balance subtotal in portfolio currency.",
+      "example": "USD",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.cash_balance_reporting_currency",
+      "canonicalTerm": "cash_balance_reporting_currency",
+      "preferredName": "cash_balance_reporting_currency",
+      "description": "Cash balance subtotal in reporting currency.",
+      "example": "USD",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -944,6 +1003,20 @@
       ]
     },
     {
+      "semanticId": "lotus.closed_on",
+      "canonicalTerm": "closed_on",
+      "preferredName": "closed_on",
+      "description": "Cash-account close date when known.",
+      "example": "2026-12-31",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
       "semanticId": "lotus.component_id",
       "canonicalTerm": "component_id",
       "preferredName": "component_id",
@@ -958,6 +1031,20 @@
       ]
     },
     {
+      "semanticId": "lotus.component_security_id",
+      "canonicalTerm": "component_security_id",
+      "preferredName": "component_security_id",
+      "description": "Underlying component security identifier.",
+      "example": "COMPONENT_SECURITY_001",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.component_type",
       "canonicalTerm": "component_type",
       "preferredName": "component_type",
@@ -967,6 +1054,20 @@
       "locations": [
         "body",
         "query"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.component_weight",
+      "canonicalTerm": "component_weight",
+      "preferredName": "component_weight",
+      "description": "Weight of the underlying component between 0 and 1.",
+      "example": "0.6000000000",
+      "type": "object",
+      "locations": [
+        "body"
       ],
       "observedTypes": [
         "object"
@@ -1119,6 +1220,22 @@
       ]
     },
     {
+      "semanticId": "lotus.country",
+      "canonicalTerm": "country",
+      "preferredName": "country",
+      "description": "Country of risk classification.",
+      "example": {
+        "id": "OBJ_001"
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
       "semanticId": "lotus.country_of_risk",
       "canonicalTerm": "country_of_risk",
       "preferredName": "country_of_risk",
@@ -1173,6 +1290,20 @@
       ],
       "observedTypes": [
         "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.decomposed_position_count",
+      "canonicalTerm": "decomposed_position_count",
+      "preferredName": "decomposed_position_count",
+      "description": "Number of parent positions decomposed into underlying components.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
       ]
     },
     {
@@ -1280,6 +1411,20 @@
       ],
       "observedTypes": [
         "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.display_name",
+      "canonicalTerm": "display_name",
+      "preferredName": "display_name",
+      "description": "Cash account display name.",
+      "example": "example_display_name",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -1737,6 +1882,20 @@
       ]
     },
     {
+      "semanticId": "lotus.include_cash_positions",
+      "canonicalTerm": "include_cash_positions",
+      "preferredName": "include_cash_positions",
+      "description": "When false, excludes cash positions from the holdings snapshot.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
       "semanticId": "lotus.include_projected",
       "canonicalTerm": "include_projected",
       "preferredName": "include_projected",
@@ -2081,6 +2240,34 @@
       ]
     },
     {
+      "semanticId": "lotus.invested_market_value_portfolio_currency",
+      "canonicalTerm": "invested_market_value_portfolio_currency",
+      "preferredName": "invested_market_value_portfolio_currency",
+      "description": "Non-cash invested market value in portfolio currency.",
+      "example": "USD",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.invested_market_value_reporting_currency",
+      "canonicalTerm": "invested_market_value_reporting_currency",
+      "preferredName": "invested_market_value_reporting_currency",
+      "description": "Non-cash invested market value in reporting currency.",
+      "example": "USD",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.investment_time_horizon",
       "canonicalTerm": "investment_time_horizon",
       "preferredName": "investment_time_horizon",
@@ -2199,6 +2386,20 @@
       ]
     },
     {
+      "semanticId": "lotus.lifecycle_status",
+      "canonicalTerm": "lifecycle_status",
+      "preferredName": "lifecycle_status",
+      "description": "Cash-account lifecycle status.",
+      "example": "ACTIVE",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.limit",
       "canonicalTerm": "limit",
       "preferredName": "limit",
@@ -2211,6 +2412,22 @@
       ],
       "observedTypes": [
         "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.limitation_reason",
+      "canonicalTerm": "limitation_reason",
+      "preferredName": "limitation_reason",
+      "description": "Explanation when look-through was requested but could not be applied.",
+      "example": {
+        "id": "OBJ_001"
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
       ]
     },
     {
@@ -2299,6 +2516,61 @@
       ],
       "observedTypes": [
         "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.look_through",
+      "canonicalTerm": "look_through",
+      "preferredName": "look_through",
+      "description": "Applied look-through mode and capability summary for the allocation query.",
+      "example": {
+        "requested_mode": "direct_only",
+        "applied_mode": "direct_only",
+        "supported": true,
+        "decomposed_position_count": 10,
+        "limitation_reason": "example_value"
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "AllocationLookThroughInfo"
+      ]
+    },
+    {
+      "semanticId": "lotus.look_through_mode",
+      "canonicalTerm": "look_through_mode",
+      "preferredName": "look_through_mode",
+      "description": "Allocation decomposition mode. `direct_only` keeps parent holdings intact. `prefer_look_through` decomposes eligible parent instruments when source-owned look-through components are available.",
+      "example": "direct_only",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.lookthrough_components",
+      "canonicalTerm": "lookthrough_components",
+      "preferredName": "lookthrough_components",
+      "description": "Instrument look-through composition rows to ingest or upsert.",
+      "example": [
+        {
+          "component_security_id": "ETF_WORLD_EQUITY",
+          "component_weight": "0.6000000000",
+          "effective_from": "2026-01-01",
+          "parent_security_id": "FUND_GLOBAL_60_40"
+        }
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
       ]
     },
     {
@@ -2409,6 +2681,20 @@
       ],
       "observedTypes": [
         "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.market_value_portfolio_currency",
+      "canonicalTerm": "market_value_portfolio_currency",
+      "preferredName": "market_value_portfolio_currency",
+      "description": "Position market value in portfolio currency.",
+      "example": "USD",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -2724,6 +3010,20 @@
       ]
     },
     {
+      "semanticId": "lotus.opened_on",
+      "canonicalTerm": "opened_on",
+      "preferredName": "opened_on",
+      "description": "Cash-account open date when known.",
+      "example": "2026-01-01",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
       "semanticId": "lotus.original_quantity",
       "canonicalTerm": "original_quantity",
       "preferredName": "original_quantity",
@@ -2863,6 +3163,20 @@
       ],
       "observedTypes": [
         "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.parent_security_id",
+      "canonicalTerm": "parent_security_id",
+      "preferredName": "parent_security_id",
+      "description": "Structured product or fund security identifier being decomposed.",
+      "example": "PARENT_SECURITY_001",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -3518,6 +3832,22 @@
       ]
     },
     {
+      "semanticId": "lotus.region",
+      "canonicalTerm": "region",
+      "preferredName": "region",
+      "description": "Derived region classification.",
+      "example": {
+        "id": "OBJ_001"
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
       "semanticId": "lotus.remaining_offset_local",
       "canonicalTerm": "remaining_offset_local",
       "preferredName": "remaining_offset_local",
@@ -3575,6 +3905,20 @@
       ]
     },
     {
+      "semanticId": "lotus.requested_mode",
+      "canonicalTerm": "requested_mode",
+      "preferredName": "requested_mode",
+      "description": "Look-through mode requested by the caller.",
+      "example": "direct_only",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.requested_window",
       "canonicalTerm": "requested_window",
       "preferredName": "requested_window",
@@ -3603,13 +3947,14 @@
       "semanticId": "lotus.resolved_as_of_date",
       "canonicalTerm": "resolved_as_of_date",
       "preferredName": "resolved_as_of_date",
-      "description": "Effective as-of date used by the query.",
-      "example": "2026-02-27",
+      "description": "Effective as-of date used to resolve the cash-account master set.",
+      "example": "2026-03-28",
       "type": "string",
       "locations": [
         "body"
       ],
       "observedTypes": [
+        "object",
         "string"
       ]
     },
@@ -4012,6 +4357,40 @@
       ]
     },
     {
+      "semanticId": "lotus.snapshot_date",
+      "canonicalTerm": "snapshot_date",
+      "preferredName": "snapshot_date",
+      "description": "Resolved snapshot date backing the summary.",
+      "example": "2026-02-27",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.snapshot_metadata",
+      "canonicalTerm": "snapshot_metadata",
+      "preferredName": "snapshot_metadata",
+      "description": "Resolved snapshot metadata for the summary query.",
+      "example": {
+        "snapshot_date": "2026-02-27",
+        "position_count": 10,
+        "cash_account_count": 10,
+        "valued_position_count": 10,
+        "unvalued_position_count": 10
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "PortfolioSummarySnapshotMetadata"
+      ]
+    },
+    {
       "semanticId": "lotus.sort_by",
       "canonicalTerm": "sort_by",
       "preferredName": "sort_by",
@@ -4099,8 +4478,8 @@
       "semanticId": "lotus.source_system",
       "canonicalTerm": "source_system",
       "preferredName": "source_system",
-      "description": "Source system from which this transaction originated.",
-      "example": "OMS_PRIMARY",
+      "description": "Upstream source system.",
+      "example": "lotus-manage",
       "type": "object",
       "locations": [
         "body"
@@ -4221,6 +4600,20 @@
       ],
       "observedTypes": [
         "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.supported",
+      "canonicalTerm": "supported",
+      "preferredName": "supported",
+      "description": "Whether source-owned look-through decomposition was available for the query.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
       ]
     },
     {
@@ -4506,6 +4899,20 @@
       ]
     },
     {
+      "semanticId": "lotus.total_market_value_portfolio_currency",
+      "canonicalTerm": "total_market_value_portfolio_currency",
+      "preferredName": "total_market_value_portfolio_currency",
+      "description": "Total portfolio market value in portfolio currency.",
+      "example": "USD",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.total_market_value_reporting_currency",
       "canonicalTerm": "total_market_value_reporting_currency",
       "preferredName": "total_market_value_reporting_currency",
@@ -4565,7 +4972,8 @@
         "ActivitySummaryTotals",
         "AssetsUnderManagementTotals",
         "CashBalancesTotals",
-        "IncomeSummaryTotals"
+        "IncomeSummaryTotals",
+        "PortfolioSummaryTotals"
       ]
     },
     {
@@ -4872,6 +5280,20 @@
       ]
     },
     {
+      "semanticId": "lotus.unvalued_position_count",
+      "canonicalTerm": "unvalued_position_count",
+      "preferredName": "unvalued_position_count",
+      "description": "Number of snapshot positions still lacking valuation coverage.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
       "semanticId": "lotus.valid_rows",
       "canonicalTerm": "valid_rows",
       "preferredName": "valid_rows",
@@ -4896,6 +5318,22 @@
         "unrealized_gain_loss": 3177.5,
         "market_value_local": 23177.5,
         "unrealized_gain_loss_local": 3177.5
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.valuation_status",
+      "canonicalTerm": "valuation_status",
+      "preferredName": "valuation_status",
+      "description": "Snapshot valuation status.",
+      "example": {
+        "id": "OBJ_001"
       },
       "type": "object",
       "locations": [
@@ -4931,6 +5369,20 @@
       ],
       "observedTypes": [
         "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.valued_position_count",
+      "canonicalTerm": "valued_position_count",
+      "preferredName": "valued_position_count",
+      "description": "Number of snapshot positions with non-UNVALUED coverage.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
       ]
     },
     {
@@ -5245,6 +5697,36 @@
       "exposure": "consumer_visible",
       "canonicalTerm": "include_projected",
       "semanticId": "lotus.include_projected"
+    },
+    {
+      "name": "portfolio_id",
+      "kind": "request_option",
+      "location": "path",
+      "type": "string",
+      "required": true,
+      "default": "",
+      "allowedValues": [],
+      "description": "Portfolio identifier.",
+      "example": "PORT-CASH-001",
+      "behaviorImpact": "Affects get_cash_accounts_portfolios__portfolio_id__cash_accounts_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "portfolio_id",
+      "semanticId": "lotus.portfolio_id"
+    },
+    {
+      "name": "as_of_date",
+      "kind": "request_option",
+      "location": "query",
+      "type": "object",
+      "required": false,
+      "default": "",
+      "allowedValues": [],
+      "description": "Optional as-of date used to filter cash-account master records by open/close window.",
+      "example": "2026-03-28",
+      "behaviorImpact": "Affects get_cash_accounts_portfolios__portfolio_id__cash_accounts_get request behavior.",
+      "exposure": "consumer_visible",
+      "canonicalTerm": "as_of_date",
+      "semanticId": "lotus.as_of_date"
     },
     {
       "name": "portfolio_id",
@@ -6957,6 +7439,166 @@
             "type": "object",
             "semanticId": "lotus.weight",
             "attributeRef": "lotus.weight"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "get_cash_accounts_portfolios__portfolio_id__cash_accounts_get",
+      "method": "GET",
+      "path": "/portfolios/{portfolio_id}/cash-accounts",
+      "domain": "cash_accounts",
+      "serviceGroup": "query",
+      "tags": [
+        "Cash Accounts"
+      ],
+      "summary": "Get canonical cash accounts for a portfolio",
+      "description": "Returns source-owned canonical cash-account master records for one portfolio. Use this endpoint for canonical account identity and lifecycle metadata; use reporting cash-balances when balances and translated totals are required.",
+      "naming": {
+        "boundedContext": "cash_accounts",
+        "canonicalTerms": [
+          "account_currency",
+          "account_role",
+          "as_of_date",
+          "cash_account_id",
+          "cash_accounts",
+          "closed_on",
+          "display_name",
+          "lifecycle_status",
+          "opened_on",
+          "portfolio_id",
+          "resolved_as_of_date",
+          "security_id",
+          "source_system"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "as_of_date",
+            "location": "query",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.as_of_date",
+            "attributeRef": "lotus.as_of_date"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "CashAccountQueryResponse",
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "resolved_as_of_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.resolved_as_of_date",
+            "attributeRef": "lotus.resolved_as_of_date"
+          },
+          {
+            "name": "cash_accounts",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.cash_accounts",
+            "attributeRef": "lotus.cash_accounts"
+          },
+          {
+            "name": "cash_accounts[].cash_account_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.cash_account_id",
+            "attributeRef": "lotus.cash_account_id"
+          },
+          {
+            "name": "cash_accounts[].portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "cash_accounts[].security_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "cash_accounts[].display_name",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.display_name",
+            "attributeRef": "lotus.display_name"
+          },
+          {
+            "name": "cash_accounts[].account_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.account_currency",
+            "attributeRef": "lotus.account_currency"
+          },
+          {
+            "name": "cash_accounts[].account_role",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.account_role",
+            "attributeRef": "lotus.account_role"
+          },
+          {
+            "name": "cash_accounts[].lifecycle_status",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.lifecycle_status",
+            "attributeRef": "lotus.lifecycle_status"
+          },
+          {
+            "name": "cash_accounts[].opened_on",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.opened_on",
+            "attributeRef": "lotus.opened_on"
+          },
+          {
+            "name": "cash_accounts[].closed_on",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.closed_on",
+            "attributeRef": "lotus.closed_on"
+          },
+          {
+            "name": "cash_accounts[].source_system",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_system",
+            "attributeRef": "lotus.source_system"
           }
         ]
       }
@@ -10024,20 +10666,27 @@
       "naming": {
         "boundedContext": "wealth_reporting",
         "canonicalTerms": [
+          "applied_mode",
           "as_of_date",
           "booking_center_code",
           "buckets",
+          "decomposed_position_count",
           "dimension",
           "dimension_value",
           "dimensions",
+          "limitation_reason",
+          "look_through",
+          "look_through_mode",
           "market_value_reporting_currency",
           "portfolio_id",
           "portfolio_ids",
           "position_count",
           "reporting_currency",
+          "requested_mode",
           "resolved_as_of_date",
           "scope",
           "scope_type",
+          "supported",
           "total_market_value_reporting_currency",
           "views",
           "weight"
@@ -10100,6 +10749,14 @@
             "type": "array",
             "semanticId": "lotus.dimensions",
             "attributeRef": "lotus.dimensions"
+          },
+          {
+            "name": "look_through_mode",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.look_through_mode",
+            "attributeRef": "lotus.look_through_mode"
           }
         ]
       },
@@ -10170,6 +10827,54 @@
             "type": "string",
             "semanticId": "lotus.total_market_value_reporting_currency",
             "attributeRef": "lotus.total_market_value_reporting_currency"
+          },
+          {
+            "name": "look_through",
+            "location": "body",
+            "required": true,
+            "type": "AllocationLookThroughInfo",
+            "semanticId": "lotus.look_through",
+            "attributeRef": "lotus.look_through"
+          },
+          {
+            "name": "look_through.requested_mode",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.requested_mode",
+            "attributeRef": "lotus.requested_mode"
+          },
+          {
+            "name": "look_through.applied_mode",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.applied_mode",
+            "attributeRef": "lotus.applied_mode"
+          },
+          {
+            "name": "look_through.supported",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.supported",
+            "attributeRef": "lotus.supported"
+          },
+          {
+            "name": "look_through.decomposed_position_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.decomposed_position_count",
+            "attributeRef": "lotus.decomposed_position_count"
+          },
+          {
+            "name": "look_through.limitation_reason",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.limitation_reason",
+            "attributeRef": "lotus.limitation_reason"
           },
           {
             "name": "views",
@@ -10439,6 +11144,506 @@
             "type": "string",
             "semanticId": "lotus.balance_reporting_currency",
             "attributeRef": "lotus.balance_reporting_currency"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "query_portfolio_summary_reporting_portfolio_summary_query_post",
+      "method": "POST",
+      "path": "/reporting/portfolio-summary/query",
+      "domain": "wealth_reporting",
+      "serviceGroup": "query",
+      "tags": [
+        "Wealth Reporting"
+      ],
+      "summary": "Query Portfolio Summary Snapshot",
+      "description": "Returns a true historical as-of portfolio summary for one portfolio, including market value totals, cash versus invested split, and snapshot coverage metadata. Use this contract when UI or reporting consumers need a restated summary in portfolio currency and reporting currency without rebuilding holdings totals client-side.",
+      "naming": {
+        "boundedContext": "wealth_reporting",
+        "canonicalTerms": [
+          "as_of_date",
+          "booking_center_code",
+          "cash_account_count",
+          "cash_balance_portfolio_currency",
+          "cash_balance_reporting_currency",
+          "client_id",
+          "invested_market_value_portfolio_currency",
+          "invested_market_value_reporting_currency",
+          "objective",
+          "portfolio_currency",
+          "portfolio_id",
+          "portfolio_type",
+          "position_count",
+          "reporting_currency",
+          "resolved_as_of_date",
+          "risk_exposure",
+          "snapshot_date",
+          "snapshot_metadata",
+          "status",
+          "total_market_value_portfolio_currency",
+          "total_market_value_reporting_currency",
+          "totals",
+          "unvalued_position_count",
+          "valued_position_count"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "as_of_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.as_of_date",
+            "attributeRef": "lotus.as_of_date"
+          },
+          {
+            "name": "reporting_currency",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.reporting_currency",
+            "attributeRef": "lotus.reporting_currency"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "PortfolioSummaryResponse",
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "booking_center_code",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.booking_center_code",
+            "attributeRef": "lotus.booking_center_code"
+          },
+          {
+            "name": "client_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.client_id",
+            "attributeRef": "lotus.client_id"
+          },
+          {
+            "name": "portfolio_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_currency",
+            "attributeRef": "lotus.portfolio_currency"
+          },
+          {
+            "name": "reporting_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.reporting_currency",
+            "attributeRef": "lotus.reporting_currency"
+          },
+          {
+            "name": "resolved_as_of_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.resolved_as_of_date",
+            "attributeRef": "lotus.resolved_as_of_date"
+          },
+          {
+            "name": "portfolio_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_type",
+            "attributeRef": "lotus.portfolio_type"
+          },
+          {
+            "name": "objective",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.objective",
+            "attributeRef": "lotus.objective"
+          },
+          {
+            "name": "risk_exposure",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.risk_exposure",
+            "attributeRef": "lotus.risk_exposure"
+          },
+          {
+            "name": "status",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.status",
+            "attributeRef": "lotus.status"
+          },
+          {
+            "name": "totals",
+            "location": "body",
+            "required": true,
+            "type": "PortfolioSummaryTotals",
+            "semanticId": "lotus.totals",
+            "attributeRef": "lotus.totals"
+          },
+          {
+            "name": "totals.total_market_value_portfolio_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.total_market_value_portfolio_currency",
+            "attributeRef": "lotus.total_market_value_portfolio_currency"
+          },
+          {
+            "name": "totals.total_market_value_reporting_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.total_market_value_reporting_currency",
+            "attributeRef": "lotus.total_market_value_reporting_currency"
+          },
+          {
+            "name": "totals.cash_balance_portfolio_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.cash_balance_portfolio_currency",
+            "attributeRef": "lotus.cash_balance_portfolio_currency"
+          },
+          {
+            "name": "totals.cash_balance_reporting_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.cash_balance_reporting_currency",
+            "attributeRef": "lotus.cash_balance_reporting_currency"
+          },
+          {
+            "name": "totals.invested_market_value_portfolio_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.invested_market_value_portfolio_currency",
+            "attributeRef": "lotus.invested_market_value_portfolio_currency"
+          },
+          {
+            "name": "totals.invested_market_value_reporting_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.invested_market_value_reporting_currency",
+            "attributeRef": "lotus.invested_market_value_reporting_currency"
+          },
+          {
+            "name": "snapshot_metadata",
+            "location": "body",
+            "required": true,
+            "type": "PortfolioSummarySnapshotMetadata",
+            "semanticId": "lotus.snapshot_metadata",
+            "attributeRef": "lotus.snapshot_metadata"
+          },
+          {
+            "name": "snapshot_metadata.snapshot_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.snapshot_date",
+            "attributeRef": "lotus.snapshot_date"
+          },
+          {
+            "name": "snapshot_metadata.position_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.position_count",
+            "attributeRef": "lotus.position_count"
+          },
+          {
+            "name": "snapshot_metadata.cash_account_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.cash_account_count",
+            "attributeRef": "lotus.cash_account_count"
+          },
+          {
+            "name": "snapshot_metadata.valued_position_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.valued_position_count",
+            "attributeRef": "lotus.valued_position_count"
+          },
+          {
+            "name": "snapshot_metadata.unvalued_position_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.unvalued_position_count",
+            "attributeRef": "lotus.unvalued_position_count"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "query_holdings_snapshot_reporting_holdings_snapshot_query_post",
+      "method": "POST",
+      "path": "/reporting/holdings-snapshot/query",
+      "domain": "wealth_reporting",
+      "serviceGroup": "query",
+      "tags": [
+        "Wealth Reporting"
+      ],
+      "summary": "Query Historical Holdings Snapshot",
+      "description": "Returns a true historical as-of holdings snapshot for one portfolio with reporting-currency restatement and portfolio-workspace classifications. Use this contract for UI holdings views and reporting extracts that need region-aware, restated holdings rows.",
+      "naming": {
+        "boundedContext": "wealth_reporting",
+        "canonicalTerms": [
+          "account_currency",
+          "as_of_date",
+          "asset_class",
+          "country",
+          "include_cash_positions",
+          "instrument_name",
+          "market_value_portfolio_currency",
+          "market_value_reporting_currency",
+          "portfolio_currency",
+          "portfolio_id",
+          "positions",
+          "quantity",
+          "region",
+          "reporting_currency",
+          "resolved_as_of_date",
+          "sector",
+          "security_id",
+          "snapshot_date",
+          "total_market_value_portfolio_currency",
+          "total_market_value_reporting_currency",
+          "valuation_status",
+          "weight"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "as_of_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.as_of_date",
+            "attributeRef": "lotus.as_of_date"
+          },
+          {
+            "name": "reporting_currency",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.reporting_currency",
+            "attributeRef": "lotus.reporting_currency"
+          },
+          {
+            "name": "include_cash_positions",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.include_cash_positions",
+            "attributeRef": "lotus.include_cash_positions"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 200,
+        "model": "HoldingsSnapshotResponse",
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "portfolio_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_currency",
+            "attributeRef": "lotus.portfolio_currency"
+          },
+          {
+            "name": "reporting_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.reporting_currency",
+            "attributeRef": "lotus.reporting_currency"
+          },
+          {
+            "name": "resolved_as_of_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.resolved_as_of_date",
+            "attributeRef": "lotus.resolved_as_of_date"
+          },
+          {
+            "name": "snapshot_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.snapshot_date",
+            "attributeRef": "lotus.snapshot_date"
+          },
+          {
+            "name": "total_market_value_portfolio_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.total_market_value_portfolio_currency",
+            "attributeRef": "lotus.total_market_value_portfolio_currency"
+          },
+          {
+            "name": "total_market_value_reporting_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.total_market_value_reporting_currency",
+            "attributeRef": "lotus.total_market_value_reporting_currency"
+          },
+          {
+            "name": "positions",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.positions",
+            "attributeRef": "lotus.positions"
+          },
+          {
+            "name": "positions[].security_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "positions[].instrument_name",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.instrument_name",
+            "attributeRef": "lotus.instrument_name"
+          },
+          {
+            "name": "positions[].asset_class",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.asset_class",
+            "attributeRef": "lotus.asset_class"
+          },
+          {
+            "name": "positions[].sector",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.sector",
+            "attributeRef": "lotus.sector"
+          },
+          {
+            "name": "positions[].country",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.country",
+            "attributeRef": "lotus.country"
+          },
+          {
+            "name": "positions[].region",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.region",
+            "attributeRef": "lotus.region"
+          },
+          {
+            "name": "positions[].account_currency",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.account_currency",
+            "attributeRef": "lotus.account_currency"
+          },
+          {
+            "name": "positions[].quantity",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.quantity",
+            "attributeRef": "lotus.quantity"
+          },
+          {
+            "name": "positions[].market_value_portfolio_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.market_value_portfolio_currency",
+            "attributeRef": "lotus.market_value_portfolio_currency"
+          },
+          {
+            "name": "positions[].market_value_reporting_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.market_value_reporting_currency",
+            "attributeRef": "lotus.market_value_reporting_currency"
+          },
+          {
+            "name": "positions[].weight",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.weight",
+            "attributeRef": "lotus.weight"
+          },
+          {
+            "name": "positions[].valuation_status",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.valuation_status",
+            "attributeRef": "lotus.valuation_status"
           }
         ]
       }
@@ -18122,6 +19327,384 @@
             "type": "string",
             "semanticId": "lotus.quality_status",
             "attributeRef": "lotus.quality_status"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 202,
+        "model": "BatchIngestionAcceptedResponse",
+        "fields": [
+          {
+            "name": "message",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.message",
+            "attributeRef": "lotus.message"
+          },
+          {
+            "name": "entity_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.entity_type",
+            "attributeRef": "lotus.entity_type"
+          },
+          {
+            "name": "accepted_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.accepted_count",
+            "attributeRef": "lotus.accepted_count"
+          },
+          {
+            "name": "correlation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.correlation_id",
+            "attributeRef": "lotus.correlation_id"
+          },
+          {
+            "name": "request_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.request_id",
+            "attributeRef": "lotus.request_id"
+          },
+          {
+            "name": "trace_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.trace_id",
+            "attributeRef": "lotus.trace_id"
+          },
+          {
+            "name": "idempotency_key",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.idempotency_key",
+            "attributeRef": "lotus.idempotency_key"
+          },
+          {
+            "name": "job_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.job_id",
+            "attributeRef": "lotus.job_id"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "ingest_cash_account_masters_ingest_reference_cash_accounts_post",
+      "method": "POST",
+      "path": "/ingest/reference/cash-accounts",
+      "domain": "reference_data",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Reference Data"
+      ],
+      "summary": "Ingest cash-account master records",
+      "description": "What: Accept canonical cash-account master records.\nHow: Validate PB/WM cash-account identity and upsert durable portfolio/account linkage metadata.\nWhen: Use during onboarding and cash-account lifecycle maintenance.",
+      "naming": {
+        "boundedContext": "reference_data",
+        "canonicalTerms": [
+          "accepted_count",
+          "account_currency",
+          "account_role",
+          "cash_account_id",
+          "cash_accounts",
+          "closed_on",
+          "correlation_id",
+          "display_name",
+          "entity_type",
+          "idempotency_key",
+          "job_id",
+          "lifecycle_status",
+          "message",
+          "opened_on",
+          "portfolio_id",
+          "request_id",
+          "security_id",
+          "source_record_id",
+          "source_system",
+          "trace_id"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "cash_accounts",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.cash_accounts",
+            "attributeRef": "lotus.cash_accounts"
+          },
+          {
+            "name": "cash_accounts[].cash_account_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.cash_account_id",
+            "attributeRef": "lotus.cash_account_id"
+          },
+          {
+            "name": "cash_accounts[].portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "lotus.portfolio_id"
+          },
+          {
+            "name": "cash_accounts[].security_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.security_id",
+            "attributeRef": "lotus.security_id"
+          },
+          {
+            "name": "cash_accounts[].display_name",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.display_name",
+            "attributeRef": "lotus.display_name"
+          },
+          {
+            "name": "cash_accounts[].account_currency",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.account_currency",
+            "attributeRef": "lotus.account_currency"
+          },
+          {
+            "name": "cash_accounts[].account_role",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.account_role",
+            "attributeRef": "lotus.account_role"
+          },
+          {
+            "name": "cash_accounts[].lifecycle_status",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.lifecycle_status",
+            "attributeRef": "lotus.lifecycle_status"
+          },
+          {
+            "name": "cash_accounts[].opened_on",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.opened_on",
+            "attributeRef": "lotus.opened_on"
+          },
+          {
+            "name": "cash_accounts[].closed_on",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.closed_on",
+            "attributeRef": "lotus.closed_on"
+          },
+          {
+            "name": "cash_accounts[].source_system",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_system",
+            "attributeRef": "lotus.source_system"
+          },
+          {
+            "name": "cash_accounts[].source_record_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_record_id",
+            "attributeRef": "lotus.source_record_id"
+          }
+        ]
+      },
+      "response": {
+        "httpStatus": 202,
+        "model": "BatchIngestionAcceptedResponse",
+        "fields": [
+          {
+            "name": "message",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.message",
+            "attributeRef": "lotus.message"
+          },
+          {
+            "name": "entity_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.entity_type",
+            "attributeRef": "lotus.entity_type"
+          },
+          {
+            "name": "accepted_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.accepted_count",
+            "attributeRef": "lotus.accepted_count"
+          },
+          {
+            "name": "correlation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.correlation_id",
+            "attributeRef": "lotus.correlation_id"
+          },
+          {
+            "name": "request_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.request_id",
+            "attributeRef": "lotus.request_id"
+          },
+          {
+            "name": "trace_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.trace_id",
+            "attributeRef": "lotus.trace_id"
+          },
+          {
+            "name": "idempotency_key",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.idempotency_key",
+            "attributeRef": "lotus.idempotency_key"
+          },
+          {
+            "name": "job_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.job_id",
+            "attributeRef": "lotus.job_id"
+          }
+        ]
+      }
+    },
+    {
+      "operationId": "ingest_instrument_lookthrough_components_ingest_reference_instrument_lookthrough_components_post",
+      "method": "POST",
+      "path": "/ingest/reference/instrument-lookthrough-components",
+      "domain": "reference_data",
+      "serviceGroup": "ingestion",
+      "tags": [
+        "Reference Data"
+      ],
+      "summary": "Ingest instrument look-through components",
+      "description": "What: Accept effective-dated look-through composition rows for funds and structured products.\nHow: Validate component weights and upsert durable decomposition records.\nWhen: Use when downstream allocation consumers need source-owned look-through views.",
+      "naming": {
+        "boundedContext": "reference_data",
+        "canonicalTerms": [
+          "accepted_count",
+          "component_security_id",
+          "component_weight",
+          "correlation_id",
+          "effective_from",
+          "effective_to",
+          "entity_type",
+          "idempotency_key",
+          "job_id",
+          "lookthrough_components",
+          "message",
+          "parent_security_id",
+          "request_id",
+          "source_record_id",
+          "source_system",
+          "trace_id"
+        ]
+      },
+      "request": {
+        "fields": [
+          {
+            "name": "lookthrough_components",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.lookthrough_components",
+            "attributeRef": "lotus.lookthrough_components"
+          },
+          {
+            "name": "lookthrough_components[].parent_security_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.parent_security_id",
+            "attributeRef": "lotus.parent_security_id"
+          },
+          {
+            "name": "lookthrough_components[].component_security_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.component_security_id",
+            "attributeRef": "lotus.component_security_id"
+          },
+          {
+            "name": "lookthrough_components[].effective_from",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.effective_from",
+            "attributeRef": "lotus.effective_from"
+          },
+          {
+            "name": "lookthrough_components[].effective_to",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.effective_to",
+            "attributeRef": "lotus.effective_to"
+          },
+          {
+            "name": "lookthrough_components[].component_weight",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.component_weight",
+            "attributeRef": "lotus.component_weight"
+          },
+          {
+            "name": "lookthrough_components[].source_system",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_system",
+            "attributeRef": "lotus.source_system"
+          },
+          {
+            "name": "lookthrough_components[].source_record_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_record_id",
+            "attributeRef": "lotus.source_record_id"
           }
         ]
       },

--- a/src/libs/portfolio-common/portfolio_common/database_models.py
+++ b/src/libs/portfolio-common/portfolio_common/database_models.py
@@ -531,6 +531,69 @@ class ClassificationTaxonomy(Base):
     )
 
 
+class CashAccountMaster(Base):
+    __tablename__ = "cash_account_masters"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    cash_account_id = Column(String, nullable=False, index=True)
+    portfolio_id = Column(String, ForeignKey("portfolios.portfolio_id"), nullable=False, index=True)
+    security_id = Column(String, nullable=False, index=True)
+    display_name = Column(String, nullable=False)
+    account_currency = Column(String(3), nullable=False, index=True)
+    account_role = Column(String, nullable=True, index=True)
+    lifecycle_status = Column(String, nullable=False, server_default="ACTIVE", index=True)
+    opened_on = Column(Date, nullable=True, index=True)
+    closed_on = Column(Date, nullable=True, index=True)
+    source_system = Column(String, nullable=True)
+    source_record_id = Column(String, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        UniqueConstraint("cash_account_id", name="_cash_account_master_id_uc"),
+        Index(
+            "ix_cash_account_master_portfolio_effective_window",
+            "portfolio_id",
+            "opened_on",
+            "closed_on",
+        ),
+    )
+
+
+class InstrumentLookthroughComponent(Base):
+    __tablename__ = "instrument_lookthrough_components"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    parent_security_id = Column(String, nullable=False, index=True)
+    component_security_id = Column(String, nullable=False, index=True)
+    effective_from = Column(Date, nullable=False, index=True)
+    effective_to = Column(Date, nullable=True, index=True)
+    component_weight = Column(Numeric(18, 10), nullable=False)
+    source_system = Column(String, nullable=True)
+    source_record_id = Column(String, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "parent_security_id",
+            "component_security_id",
+            "effective_from",
+            name="_instrument_lookthrough_component_effective_uc",
+        ),
+        Index(
+            "ix_instrument_lookthrough_parent_effective_window",
+            "parent_security_id",
+            "effective_from",
+            "effective_to",
+        ),
+    )
+
+
 class Transaction(Base):
     __tablename__ = "transactions"
 

--- a/src/services/ingestion_service/app/DTOs/reference_data_dto.py
+++ b/src/services/ingestion_service/app/DTOs/reference_data_dto.py
@@ -357,6 +357,96 @@ class ClassificationTaxonomyRecord(BaseModel):
     model_config = ConfigDict()
 
 
+class CashAccountMasterRecord(BaseModel):
+    cash_account_id: str = Field(
+        ..., description="Canonical Lotus cash account identifier.", examples=["CASH-ACC-USD-001"]
+    )
+    portfolio_id: str = Field(..., description="Owning portfolio identifier.", examples=["PORT-001"])
+    security_id: str = Field(
+        ...,
+        description="Linked cash instrument/security identifier.",
+        examples=["CASH_USD"],
+    )
+    display_name: str = Field(
+        ..., description="Cash account display name.", examples=["USD Operating Cash"]
+    )
+    account_currency: str = Field(
+        ..., description="Native cash account currency.", examples=["USD"]
+    )
+    account_role: str | None = Field(
+        None,
+        description="Optional account role label.",
+        examples=["OPERATING_CASH"],
+    )
+    lifecycle_status: str = Field(
+        "ACTIVE",
+        description="Cash account lifecycle status.",
+        examples=["ACTIVE"],
+    )
+    opened_on: date | None = Field(
+        None,
+        description="Optional cash account open date.",
+        examples=["2026-01-01"],
+    )
+    closed_on: date | None = Field(
+        None,
+        description="Optional cash account close date.",
+        examples=["2026-12-31"],
+    )
+    source_system: str | None = Field(
+        None,
+        description="Upstream source system.",
+        examples=["lotus-manage"],
+    )
+    source_record_id: str | None = Field(
+        None,
+        description="Upstream source record identifier.",
+        examples=["cash-account-001"],
+    )
+
+    model_config = ConfigDict()
+
+
+class InstrumentLookthroughComponentRecord(BaseModel):
+    parent_security_id: str = Field(
+        ...,
+        description="Structured product or fund security identifier being decomposed.",
+        examples=["FUND_GLOBAL_60_40"],
+    )
+    component_security_id: str = Field(
+        ...,
+        description="Underlying component security identifier.",
+        examples=["ETF_WORLD_EQUITY"],
+    )
+    effective_from: date = Field(
+        ...,
+        description="Effective start date for the look-through composition row.",
+        examples=["2026-01-01"],
+    )
+    effective_to: date | None = Field(
+        None,
+        description="Effective end date for the look-through composition row.",
+        examples=["2026-12-31"],
+    )
+    component_weight: condecimal(ge=Decimal(0), le=Decimal(1)) = Field(
+        ...,
+        description="Weight of the underlying component between 0 and 1.",
+        examples=["0.6000000000"],
+    )
+    source_system: str | None = Field(
+        None,
+        description="Upstream source system.",
+        examples=["lotus-manage"],
+    )
+    source_record_id: str | None = Field(
+        None,
+        description="Upstream source record identifier.",
+        examples=["lt-001"],
+    )
+
+    model_config = ConfigDict()
+
+
 class PortfolioBenchmarkAssignmentIngestionRequest(BaseModel):
     benchmark_assignments: list[PortfolioBenchmarkAssignmentRecord] = Field(
         ...,
@@ -543,6 +633,49 @@ class ClassificationTaxonomyIngestionRequest(BaseModel):
                     "dimension_name": "sector",
                     "dimension_value": "technology",
                     "effective_from": "2025-01-01",
+                }
+            ]
+        ],
+    )
+
+    model_config = ConfigDict()
+
+
+class CashAccountMasterIngestionRequest(BaseModel):
+    cash_accounts: list[CashAccountMasterRecord] = Field(
+        ...,
+        description="Cash-account master records to ingest or upsert.",
+        min_length=1,
+        examples=[
+            [
+                {
+                    "cash_account_id": "CASH-ACC-USD-001",
+                    "portfolio_id": "PORT-001",
+                    "security_id": "CASH_USD",
+                    "display_name": "USD Operating Cash",
+                    "account_currency": "USD",
+                    "account_role": "OPERATING_CASH",
+                    "lifecycle_status": "ACTIVE",
+                }
+            ]
+        ],
+    )
+
+    model_config = ConfigDict()
+
+
+class InstrumentLookthroughComponentIngestionRequest(BaseModel):
+    lookthrough_components: list[InstrumentLookthroughComponentRecord] = Field(
+        ...,
+        description="Instrument look-through composition rows to ingest or upsert.",
+        min_length=1,
+        examples=[
+            [
+                {
+                    "parent_security_id": "FUND_GLOBAL_60_40",
+                    "component_security_id": "ETF_WORLD_EQUITY",
+                    "effective_from": "2026-01-01",
+                    "component_weight": "0.6000000000",
                 }
             ]
         ],

--- a/src/services/ingestion_service/app/routers/reference_data.py
+++ b/src/services/ingestion_service/app/routers/reference_data.py
@@ -9,10 +9,12 @@ from ..DTOs.reference_data_dto import (
     BenchmarkCompositionIngestionRequest,
     BenchmarkDefinitionIngestionRequest,
     BenchmarkReturnSeriesIngestionRequest,
+    CashAccountMasterIngestionRequest,
     ClassificationTaxonomyIngestionRequest,
     IndexDefinitionIngestionRequest,
     IndexPriceSeriesIngestionRequest,
     IndexReturnSeriesIngestionRequest,
+    InstrumentLookthroughComponentIngestionRequest,
     PortfolioBenchmarkAssignmentIngestionRequest,
     RiskFreeSeriesIngestionRequest,
 )
@@ -437,6 +439,76 @@ async def ingest_classification_taxonomy(
         request_payload=request.model_dump(mode="json"),
         persist_fn=lambda: reference_data_service.upsert_classification_taxonomy(
             [item.model_dump() for item in request.classification_taxonomy]
+        ),
+        ingestion_job_service=ingestion_job_service,
+    )
+
+
+@router.post(
+    "/ingest/reference/cash-accounts",
+    status_code=status.HTTP_202_ACCEPTED,
+    response_model=BatchIngestionAcceptedResponse,
+    responses=REFERENCE_INGESTION_RESPONSES,
+    tags=["Reference Data"],
+    summary="Ingest cash-account master records",
+    description=(
+        "What: Accept canonical cash-account master records.\n"
+        "How: Validate PB/WM cash-account identity and upsert durable portfolio/account linkage "
+        "metadata.\n"
+        "When: Use during onboarding and cash-account lifecycle maintenance."
+    ),
+)
+async def ingest_cash_account_masters(
+    request: CashAccountMasterIngestionRequest,
+    http_request: Request,
+    reference_data_service: ReferenceDataIngestionService = Depends(
+        get_reference_data_ingestion_service
+    ),
+    ingestion_job_service: IngestionJobService = Depends(get_ingestion_job_service),
+) -> BatchIngestionAcceptedResponse:
+    return await _handle_reference_ingestion(
+        http_request=http_request,
+        endpoint="/ingest/reference/cash-accounts",
+        entity_type="cash_account_master",
+        accepted_count=len(request.cash_accounts),
+        request_payload=request.model_dump(mode="json"),
+        persist_fn=lambda: reference_data_service.upsert_cash_account_masters(
+            [item.model_dump() for item in request.cash_accounts]
+        ),
+        ingestion_job_service=ingestion_job_service,
+    )
+
+
+@router.post(
+    "/ingest/reference/instrument-lookthrough-components",
+    status_code=status.HTTP_202_ACCEPTED,
+    response_model=BatchIngestionAcceptedResponse,
+    responses=REFERENCE_INGESTION_RESPONSES,
+    tags=["Reference Data"],
+    summary="Ingest instrument look-through components",
+    description=(
+        "What: Accept effective-dated look-through composition rows for funds and structured "
+        "products.\n"
+        "How: Validate component weights and upsert durable decomposition records.\n"
+        "When: Use when downstream allocation consumers need source-owned look-through views."
+    ),
+)
+async def ingest_instrument_lookthrough_components(
+    request: InstrumentLookthroughComponentIngestionRequest,
+    http_request: Request,
+    reference_data_service: ReferenceDataIngestionService = Depends(
+        get_reference_data_ingestion_service
+    ),
+    ingestion_job_service: IngestionJobService = Depends(get_ingestion_job_service),
+) -> BatchIngestionAcceptedResponse:
+    return await _handle_reference_ingestion(
+        http_request=http_request,
+        endpoint="/ingest/reference/instrument-lookthrough-components",
+        entity_type="instrument_lookthrough_component",
+        accepted_count=len(request.lookthrough_components),
+        request_payload=request.model_dump(mode="json"),
+        persist_fn=lambda: reference_data_service.upsert_instrument_lookthrough_components(
+            [item.model_dump() for item in request.lookthrough_components]
         ),
         ingestion_job_service=ingestion_job_service,
     )

--- a/src/services/ingestion_service/app/services/reference_data_ingestion_service.py
+++ b/src/services/ingestion_service/app/services/reference_data_ingestion_service.py
@@ -8,10 +8,12 @@ from portfolio_common.database_models import (
     BenchmarkCompositionSeries,
     BenchmarkDefinition,
     BenchmarkReturnSeries,
+    CashAccountMaster,
     ClassificationTaxonomy,
     IndexDefinition,
     IndexPriceSeries,
     IndexReturnSeries,
+    InstrumentLookthroughComponent,
     PortfolioBenchmarkAssignment,
     RiskFreeSeries,
 )
@@ -199,6 +201,44 @@ class ReferenceDataIngestionService:
                 "source_vendor",
                 "source_record_id",
                 "quality_status",
+            ],
+        )
+
+    async def upsert_cash_account_masters(self, records: list[dict[str, Any]]) -> None:
+        await self._upsert_many(
+            model=CashAccountMaster,
+            records=records,
+            conflict_columns=["cash_account_id"],
+            update_columns=[
+                "portfolio_id",
+                "security_id",
+                "display_name",
+                "account_currency",
+                "account_role",
+                "lifecycle_status",
+                "opened_on",
+                "closed_on",
+                "source_system",
+                "source_record_id",
+            ],
+        )
+
+    async def upsert_instrument_lookthrough_components(
+        self, records: list[dict[str, Any]]
+    ) -> None:
+        await self._upsert_many(
+            model=InstrumentLookthroughComponent,
+            records=records,
+            conflict_columns=[
+                "parent_security_id",
+                "component_security_id",
+                "effective_from",
+            ],
+            update_columns=[
+                "effective_to",
+                "component_weight",
+                "source_system",
+                "source_record_id",
             ],
         )
 

--- a/src/services/query_service/app/dtos/cash_account_dto.py
+++ b/src/services/query_service/app/dtos/cash_account_dto.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from datetime import date
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class CashAccountRecord(BaseModel):
+    cash_account_id: str = Field(
+        ...,
+        description="Canonical Lotus cash account identifier.",
+        examples=["CASH-ACC-USD-001"],
+    )
+    portfolio_id: str = Field(
+        ...,
+        description="Owning portfolio identifier.",
+        examples=["PORT-001"],
+    )
+    security_id: str = Field(
+        ...,
+        description="Linked cash instrument/security identifier.",
+        examples=["CASH_USD"],
+    )
+    display_name: str = Field(
+        ...,
+        description="Cash account display name.",
+        examples=["USD Operating Cash"],
+    )
+    account_currency: str = Field(
+        ...,
+        description="Native cash account currency.",
+        examples=["USD"],
+    )
+    account_role: str | None = Field(
+        None,
+        description="Optional cash-account role classification.",
+        examples=["OPERATING_CASH"],
+    )
+    lifecycle_status: str = Field(
+        ...,
+        description="Cash-account lifecycle status.",
+        examples=["ACTIVE"],
+    )
+    opened_on: date | None = Field(
+        None,
+        description="Cash-account open date when known.",
+        examples=["2026-01-01"],
+    )
+    closed_on: date | None = Field(
+        None,
+        description="Cash-account close date when known.",
+        examples=["2026-12-31"],
+    )
+    source_system: str | None = Field(
+        None,
+        description="Upstream source system.",
+        examples=["lotus-manage"],
+    )
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CashAccountQueryResponse(BaseModel):
+    portfolio_id: str = Field(..., description="Portfolio identifier.", examples=["PORT-001"])
+    resolved_as_of_date: date | None = Field(
+        None,
+        description="Effective as-of date used to resolve the cash-account master set.",
+        examples=["2026-03-28"],
+    )
+    cash_accounts: list[CashAccountRecord] = Field(
+        ...,
+        description="Canonical cash accounts linked to the portfolio.",
+    )

--- a/src/services/query_service/app/dtos/reporting_dto.py
+++ b/src/services/query_service/app/dtos/reporting_dto.py
@@ -9,11 +9,13 @@ from pydantic import BaseModel, Field, model_validator
 ReportingScopeType = Literal["portfolio", "portfolio_list", "business_unit"]
 IncomeType = Literal["DIVIDEND", "INTEREST", "CASH_IN_LIEU"]
 ActivityBucketType = Literal["INFLOWS", "OUTFLOWS", "FEES", "TAXES"]
+LookThroughMode = Literal["direct_only", "prefer_look_through"]
 AllocationDimension = Literal[
     "asset_class",
     "currency",
     "sector",
     "country",
+    "region",
     "product_type",
     "rating",
     "issuer_id",
@@ -135,6 +137,15 @@ class AssetAllocationQueryRequest(BaseModel):
         ),
         examples=[["asset_class", "currency", "sector"]],
     )
+    look_through_mode: LookThroughMode = Field(
+        "direct_only",
+        description=(
+            "Allocation decomposition mode. `direct_only` keeps parent holdings intact. "
+            "`prefer_look_through` decomposes eligible parent instruments when source-owned "
+            "look-through components are available."
+        ),
+        examples=["prefer_look_through"],
+    )
 
     @model_validator(mode="after")
     def validate_reporting_currency_requirements(self) -> "AssetAllocationQueryRequest":
@@ -163,6 +174,51 @@ class CashBalancesQueryRequest(BaseModel):
             "Optional reporting currency. Defaults to the portfolio currency when not provided."
         ),
         examples=["USD"],
+    )
+
+
+class PortfolioSummaryQueryRequest(BaseModel):
+    portfolio_id: str = Field(
+        ...,
+        description="Portfolio identifier for the summary query.",
+        examples=["PORT-001"],
+    )
+    as_of_date: date | None = Field(
+        None,
+        description=(
+            "As-of date for the historical portfolio snapshot. Defaults to latest business date."
+        ),
+        examples=["2026-03-27"],
+    )
+    reporting_currency: str | None = Field(
+        None,
+        description="Optional reporting currency. Defaults to the portfolio currency.",
+        examples=["USD"],
+    )
+
+
+class HoldingsSnapshotQueryRequest(BaseModel):
+    portfolio_id: str = Field(
+        ...,
+        description="Portfolio identifier for the holdings snapshot query.",
+        examples=["PORT-001"],
+    )
+    as_of_date: date | None = Field(
+        None,
+        description=(
+            "As-of date for the historical holdings snapshot. Defaults to latest business date."
+        ),
+        examples=["2026-03-27"],
+    )
+    reporting_currency: str | None = Field(
+        None,
+        description="Optional reporting currency. Defaults to the portfolio currency.",
+        examples=["USD"],
+    )
+    include_cash_positions: bool = Field(
+        True,
+        description="When false, excludes cash positions from the holdings snapshot.",
+        examples=[True],
     )
 
 
@@ -308,8 +364,35 @@ class AssetAllocationResponse(BaseModel):
     total_market_value_reporting_currency: Decimal = Field(
         ..., description="Total AUM represented by the allocation views."
     )
+    look_through: "AllocationLookThroughInfo" = Field(
+        ...,
+        description="Applied look-through mode and capability summary for the allocation query.",
+    )
     views: list[AllocationView] = Field(
         ..., description="Allocation views for the requested classification dimensions."
+    )
+
+
+class AllocationLookThroughInfo(BaseModel):
+    requested_mode: LookThroughMode = Field(
+        ...,
+        description="Look-through mode requested by the caller.",
+    )
+    applied_mode: LookThroughMode = Field(
+        ...,
+        description="Look-through mode actually applied to the response.",
+    )
+    supported: bool = Field(
+        ...,
+        description="Whether source-owned look-through decomposition was available for the query.",
+    )
+    decomposed_position_count: int = Field(
+        ...,
+        description="Number of parent positions decomposed into underlying components.",
+    )
+    limitation_reason: str | None = Field(
+        None,
+        description="Explanation when look-through was requested but could not be applied.",
     )
 
 
@@ -367,6 +450,117 @@ class CashBalancesResponse(BaseModel):
     totals: CashBalancesTotals = Field(..., description="Portfolio-level cash totals.")
     cash_accounts: list[CashAccountBalanceRecord] = Field(
         ..., description="Resolved cash accounts and balances for the portfolio."
+    )
+
+
+class PortfolioSummaryTotals(BaseModel):
+    total_market_value_portfolio_currency: Decimal = Field(
+        ...,
+        description="Total portfolio market value in portfolio currency.",
+    )
+    total_market_value_reporting_currency: Decimal = Field(
+        ...,
+        description="Total portfolio market value in reporting currency.",
+    )
+    cash_balance_portfolio_currency: Decimal = Field(
+        ...,
+        description="Cash balance subtotal in portfolio currency.",
+    )
+    cash_balance_reporting_currency: Decimal = Field(
+        ...,
+        description="Cash balance subtotal in reporting currency.",
+    )
+    invested_market_value_portfolio_currency: Decimal = Field(
+        ...,
+        description="Non-cash invested market value in portfolio currency.",
+    )
+    invested_market_value_reporting_currency: Decimal = Field(
+        ...,
+        description="Non-cash invested market value in reporting currency.",
+    )
+
+
+class PortfolioSummarySnapshotMetadata(BaseModel):
+    snapshot_date: date = Field(..., description="Resolved snapshot date backing the summary.")
+    position_count: int = Field(..., description="Number of positions in the snapshot.")
+    cash_account_count: int = Field(..., description="Number of cash accounts represented.")
+    valued_position_count: int = Field(
+        ...,
+        description="Number of snapshot positions with non-UNVALUED coverage.",
+    )
+    unvalued_position_count: int = Field(
+        ...,
+        description="Number of snapshot positions still lacking valuation coverage.",
+    )
+
+
+class PortfolioSummaryResponse(BaseModel):
+    portfolio_id: str = Field(..., description="Portfolio identifier.", examples=["PORT-001"])
+    booking_center_code: str = Field(..., description="Booking center code.", examples=["SGPB"])
+    client_id: str = Field(..., description="Client identifier.", examples=["CIF-1001"])
+    portfolio_currency: str = Field(..., description="Portfolio base currency.", examples=["USD"])
+    reporting_currency: str = Field(
+        ...,
+        description="Effective reporting currency.",
+        examples=["USD"],
+    )
+    resolved_as_of_date: date = Field(..., description="Effective as-of date used by the query.")
+    portfolio_type: str = Field(..., description="Portfolio product/type classification.")
+    objective: str | None = Field(None, description="Primary portfolio objective.")
+    risk_exposure: str = Field(..., description="Risk-exposure classification.")
+    status: str = Field(..., description="Portfolio lifecycle status.")
+    totals: PortfolioSummaryTotals = Field(..., description="Portfolio summary totals.")
+    snapshot_metadata: PortfolioSummarySnapshotMetadata = Field(
+        ...,
+        description="Resolved snapshot metadata for the summary query.",
+    )
+
+
+class HoldingSnapshotRecord(BaseModel):
+    security_id: str = Field(..., description="Security identifier.", examples=["SEC-US-AAPL"])
+    instrument_name: str = Field(..., description="Instrument display name.")
+    asset_class: str | None = Field(None, description="Asset class classification.")
+    sector: str | None = Field(None, description="Sector classification.")
+    country: str | None = Field(None, description="Country of risk classification.")
+    region: str | None = Field(None, description="Derived region classification.")
+    account_currency: str | None = Field(None, description="Instrument or account currency.")
+    quantity: Decimal = Field(..., description="Position quantity.")
+    market_value_portfolio_currency: Decimal = Field(
+        ...,
+        description="Position market value in portfolio currency.",
+    )
+    market_value_reporting_currency: Decimal = Field(
+        ...,
+        description="Position market value in reporting currency.",
+    )
+    weight: Decimal = Field(..., description="Position weight versus total snapshot market value.")
+    valuation_status: str | None = Field(None, description="Snapshot valuation status.")
+
+
+class HoldingsSnapshotResponse(BaseModel):
+    portfolio_id: str = Field(..., description="Portfolio identifier.", examples=["PORT-001"])
+    portfolio_currency: str = Field(..., description="Portfolio base currency.", examples=["USD"])
+    reporting_currency: str = Field(
+        ...,
+        description="Effective reporting currency.",
+        examples=["USD"],
+    )
+    resolved_as_of_date: date = Field(..., description="Effective as-of date used by the query.")
+    snapshot_date: date = Field(
+        ...,
+        description="Resolved snapshot date backing the holdings view.",
+    )
+    total_market_value_portfolio_currency: Decimal = Field(
+        ...,
+        description="Total snapshot market value in portfolio currency.",
+    )
+    total_market_value_reporting_currency: Decimal = Field(
+        ...,
+        description="Total snapshot market value in reporting currency.",
+    )
+    positions: list[HoldingSnapshotRecord] = Field(
+        ...,
+        description="Holdings snapshot rows for the resolved portfolio and as-of date.",
     )
 
 
@@ -506,3 +700,6 @@ class ActivitySummaryResponse(BaseModel):
     portfolios: list[PortfolioActivitySummary] = Field(
         ..., description="Per-portfolio activity summary rows for the resolved scope."
     )
+
+
+AssetAllocationResponse.model_rebuild()

--- a/src/services/query_service/app/main.py
+++ b/src/services/query_service/app/main.py
@@ -13,6 +13,7 @@ from .enterprise_readiness import (
 )
 from .routers import (
     buy_state,
+    cash_accounts,
     cashflow_projection,
     fx_rates,
     instruments,
@@ -66,6 +67,7 @@ include_routers(
     health_router,
     portfolios.router,
     positions.router,
+    cash_accounts.router,
     buy_state.router,
     sell_state.router,
     transactions.router,

--- a/src/services/query_service/app/repositories/cash_account_repository.py
+++ b/src/services/query_service/app/repositories/cash_account_repository.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from datetime import date
+
+from portfolio_common.database_models import CashAccountMaster, Portfolio
+from sqlalchemy import and_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class CashAccountRepository:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def portfolio_exists(self, portfolio_id: str) -> bool:
+        stmt = select(Portfolio.portfolio_id).where(Portfolio.portfolio_id == portfolio_id)
+        return (await self.db.execute(stmt)).scalar_one_or_none() is not None
+
+    async def list_cash_accounts(
+        self,
+        portfolio_id: str,
+        *,
+        as_of_date: date | None = None,
+    ) -> list[CashAccountMaster]:
+        stmt = select(CashAccountMaster).where(CashAccountMaster.portfolio_id == portfolio_id)
+        if as_of_date is not None:
+            stmt = stmt.where(
+                or_(
+                    CashAccountMaster.opened_on.is_(None),
+                    CashAccountMaster.opened_on <= as_of_date,
+                ),
+                or_(
+                    CashAccountMaster.closed_on.is_(None),
+                    CashAccountMaster.closed_on >= as_of_date,
+                ),
+            )
+        stmt = stmt.order_by(
+            CashAccountMaster.account_currency.asc(),
+            CashAccountMaster.cash_account_id.asc(),
+        )
+        return list((await self.db.execute(stmt)).scalars().all())

--- a/src/services/query_service/app/repositories/cash_account_repository.py
+++ b/src/services/query_service/app/repositories/cash_account_repository.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import date
 
 from portfolio_common.database_models import CashAccountMaster, Portfolio
-from sqlalchemy import and_, or_, select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 

--- a/src/services/query_service/app/repositories/reporting_repository.py
+++ b/src/services/query_service/app/repositories/reporting_repository.py
@@ -7,14 +7,15 @@ from decimal import Decimal
 from portfolio_common.config import DEFAULT_BUSINESS_CALENDAR_CODE
 from portfolio_common.database_models import (
     BusinessDate,
+    CashAccountMaster,
     DailyPositionSnapshot,
     FxRate,
     Instrument,
+    InstrumentLookthroughComponent,
     Portfolio,
-    PositionState,
     Transaction,
 )
-from sqlalchemy import String, and_, case, func, literal, select, union_all
+from sqlalchemy import String, and_, case, func, literal, or_, select, union_all
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .date_filters import start_of_day, start_of_next_day
@@ -59,6 +60,14 @@ class ActivitySummaryAggregateRow:
     ytd_transaction_count: int
     requested_amount: Decimal
     ytd_amount: Decimal
+
+
+@dataclass(frozen=True)
+class InstrumentLookthroughComponentRow:
+    parent_security_id: str
+    component_security_id: str
+    component_weight: Decimal
+    component_instrument: Instrument | None
 
 
 class ReportingRepository:
@@ -113,14 +122,6 @@ class ReportingRepository:
                     order_by=(DailyPositionSnapshot.date.desc(), DailyPositionSnapshot.id.desc()),
                 )
                 .label("rn"),
-            )
-            .join(
-                PositionState,
-                and_(
-                    DailyPositionSnapshot.portfolio_id == PositionState.portfolio_id,
-                    DailyPositionSnapshot.security_id == PositionState.security_id,
-                    DailyPositionSnapshot.epoch == PositionState.epoch,
-                ),
             )
             .where(
                 DailyPositionSnapshot.portfolio_id.in_(portfolio_ids),
@@ -209,6 +210,79 @@ class ReportingRepository:
         ).where(ranked_txn_subq.c.rn == 1)
         rows = (await self.db.execute(stmt)).all()
         return {str(security_id): str(cash_account_id) for security_id, cash_account_id in rows}
+
+    async def list_cash_account_masters(
+        self,
+        *,
+        portfolio_id: str,
+        as_of_date: date | None,
+    ) -> list[CashAccountMaster]:
+        stmt = select(CashAccountMaster).where(CashAccountMaster.portfolio_id == portfolio_id)
+        if as_of_date is not None:
+            stmt = stmt.where(
+                or_(
+                    CashAccountMaster.opened_on.is_(None),
+                    CashAccountMaster.opened_on <= as_of_date,
+                ),
+                or_(
+                    CashAccountMaster.closed_on.is_(None),
+                    CashAccountMaster.closed_on >= as_of_date,
+                ),
+            )
+        stmt = stmt.order_by(
+            CashAccountMaster.account_currency.asc(),
+            CashAccountMaster.cash_account_id.asc(),
+        )
+        return list((await self.db.execute(stmt)).scalars().all())
+
+    async def list_instrument_lookthrough_components(
+        self,
+        *,
+        parent_security_ids: list[str],
+        as_of_date: date,
+    ) -> list[InstrumentLookthroughComponentRow]:
+        if not parent_security_ids:
+            return []
+
+        stmt = (
+            select(
+                InstrumentLookthroughComponent.parent_security_id,
+                InstrumentLookthroughComponent.component_security_id,
+                InstrumentLookthroughComponent.component_weight,
+                Instrument,
+            )
+            .outerjoin(
+                Instrument,
+                Instrument.security_id == InstrumentLookthroughComponent.component_security_id,
+            )
+            .where(
+                InstrumentLookthroughComponent.parent_security_id.in_(parent_security_ids),
+                InstrumentLookthroughComponent.effective_from <= as_of_date,
+                or_(
+                    InstrumentLookthroughComponent.effective_to.is_(None),
+                    InstrumentLookthroughComponent.effective_to >= as_of_date,
+                ),
+            )
+            .order_by(
+                InstrumentLookthroughComponent.parent_security_id.asc(),
+                InstrumentLookthroughComponent.component_security_id.asc(),
+            )
+        )
+        rows = (await self.db.execute(stmt)).all()
+        return [
+            InstrumentLookthroughComponentRow(
+                parent_security_id=parent_security_id,
+                component_security_id=component_security_id,
+                component_weight=component_weight,
+                component_instrument=component_instrument,
+            )
+            for (
+                parent_security_id,
+                component_security_id,
+                component_weight,
+                component_instrument,
+            ) in rows
+        ]
 
     async def list_income_summary_rows(
         self,
@@ -314,8 +388,7 @@ class ReportingRepository:
             case(
                 (
                     Transaction.transaction_type == "FEE",
-                    Transaction.gross_transaction_amount
-                    + func.coalesce(Transaction.trade_fee, 0),
+                    Transaction.gross_transaction_amount + func.coalesce(Transaction.trade_fee, 0),
                 ),
                 else_=Transaction.gross_transaction_amount,
             )

--- a/src/services/query_service/app/routers/cash_accounts.py
+++ b/src/services/query_service/app/routers/cash_accounts.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import date
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
+from portfolio_common.db import get_async_db_session
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..dtos.cash_account_dto import CashAccountQueryResponse
+from ..services.cash_account_service import CashAccountService
+
+router = APIRouter(prefix="/portfolios", tags=["Cash Accounts"])
+
+PORTFOLIO_NOT_FOUND_RESPONSE_EXAMPLE = {"detail": "Portfolio with id PORT-CASH-001 not found"}
+
+
+def get_cash_account_service(
+    db: AsyncSession = Depends(get_async_db_session),
+) -> CashAccountService:
+    return CashAccountService(db)
+
+
+@router.get(
+    "/{portfolio_id}/cash-accounts",
+    response_model=CashAccountQueryResponse,
+    responses={
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Portfolio not found.",
+            "content": {"application/json": {"example": PORTFOLIO_NOT_FOUND_RESPONSE_EXAMPLE}},
+        }
+    },
+    summary="Get canonical cash accounts for a portfolio",
+    description=(
+        "Returns source-owned canonical cash-account master records for one portfolio. "
+        "Use this endpoint for canonical account identity and lifecycle metadata; "
+        "use reporting cash-balances when balances and translated totals are required."
+    ),
+)
+async def get_cash_accounts(
+    portfolio_id: str = Path(
+        ...,
+        description="Portfolio identifier.",
+        examples=["PORT-CASH-001"],
+    ),
+    as_of_date: date | None = Query(
+        None,
+        description=(
+            "Optional as-of date used to filter cash-account master records by open/close window."
+        ),
+        examples=["2026-03-28"],
+    ),
+    service: CashAccountService = Depends(get_cash_account_service),
+):
+    try:
+        return await service.get_cash_accounts(portfolio_id, as_of_date=as_of_date)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))

--- a/src/services/query_service/app/routers/reporting.py
+++ b/src/services/query_service/app/routers/reporting.py
@@ -11,8 +11,12 @@ from ..dtos.reporting_dto import (
     AssetsUnderManagementResponse,
     CashBalancesQueryRequest,
     CashBalancesResponse,
+    HoldingsSnapshotQueryRequest,
+    HoldingsSnapshotResponse,
     IncomeSummaryQueryRequest,
     IncomeSummaryResponse,
+    PortfolioSummaryQueryRequest,
+    PortfolioSummaryResponse,
 )
 from ..services.reporting_service import ReportingService
 
@@ -81,6 +85,47 @@ async def query_cash_balances(
 ):
     try:
         return await service.get_cash_balances(request)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+
+@router.post(
+    "/portfolio-summary/query",
+    response_model=PortfolioSummaryResponse,
+    summary="Query Portfolio Summary Snapshot",
+    description=(
+        "Returns a true historical as-of portfolio summary for one portfolio, including market "
+        "value totals, cash versus invested split, and snapshot coverage metadata. Use this "
+        "contract when UI or reporting consumers need a restated summary in portfolio currency "
+        "and reporting currency without rebuilding holdings totals client-side."
+    ),
+)
+async def query_portfolio_summary(
+    request: PortfolioSummaryQueryRequest,
+    service: ReportingService = Depends(get_reporting_service),
+):
+    try:
+        return await service.get_portfolio_summary(request)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+
+@router.post(
+    "/holdings-snapshot/query",
+    response_model=HoldingsSnapshotResponse,
+    summary="Query Historical Holdings Snapshot",
+    description=(
+        "Returns a true historical as-of holdings snapshot for one portfolio with reporting-"
+        "currency restatement and portfolio-workspace classifications. Use this contract for "
+        "UI holdings views and reporting extracts that need region-aware, restated holdings rows."
+    ),
+)
+async def query_holdings_snapshot(
+    request: HoldingsSnapshotQueryRequest,
+    service: ReportingService = Depends(get_reporting_service),
+):
+    try:
+        return await service.get_holdings_snapshot(request)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
 

--- a/src/services/query_service/app/services/cash_account_service.py
+++ b/src/services/query_service/app/services/cash_account_service.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from datetime import date
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..dtos.cash_account_dto import CashAccountQueryResponse, CashAccountRecord
+from ..repositories.cash_account_repository import CashAccountRepository
+
+
+class CashAccountService:
+    def __init__(self, db: AsyncSession):
+        self.repo = CashAccountRepository(db)
+
+    async def get_cash_accounts(
+        self, portfolio_id: str, *, as_of_date: date | None = None
+    ) -> CashAccountQueryResponse:
+        if not await self.repo.portfolio_exists(portfolio_id):
+            raise ValueError(f"Portfolio with id {portfolio_id} not found")
+
+        accounts = await self.repo.list_cash_accounts(portfolio_id, as_of_date=as_of_date)
+        return CashAccountQueryResponse(
+            portfolio_id=portfolio_id,
+            resolved_as_of_date=as_of_date,
+            cash_accounts=[CashAccountRecord.model_validate(account) for account in accounts],
+        )

--- a/src/services/query_service/app/services/reporting_classification.py
+++ b/src/services/query_service/app/services/reporting_classification.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+
+COUNTRY_TO_REGION = {
+    "US": "North America",
+    "CA": "North America",
+    "MX": "Latin America",
+    "BR": "Latin America",
+    "AR": "Latin America",
+    "GB": "Europe",
+    "IE": "Europe",
+    "FR": "Europe",
+    "DE": "Europe",
+    "CH": "Europe",
+    "IT": "Europe",
+    "ES": "Europe",
+    "NL": "Europe",
+    "SE": "Europe",
+    "NO": "Europe",
+    "DK": "Europe",
+    "FI": "Europe",
+    "AT": "Europe",
+    "BE": "Europe",
+    "PT": "Europe",
+    "SG": "Asia Pacific",
+    "HK": "Asia Pacific",
+    "CN": "Asia Pacific",
+    "JP": "Asia Pacific",
+    "AU": "Asia Pacific",
+    "NZ": "Asia Pacific",
+    "IN": "Asia Pacific",
+    "KR": "Asia Pacific",
+    "TW": "Asia Pacific",
+    "TH": "Asia Pacific",
+    "MY": "Asia Pacific",
+    "ID": "Asia Pacific",
+    "PH": "Asia Pacific",
+    "VN": "Asia Pacific",
+    "AE": "Middle East & Africa",
+    "SA": "Middle East & Africa",
+    "ZA": "Middle East & Africa",
+    "EG": "Middle East & Africa",
+    "NG": "Middle East & Africa",
+}
+
+
+def resolve_region(country_code: str | None) -> str | None:
+    if not country_code:
+        return None
+    return COUNTRY_TO_REGION.get(country_code.upper(), "Other")

--- a/src/services/query_service/app/services/reporting_service.py
+++ b/src/services/query_service/app/services/reporting_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from datetime import date
 from decimal import Decimal
+from types import SimpleNamespace
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -12,6 +13,7 @@ from ..dtos.reporting_dto import (
     ActivitySummaryResponse,
     ActivitySummaryTotals,
     AllocationBucket,
+    AllocationLookThroughInfo,
     AllocationView,
     AssetAllocationQueryRequest,
     AssetAllocationResponse,
@@ -23,6 +25,9 @@ from ..dtos.reporting_dto import (
     CashBalancesResponse,
     CashBalancesTotals,
     FlowPeriodSummary,
+    HoldingSnapshotRecord,
+    HoldingsSnapshotQueryRequest,
+    HoldingsSnapshotResponse,
     IncomePeriodSummary,
     IncomeSummaryQueryRequest,
     IncomeSummaryResponse,
@@ -30,14 +35,20 @@ from ..dtos.reporting_dto import (
     IncomeTypeSummary,
     PortfolioActivitySummary,
     PortfolioIncomeSummary,
+    PortfolioSummaryQueryRequest,
+    PortfolioSummaryResponse,
+    PortfolioSummarySnapshotMetadata,
+    PortfolioSummaryTotals,
     ReportingPortfolioSummary,
     ReportingScope,
 )
 from ..repositories.reporting_repository import (
     ActivitySummaryAggregateRow,
     IncomeSummaryAggregateRow,
+    InstrumentLookthroughComponentRow,
     ReportingRepository,
 )
+from .reporting_classification import resolve_region
 
 ZERO = Decimal("0")
 CASH_ASSET_CLASS = "CASH"
@@ -48,6 +59,9 @@ ALLOCATION_DIMENSION_ACCESSORS = {
     ),
     "sector": lambda instrument, snapshot: instrument.sector if instrument else None,
     "country": lambda instrument, snapshot: instrument.country_of_risk if instrument else None,
+    "region": lambda instrument, snapshot: (
+        resolve_region(instrument.country_of_risk) if instrument else None
+    ),
     "product_type": lambda instrument, snapshot: instrument.product_type if instrument else None,
     "rating": lambda instrument, snapshot: instrument.rating if instrument else None,
     "issuer_id": lambda instrument, snapshot: instrument.issuer_id if instrument else None,
@@ -150,6 +164,12 @@ class ReportingService:
             portfolio_ids=[portfolio.portfolio_id for portfolio in portfolios],
             as_of_date=resolved_as_of_date,
         )
+        allocation_rows, look_through_info = await self._resolve_allocation_rows(
+            rows=rows,
+            requested_mode=request.look_through_mode,
+            as_of_date=resolved_as_of_date,
+            reporting_currency=reporting_currency,
+        )
 
         total_market_value = ZERO
         views_payload: dict[str, dict[str, Decimal]] = {
@@ -159,18 +179,11 @@ class ReportingService:
             dimension: defaultdict(int) for dimension in request.dimensions
         }
 
-        for row in rows:
-            native_value = Decimal(str(row.snapshot.market_value or ZERO))
-            reporting_value = await self._convert_amount(
-                amount=native_value,
-                from_currency=row.portfolio.base_currency,
-                to_currency=reporting_currency,
-                as_of_date=resolved_as_of_date,
-            )
+        for instrument, snapshot, reporting_value in allocation_rows:
             total_market_value += reporting_value
             for dimension in request.dimensions:
                 accessor = ALLOCATION_DIMENSION_ACCESSORS[dimension]
-                raw_value = accessor(row.instrument, row.snapshot)
+                raw_value = accessor(instrument, snapshot)
                 bucket_key = str(raw_value or "UNCLASSIFIED")
                 views_payload[dimension][bucket_key] += reporting_value
                 views_position_counts[dimension][bucket_key] += 1
@@ -201,6 +214,7 @@ class ReportingService:
             resolved_as_of_date=resolved_as_of_date,
             reporting_currency=reporting_currency,
             total_market_value_reporting_currency=total_market_value,
+            look_through=look_through_info,
             views=views,
         )
 
@@ -218,50 +232,21 @@ class ReportingService:
             portfolio_ids=[portfolio.portfolio_id],
             as_of_date=resolved_as_of_date,
         )
-        cash_rows = [
-            row
-            for row in rows
-            if row.instrument is not None
-            and str(row.instrument.asset_class or "").upper() == CASH_ASSET_CLASS
-        ]
-        cash_account_map = await self.repo.get_latest_cash_account_ids(
-            portfolio_id=portfolio.portfolio_id,
-            cash_security_ids=[row.snapshot.security_id for row in cash_rows],
-            as_of_date=resolved_as_of_date,
+        cash_rows = [row for row in rows if self._is_cash_row(row)]
+        account_records = await self._build_cash_account_balance_records(
+            portfolio=portfolio,
+            cash_rows=cash_rows,
+            resolved_as_of_date=resolved_as_of_date,
+            reporting_currency=reporting_currency,
         )
-
-        account_records: list[CashAccountBalanceRecord] = []
-        total_portfolio_currency = ZERO
-        total_reporting_currency = ZERO
-        for row in cash_rows:
-            account_currency = row.instrument.currency or portfolio.base_currency
-            native_source_value = (
-                row.snapshot.market_value_local or row.snapshot.market_value or ZERO
-            )
-            native_balance = Decimal(str(native_source_value))
-            portfolio_balance = Decimal(str(row.snapshot.market_value or ZERO))
-            reporting_balance = await self._convert_amount(
-                amount=portfolio_balance,
-                from_currency=portfolio.base_currency,
-                to_currency=reporting_currency,
-                as_of_date=resolved_as_of_date,
-            )
-            total_portfolio_currency += portfolio_balance
-            total_reporting_currency += reporting_balance
-            account_records.append(
-                CashAccountBalanceRecord(
-                    cash_account_id=(
-                        cash_account_map.get(row.snapshot.security_id) or row.snapshot.security_id
-                    ),
-                    instrument_id=row.instrument.security_id,
-                    security_id=row.snapshot.security_id,
-                    account_currency=account_currency,
-                    instrument_name=row.instrument.name,
-                    balance_account_currency=native_balance,
-                    balance_portfolio_currency=portfolio_balance,
-                    balance_reporting_currency=reporting_balance,
-                )
-            )
+        total_portfolio_currency = sum(
+            (record.balance_portfolio_currency for record in account_records),
+            ZERO,
+        )
+        total_reporting_currency = sum(
+            (record.balance_reporting_currency for record in account_records),
+            ZERO,
+        )
 
         return CashBalancesResponse(
             portfolio_id=portfolio.portfolio_id,
@@ -274,6 +259,402 @@ class ReportingService:
                 total_balance_reporting_currency=total_reporting_currency,
             ),
             cash_accounts=account_records,
+        )
+
+    async def get_portfolio_summary(
+        self, request: PortfolioSummaryQueryRequest
+    ) -> PortfolioSummaryResponse:
+        portfolio = await self.repo.get_portfolio_by_id(request.portfolio_id)
+        if portfolio is None:
+            raise ValueError(f"Portfolio with id {request.portfolio_id} not found")
+
+        resolved_as_of_date = request.as_of_date or await self.repo.get_latest_business_date()
+        if resolved_as_of_date is None:
+            raise ValueError("No business date is available for portfolio summary queries.")
+        reporting_currency = request.reporting_currency or portfolio.base_currency
+
+        rows = await self.repo.list_latest_snapshot_rows(
+            portfolio_ids=[portfolio.portfolio_id],
+            as_of_date=resolved_as_of_date,
+        )
+        cash_rows = [row for row in rows if self._is_cash_row(row)]
+        cash_account_records = await self._build_cash_account_balance_records(
+            portfolio=portfolio,
+            cash_rows=cash_rows,
+            resolved_as_of_date=resolved_as_of_date,
+            reporting_currency=reporting_currency,
+        )
+
+        total_portfolio = ZERO
+        total_reporting = ZERO
+        cash_portfolio = sum(
+            (record.balance_portfolio_currency for record in cash_account_records),
+            ZERO,
+        )
+        cash_reporting = sum(
+            (record.balance_reporting_currency for record in cash_account_records),
+            ZERO,
+        )
+        valued_position_count = 0
+        unvalued_position_count = 0
+        snapshot_date = resolved_as_of_date
+
+        for row in rows:
+            snapshot_date = max(snapshot_date, row.snapshot.date)
+            portfolio_value = Decimal(str(row.snapshot.market_value or ZERO))
+            reporting_value = await self._convert_amount(
+                amount=portfolio_value,
+                from_currency=portfolio.base_currency,
+                to_currency=reporting_currency,
+                as_of_date=resolved_as_of_date,
+            )
+            total_portfolio += portfolio_value
+            total_reporting += reporting_value
+            if str(row.snapshot.valuation_status or "").upper() == "UNVALUED":
+                unvalued_position_count += 1
+            else:
+                valued_position_count += 1
+
+        return PortfolioSummaryResponse(
+            portfolio_id=portfolio.portfolio_id,
+            booking_center_code=portfolio.booking_center_code,
+            client_id=portfolio.client_id,
+            portfolio_currency=portfolio.base_currency,
+            reporting_currency=reporting_currency,
+            resolved_as_of_date=resolved_as_of_date,
+            portfolio_type=portfolio.portfolio_type,
+            objective=portfolio.objective,
+            risk_exposure=portfolio.risk_exposure,
+            status=portfolio.status,
+            totals=PortfolioSummaryTotals(
+                total_market_value_portfolio_currency=total_portfolio,
+                total_market_value_reporting_currency=total_reporting,
+                cash_balance_portfolio_currency=cash_portfolio,
+                cash_balance_reporting_currency=cash_reporting,
+                invested_market_value_portfolio_currency=total_portfolio - cash_portfolio,
+                invested_market_value_reporting_currency=total_reporting - cash_reporting,
+            ),
+            snapshot_metadata=PortfolioSummarySnapshotMetadata(
+                snapshot_date=snapshot_date,
+                position_count=len(rows),
+                cash_account_count=len(cash_account_records),
+                valued_position_count=valued_position_count,
+                unvalued_position_count=unvalued_position_count,
+            ),
+        )
+
+    async def get_holdings_snapshot(
+        self, request: HoldingsSnapshotQueryRequest
+    ) -> HoldingsSnapshotResponse:
+        portfolio = await self.repo.get_portfolio_by_id(request.portfolio_id)
+        if portfolio is None:
+            raise ValueError(f"Portfolio with id {request.portfolio_id} not found")
+
+        resolved_as_of_date = request.as_of_date or await self.repo.get_latest_business_date()
+        if resolved_as_of_date is None:
+            raise ValueError("No business date is available for holdings snapshot queries.")
+        reporting_currency = request.reporting_currency or portfolio.base_currency
+
+        rows = await self.repo.list_latest_snapshot_rows(
+            portfolio_ids=[portfolio.portfolio_id],
+            as_of_date=resolved_as_of_date,
+        )
+        if not request.include_cash_positions:
+            rows = [
+                row
+                for row in rows
+                if not (
+                    row.instrument is not None
+                    and str(row.instrument.asset_class or "").upper() == CASH_ASSET_CLASS
+                )
+            ]
+
+        snapshot_date = resolved_as_of_date
+        total_portfolio_value = ZERO
+        reporting_values: list[Decimal] = []
+        portfolio_values: list[Decimal] = []
+
+        for row in rows:
+            snapshot_date = max(snapshot_date, row.snapshot.date)
+            portfolio_value = Decimal(str(row.snapshot.market_value or ZERO))
+            reporting_value = await self._convert_amount(
+                amount=portfolio_value,
+                from_currency=portfolio.base_currency,
+                to_currency=reporting_currency,
+                as_of_date=resolved_as_of_date,
+            )
+            portfolio_values.append(portfolio_value)
+            reporting_values.append(reporting_value)
+            total_portfolio_value += portfolio_value
+
+        holdings: list[HoldingSnapshotRecord] = []
+        total_reporting_value = sum(reporting_values, ZERO)
+        for row, portfolio_value, reporting_value in zip(rows, portfolio_values, reporting_values):
+            holdings.append(
+                HoldingSnapshotRecord(
+                    security_id=row.snapshot.security_id,
+                    instrument_name=(
+                        row.instrument.name if row.instrument else row.snapshot.security_id
+                    ),
+                    asset_class=(row.instrument.asset_class if row.instrument else None),
+                    sector=(row.instrument.sector if row.instrument else None),
+                    country=(row.instrument.country_of_risk if row.instrument else None),
+                    region=(
+                        resolve_region(row.instrument.country_of_risk) if row.instrument else None
+                    ),
+                    account_currency=(row.instrument.currency if row.instrument else None),
+                    quantity=Decimal(str(row.snapshot.quantity)),
+                    market_value_portfolio_currency=portfolio_value,
+                    market_value_reporting_currency=reporting_value,
+                    weight=(
+                        portfolio_value / total_portfolio_value if total_portfolio_value else ZERO
+                    ),
+                    valuation_status=row.snapshot.valuation_status,
+                )
+            )
+
+        return HoldingsSnapshotResponse(
+            portfolio_id=portfolio.portfolio_id,
+            portfolio_currency=portfolio.base_currency,
+            reporting_currency=reporting_currency,
+            resolved_as_of_date=resolved_as_of_date,
+            snapshot_date=snapshot_date,
+            total_market_value_portfolio_currency=total_portfolio_value,
+            total_market_value_reporting_currency=total_reporting_value,
+            positions=holdings,
+        )
+
+    async def _build_cash_account_balance_records(
+        self,
+        *,
+        portfolio,
+        cash_rows: list,
+        resolved_as_of_date: date,
+        reporting_currency: str,
+    ) -> list[CashAccountBalanceRecord]:
+        cash_security_ids = [row.snapshot.security_id for row in cash_rows]
+        master_rows = await self.repo.list_cash_account_masters(
+            portfolio_id=portfolio.portfolio_id,
+            as_of_date=resolved_as_of_date,
+        )
+        master_by_security_id = {row.security_id: row for row in master_rows}
+        fallback_cash_account_ids = await self.repo.get_latest_cash_account_ids(
+            portfolio_id=portfolio.portfolio_id,
+            cash_security_ids=cash_security_ids,
+            as_of_date=resolved_as_of_date,
+        )
+        snapshot_by_security_id = {row.snapshot.security_id: row for row in cash_rows}
+
+        account_records: list[CashAccountBalanceRecord] = []
+        emitted_cash_account_ids: set[str] = set()
+
+        for master_row in master_rows:
+            snapshot_row = snapshot_by_security_id.get(master_row.security_id)
+            account_record = await self._build_cash_account_balance_record(
+                portfolio=portfolio,
+                snapshot_row=snapshot_row,
+                resolved_as_of_date=resolved_as_of_date,
+                reporting_currency=reporting_currency,
+                cash_account_id=master_row.cash_account_id,
+                security_id=master_row.security_id,
+                instrument_name=(
+                    snapshot_row.instrument.name
+                    if snapshot_row and snapshot_row.instrument
+                    else master_row.display_name
+                ),
+                account_currency=master_row.account_currency,
+            )
+            account_records.append(account_record)
+            emitted_cash_account_ids.add(master_row.cash_account_id)
+
+        for cash_row in cash_rows:
+            master_row = master_by_security_id.get(cash_row.snapshot.security_id)
+            fallback_cash_account_id = (
+                master_row.cash_account_id
+                if master_row is not None
+                else fallback_cash_account_ids.get(cash_row.snapshot.security_id)
+                or cash_row.snapshot.security_id
+            )
+            if fallback_cash_account_id in emitted_cash_account_ids:
+                continue
+            account_records.append(
+                await self._build_cash_account_balance_record(
+                    portfolio=portfolio,
+                    snapshot_row=cash_row,
+                    resolved_as_of_date=resolved_as_of_date,
+                    reporting_currency=reporting_currency,
+                    cash_account_id=fallback_cash_account_id,
+                    security_id=cash_row.snapshot.security_id,
+                    instrument_name=(
+                        cash_row.instrument.name
+                        if cash_row.instrument is not None
+                        else cash_row.snapshot.security_id
+                    ),
+                    account_currency=(
+                        cash_row.instrument.currency
+                        if cash_row.instrument and cash_row.instrument.currency
+                        else portfolio.base_currency
+                    ),
+                )
+            )
+
+        account_records.sort(key=lambda row: (row.account_currency, row.cash_account_id))
+        return account_records
+
+    async def _build_cash_account_balance_record(
+        self,
+        *,
+        portfolio,
+        snapshot_row,
+        resolved_as_of_date: date,
+        reporting_currency: str,
+        cash_account_id: str,
+        security_id: str,
+        instrument_name: str,
+        account_currency: str,
+    ) -> CashAccountBalanceRecord:
+        if snapshot_row is None:
+            native_balance = ZERO
+            portfolio_balance = ZERO
+        else:
+            native_source_value = (
+                snapshot_row.snapshot.market_value_local
+                or snapshot_row.snapshot.market_value
+                or ZERO
+            )
+            native_balance = Decimal(str(native_source_value))
+            portfolio_balance = Decimal(str(snapshot_row.snapshot.market_value or ZERO))
+        reporting_balance = await self._convert_amount(
+            amount=portfolio_balance,
+            from_currency=portfolio.base_currency,
+            to_currency=reporting_currency,
+            as_of_date=resolved_as_of_date,
+        )
+        return CashAccountBalanceRecord(
+            cash_account_id=cash_account_id,
+            instrument_id=security_id,
+            security_id=security_id,
+            account_currency=account_currency,
+            instrument_name=instrument_name,
+            balance_account_currency=native_balance,
+            balance_portfolio_currency=portfolio_balance,
+            balance_reporting_currency=reporting_balance,
+        )
+
+    async def _resolve_allocation_rows(
+        self,
+        *,
+        rows: list,
+        requested_mode: str,
+        as_of_date: date,
+        reporting_currency: str,
+    ) -> tuple[list[tuple[object | None, object, Decimal]], AllocationLookThroughInfo]:
+        direct_rows: list[tuple[object | None, object, Decimal]] = []
+        for row in rows:
+            native_value = Decimal(str(row.snapshot.market_value or ZERO))
+            reporting_value = await self._convert_amount(
+                amount=native_value,
+                from_currency=row.portfolio.base_currency,
+                to_currency=reporting_currency,
+                as_of_date=as_of_date,
+            )
+            direct_rows.append((row.instrument, row.snapshot, reporting_value))
+
+        component_rows = await self.repo.list_instrument_lookthrough_components(
+            parent_security_ids=[row.snapshot.security_id for row in rows],
+            as_of_date=as_of_date,
+        )
+        components_by_parent: dict[str, list[InstrumentLookthroughComponentRow]] = defaultdict(list)
+        for component_row in component_rows:
+            components_by_parent[component_row.parent_security_id].append(component_row)
+        decomposable_parent_ids = {
+            parent_security_id
+            for parent_security_id, components in components_by_parent.items()
+            if self._can_decompose_position(components)
+        }
+
+        if requested_mode == "direct_only":
+            return direct_rows, AllocationLookThroughInfo(
+                requested_mode=requested_mode,
+                applied_mode="direct_only",
+                supported=bool(decomposable_parent_ids),
+                decomposed_position_count=0,
+                limitation_reason=None,
+            )
+
+        allocation_rows: list[tuple[object | None, object, Decimal]] = []
+        decomposed_position_count = 0
+        undecomposed_requested_count = 0
+
+        for row in rows:
+            native_value = Decimal(str(row.snapshot.market_value or ZERO))
+            reporting_value = await self._convert_amount(
+                amount=native_value,
+                from_currency=row.portfolio.base_currency,
+                to_currency=reporting_currency,
+                as_of_date=as_of_date,
+            )
+            components = components_by_parent.get(row.snapshot.security_id, [])
+            if row.snapshot.security_id not in decomposable_parent_ids:
+                allocation_rows.append((row.instrument, row.snapshot, reporting_value))
+                if not self._is_cash_row(row):
+                    undecomposed_requested_count += 1
+                continue
+
+            decomposed_position_count += 1
+            for component in components:
+                allocation_rows.append(
+                    (
+                        component.component_instrument,
+                        SimpleNamespace(security_id=component.component_security_id),
+                        reporting_value * Decimal(str(component.component_weight)),
+                    )
+                )
+
+        if decomposed_position_count == 0:
+            limitation_reason = (
+                "Look-through components were requested but no fully weighted source-owned "
+                "decomposition set was available for the resolved holdings."
+            )
+            return direct_rows, AllocationLookThroughInfo(
+                requested_mode=requested_mode,
+                applied_mode="direct_only",
+                supported=False,
+                decomposed_position_count=0,
+                limitation_reason=limitation_reason,
+            )
+
+        limitation_reason = None
+        if undecomposed_requested_count:
+            limitation_reason = (
+                "Look-through was applied where complete component weights were available; "
+                "remaining positions stayed at direct-holding level."
+            )
+        return allocation_rows, AllocationLookThroughInfo(
+            requested_mode=requested_mode,
+            applied_mode="prefer_look_through",
+            supported=True,
+            decomposed_position_count=decomposed_position_count,
+            limitation_reason=limitation_reason,
+        )
+
+    @staticmethod
+    def _can_decompose_position(
+        components: list[InstrumentLookthroughComponentRow],
+    ) -> bool:
+        if not components:
+            return False
+        total_weight = sum(
+            (Decimal(str(component.component_weight)) for component in components),
+            ZERO,
+        )
+        return abs(total_weight - Decimal("1")) <= Decimal("0.000001")
+
+    @staticmethod
+    def _is_cash_row(row) -> bool:
+        return (
+            row.instrument is not None
+            and str(row.instrument.asset_class or "").upper() == CASH_ASSET_CLASS
         )
 
     async def get_income_summary(self, request: IncomeSummaryQueryRequest) -> IncomeSummaryResponse:

--- a/tests/integration/services/ingestion_service/test_ingestion_routers.py
+++ b/tests/integration/services/ingestion_service/test_ingestion_routers.py
@@ -569,8 +569,7 @@ async def ingestion_test_harness(mock_kafka_producer: MagicMock):
             row = self.replay_audit.get(replay_fingerprint)
             if (
                 row
-                and row.get("replay_status")
-                in {"replayed", "replayed_bookkeeping_failed"}
+                and row.get("replay_status") in {"replayed", "replayed_bookkeeping_failed"}
                 and (recovery_path is None or row.get("recovery_path") == recovery_path)
             ):
                 return {
@@ -708,9 +707,7 @@ async def ingestion_test_harness(mock_kafka_producer: MagicMock):
                 normalized.append(row)
             self.persisted["benchmark_assignments"].extend(normalized)
 
-        async def upsert_benchmark_definitions(
-            self, records: list[dict[str, object]]
-        ) -> None:
+        async def upsert_benchmark_definitions(self, records: list[dict[str, object]]) -> None:
             self.persisted["benchmark_definitions"].extend(records)
 
         async def upsert_benchmark_compositions(self, records: list[dict[str, object]]) -> None:
@@ -734,6 +731,14 @@ async def ingestion_test_harness(mock_kafka_producer: MagicMock):
         async def upsert_classification_taxonomy(self, records: list[dict[str, object]]) -> None:
             return None
 
+        async def upsert_cash_account_masters(self, records: list[dict[str, object]]) -> None:
+            return None
+
+        async def upsert_instrument_lookthrough_components(
+            self, records: list[dict[str, object]]
+        ) -> None:
+            return None
+
     fake_job_service = FakeIngestionJobService()
     fake_reference_data_service = FakeReferenceDataIngestionService()
     target_apps = (app, event_replay_app)
@@ -742,31 +747,31 @@ async def ingestion_test_harness(mock_kafka_producer: MagicMock):
         target_app.dependency_overrides[get_ingestion_job_service] = lambda: fake_job_service
         target_app.dependency_overrides[get_kafka_producer] = override_get_kafka_producer
 
-    app.dependency_overrides[transactions_router.get_ingestion_job_service] = (
-        lambda: fake_job_service
+    app.dependency_overrides[transactions_router.get_ingestion_job_service] = lambda: (
+        fake_job_service
     )
     app.dependency_overrides[portfolios_router.get_ingestion_job_service] = lambda: fake_job_service
-    app.dependency_overrides[instruments_router.get_ingestion_job_service] = (
-        lambda: fake_job_service
+    app.dependency_overrides[instruments_router.get_ingestion_job_service] = lambda: (
+        fake_job_service
     )
-    app.dependency_overrides[market_prices_router.get_ingestion_job_service] = (
-        lambda: fake_job_service
+    app.dependency_overrides[market_prices_router.get_ingestion_job_service] = lambda: (
+        fake_job_service
     )
     app.dependency_overrides[fx_rates_router.get_ingestion_job_service] = lambda: fake_job_service
-    app.dependency_overrides[business_dates_router.get_ingestion_job_service] = (
-        lambda: fake_job_service
+    app.dependency_overrides[business_dates_router.get_ingestion_job_service] = lambda: (
+        fake_job_service
     )
     app.dependency_overrides[portfolio_bundle_router.get_ingestion_job_service] = lambda: (
         fake_job_service
     )
-    app.dependency_overrides[reprocessing_router.get_ingestion_job_service] = (
-        lambda: fake_job_service
+    app.dependency_overrides[reprocessing_router.get_ingestion_job_service] = lambda: (
+        fake_job_service
     )
-    app.dependency_overrides[reference_data_router.get_ingestion_job_service] = (
-        lambda: fake_job_service
+    app.dependency_overrides[reference_data_router.get_ingestion_job_service] = lambda: (
+        fake_job_service
     )
-    app.dependency_overrides[reference_data_router.get_reference_data_ingestion_service] = (
-        lambda: fake_reference_data_service
+    app.dependency_overrides[reference_data_router.get_reference_data_ingestion_service] = lambda: (
+        fake_reference_data_service
     )
     event_replay_app.dependency_overrides[ingestion_operations_router.get_ingestion_job_service] = (
         lambda: fake_job_service
@@ -1181,9 +1186,7 @@ async def test_ingestion_job_retry_reports_bookkeeping_failure_after_replay_publ
         params={"job_id": failed_job_id},
     )
     audits = audit_response.json()["audits"]
-    assert any(
-        row["replay_status"] == "replayed_bookkeeping_failed" for row in audits
-    )
+    assert any(row["replay_status"] == "replayed_bookkeeping_failed" for row in audits)
 
     ingestion_test_harness["fake_job_service"].fail_mark_queued_job_ids.discard(failed_job_id)
     duplicate_response = await event_replay_test_client.post(
@@ -1671,9 +1674,7 @@ async def test_replay_consumer_dlq_event_reports_bookkeeping_failure_after_publi
         params={"job_id": job_id},
     )
     audits = audit_response.json()["audits"]
-    assert any(
-        row["replay_status"] == "replayed_bookkeeping_failed" for row in audits
-    )
+    assert any(row["replay_status"] == "replayed_bookkeeping_failed" for row in audits)
 
     ingestion_test_harness["fake_job_service"].fail_mark_queued_job_ids.discard(job_id)
     second = await event_replay_test_client.post(
@@ -1821,6 +1822,53 @@ async def test_ingest_fx_rates_endpoint(
 
     assert response.status_code == 202
     mock_kafka_producer.publish_message.assert_called_once()
+
+
+async def test_ingest_cash_account_masters_endpoint(
+    async_test_client: httpx.AsyncClient, mock_kafka_producer: MagicMock
+):
+    mock_kafka_producer.publish_message.reset_mock()
+    payload = {
+        "cash_accounts": [
+            {
+                "cash_account_id": "CASH-ACC-USD-001",
+                "portfolio_id": "P1",
+                "security_id": "CASH_USD",
+                "display_name": "USD Operating Cash",
+                "account_currency": "USD",
+                "lifecycle_status": "ACTIVE",
+            }
+        ]
+    }
+
+    response = await async_test_client.post("/ingest/reference/cash-accounts", json=payload)
+
+    assert response.status_code == 202
+    mock_kafka_producer.publish_message.assert_not_called()
+
+
+async def test_ingest_instrument_lookthrough_components_endpoint(
+    async_test_client: httpx.AsyncClient, mock_kafka_producer: MagicMock
+):
+    mock_kafka_producer.publish_message.reset_mock()
+    payload = {
+        "lookthrough_components": [
+            {
+                "parent_security_id": "FUND_001",
+                "component_security_id": "ETF_001",
+                "effective_from": "2026-01-01",
+                "component_weight": "0.6000000000",
+            }
+        ]
+    }
+
+    response = await async_test_client.post(
+        "/ingest/reference/instrument-lookthrough-components",
+        json=payload,
+    )
+
+    assert response.status_code == 202
+    mock_kafka_producer.publish_message.assert_not_called()
 
 
 async def test_ingest_portfolio_bundle_endpoint(

--- a/tests/integration/services/ingestion_service/test_ingestion_routers.py
+++ b/tests/integration/services/ingestion_service/test_ingestion_routers.py
@@ -2395,3 +2395,339 @@ async def test_transaction_ingestion_allows_future_dated_trade(
         },
     )
     assert response.status_code == 202
+
+
+@pytest.mark.parametrize(
+    ("path", "payload", "entity_type"),
+    [
+        (
+            "/ingest/benchmark-assignments",
+            {
+                "benchmark_assignments": [
+                    {
+                        "portfolio_id": "P1",
+                        "benchmark_id": "BMK_001",
+                        "effective_from": "2026-01-01",
+                        "assignment_version": 1,
+                        "assignment_source": "benchmark_policy_engine",
+                        "assignment_status": "active",
+                    }
+                ]
+            },
+            "benchmark_assignment",
+        ),
+        (
+            "/ingest/benchmark-definitions",
+            {
+                "benchmark_definitions": [
+                    {
+                        "benchmark_id": "BMK_001",
+                        "effective_from": "2026-01-01",
+                        "benchmark_name": "Balanced Mandate Benchmark",
+                        "benchmark_type": "composite",
+                        "benchmark_currency": "USD",
+                        "return_convention": "total_return_index",
+                        "benchmark_status": "active",
+                    }
+                ]
+            },
+            "benchmark_definition",
+        ),
+        (
+            "/ingest/benchmark-compositions",
+            {
+                "benchmark_compositions": [
+                    {
+                        "benchmark_id": "BMK_001",
+                        "index_id": "IDX_001",
+                        "composition_effective_from": "2026-01-01",
+                        "composition_weight": "1.0",
+                    }
+                ]
+            },
+            "benchmark_composition",
+        ),
+        (
+            "/ingest/indices",
+            {
+                "indices": [
+                    {
+                        "index_id": "IDX_001",
+                        "effective_from": "2026-01-01",
+                        "index_name": "MSCI World",
+                        "index_currency": "USD",
+                        "index_type": "equity",
+                        "index_status": "active",
+                    }
+                ]
+            },
+            "index_definition",
+        ),
+        (
+            "/ingest/index-price-series",
+            {
+                "index_price_series": [
+                    {
+                        "series_id": "IDXP_001",
+                        "index_id": "IDX_001",
+                        "series_date": "2026-01-01",
+                        "index_price": "1234.56",
+                        "series_currency": "USD",
+                        "value_convention": "close",
+                    }
+                ]
+            },
+            "index_price_series",
+        ),
+        (
+            "/ingest/index-return-series",
+            {
+                "index_return_series": [
+                    {
+                        "series_id": "IDXR_001",
+                        "index_id": "IDX_001",
+                        "series_date": "2026-01-01",
+                        "index_return": "0.0123",
+                        "return_period": "daily",
+                        "return_convention": "gross",
+                        "series_currency": "USD",
+                    }
+                ]
+            },
+            "index_return_series",
+        ),
+        (
+            "/ingest/benchmark-return-series",
+            {
+                "benchmark_return_series": [
+                    {
+                        "series_id": "BMKR_001",
+                        "benchmark_id": "BMK_001",
+                        "series_date": "2026-01-01",
+                        "benchmark_return": "0.0100",
+                        "return_period": "daily",
+                        "return_convention": "gross",
+                        "series_currency": "USD",
+                    }
+                ]
+            },
+            "benchmark_return_series",
+        ),
+        (
+            "/ingest/risk-free-series",
+            {
+                "risk_free_series": [
+                    {
+                        "series_id": "RF_001",
+                        "risk_free_curve_id": "USD_OIS",
+                        "series_date": "2026-01-01",
+                        "value": "0.035",
+                        "value_convention": "annualized_rate",
+                        "day_count_convention": "ACT_360",
+                        "compounding_convention": "simple",
+                        "series_currency": "USD",
+                    }
+                ]
+            },
+            "risk_free_series",
+        ),
+        (
+            "/ingest/reference/classification-taxonomy",
+            {
+                "classification_taxonomy": [
+                    {
+                        "classification_set_id": "TAX_001",
+                        "taxonomy_scope": "portfolio_workspace",
+                        "dimension_name": "asset_class",
+                        "dimension_value": "EQUITY",
+                        "effective_from": "2026-01-01",
+                    }
+                ]
+            },
+            "classification_taxonomy",
+        ),
+        (
+            "/ingest/reference/cash-accounts",
+            {
+                "cash_accounts": [
+                    {
+                        "cash_account_id": "CASH-ACC-USD-001",
+                        "portfolio_id": "P1",
+                        "security_id": "CASH_USD",
+                        "display_name": "USD Operating Cash",
+                        "account_currency": "USD",
+                        "lifecycle_status": "ACTIVE",
+                    }
+                ]
+            },
+            "cash_account_master",
+        ),
+        (
+            "/ingest/reference/instrument-lookthrough-components",
+            {
+                "lookthrough_components": [
+                    {
+                        "parent_security_id": "FUND_001",
+                        "component_security_id": "ETF_001",
+                        "effective_from": "2026-01-01",
+                        "component_weight": "0.6000000000",
+                    }
+                ]
+            },
+            "instrument_lookthrough_component",
+        ),
+    ],
+)
+async def test_reference_data_ingestion_endpoints_return_canonical_ack_contract(
+    async_test_client: httpx.AsyncClient,
+    path: str,
+    payload: dict,
+    entity_type: str,
+):
+    response = await async_test_client.post(
+        path,
+        json=payload,
+        headers={"X-Idempotency-Key": f"{entity_type}-idempotency"},
+    )
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["entity_type"] == entity_type
+    assert body["accepted_count"] == 1
+    assert body["idempotency_key"] == f"{entity_type}-idempotency"
+    assert body["job_id"]
+
+
+async def test_reference_data_ingestion_replays_duplicate_idempotency_key(
+    async_test_client: httpx.AsyncClient,
+):
+    payload = {
+        "cash_accounts": [
+            {
+                "cash_account_id": "CASH-ACC-USD-001",
+                "portfolio_id": "P1",
+                "security_id": "CASH_USD",
+                "display_name": "USD Operating Cash",
+                "account_currency": "USD",
+                "lifecycle_status": "ACTIVE",
+            }
+        ]
+    }
+
+    first = await async_test_client.post(
+        "/ingest/reference/cash-accounts",
+        json=payload,
+        headers={"X-Idempotency-Key": "cash-account-replay"},
+    )
+    second = await async_test_client.post(
+        "/ingest/reference/cash-accounts",
+        json=payload,
+        headers={"X-Idempotency-Key": "cash-account-replay"},
+    )
+
+    assert first.status_code == 202
+    assert second.status_code == 202
+    second_body = second.json()
+    assert second_body["message"] == "Duplicate ingestion request accepted via idempotency replay."
+    assert second_body["job_id"] == first.json()["job_id"]
+
+
+async def test_reference_data_ingestion_returns_503_when_mode_blocks_writes(
+    async_test_client: httpx.AsyncClient,
+    ingestion_test_harness,
+):
+    job_service = ingestion_test_harness["fake_job_service"]
+    job_service.mode = "paused"
+
+    response = await async_test_client.post(
+        "/ingest/reference/cash-accounts",
+        json={
+            "cash_accounts": [
+                {
+                    "cash_account_id": "CASH-ACC-USD-001",
+                    "portfolio_id": "P1",
+                    "security_id": "CASH_USD",
+                    "display_name": "USD Operating Cash",
+                    "account_currency": "USD",
+                    "lifecycle_status": "ACTIVE",
+                }
+            ]
+        },
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["code"] == "INGESTION_MODE_BLOCKS_WRITES"
+
+
+async def test_reference_data_ingestion_returns_429_when_rate_limited(
+    async_test_client: httpx.AsyncClient,
+    monkeypatch,
+):
+    def _raise_rate_limit(*, endpoint: str, record_count: int) -> None:
+        raise PermissionError(f"{endpoint} blocked after {record_count} records")
+
+    monkeypatch.setattr(
+        reference_data_router,
+        "enforce_ingestion_write_rate_limit",
+        _raise_rate_limit,
+    )
+
+    response = await async_test_client.post(
+        "/ingest/reference/cash-accounts",
+        json={
+            "cash_accounts": [
+                {
+                    "cash_account_id": "CASH-ACC-USD-001",
+                    "portfolio_id": "P1",
+                    "security_id": "CASH_USD",
+                    "display_name": "USD Operating Cash",
+                    "account_currency": "USD",
+                    "lifecycle_status": "ACTIVE",
+                }
+            ]
+        },
+    )
+
+    assert response.status_code == 429
+    assert response.json()["detail"]["code"] == "INGESTION_RATE_LIMIT_EXCEEDED"
+
+
+async def test_reference_data_ingestion_marks_job_failed_when_persist_fn_raises(
+    async_test_client: httpx.AsyncClient,
+    ingestion_test_harness,
+    monkeypatch,
+):
+    async def _raise_persist_failure(records: list[dict[str, object]]) -> None:
+        raise RuntimeError("cash account master persist failed")
+
+    fake_reference_data_service = ingestion_test_harness["fake_reference_data_service"]
+    monkeypatch.setattr(
+        fake_reference_data_service,
+        "upsert_cash_account_masters",
+        _raise_persist_failure,
+    )
+
+    with pytest.raises(RuntimeError, match="cash account master persist failed"):
+        await async_test_client.post(
+            "/ingest/reference/cash-accounts",
+            json={
+                "cash_accounts": [
+                    {
+                        "cash_account_id": "CASH-ACC-USD-001",
+                        "portfolio_id": "P1",
+                        "security_id": "CASH_USD",
+                        "display_name": "USD Operating Cash",
+                        "account_currency": "USD",
+                        "lifecycle_status": "ACTIVE",
+                    }
+                ]
+            },
+        )
+
+    failed_jobs = [
+        job
+        for job in ingestion_test_harness["fake_job_service"].jobs.values()
+        if job.status == "failed"
+    ]
+    assert len(failed_jobs) == 1
+    assert failed_jobs[0].failure_reason == "cash account master persist failed"

--- a/tests/integration/services/query_service/test_cash_accounts_router.py
+++ b/tests/integration/services/query_service/test_cash_accounts_router.py
@@ -1,0 +1,61 @@
+from datetime import date
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from src.services.query_service.app.main import app
+from src.services.query_service.app.routers.cash_accounts import (
+    CashAccountService,
+    get_cash_account_service,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture
+async def async_test_client():
+    mock_service = AsyncMock(spec=CashAccountService)
+    app.dependency_overrides[get_cash_account_service] = lambda: mock_service
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client, mock_service
+    app.dependency_overrides.pop(get_cash_account_service, None)
+
+
+async def test_get_cash_accounts(async_test_client):
+    client, mock_service = async_test_client
+    mock_service.get_cash_accounts.return_value = {
+        "portfolio_id": "P1",
+        "resolved_as_of_date": date(2026, 3, 27),
+        "cash_accounts": [
+            {
+                "cash_account_id": "CASH-ACC-USD-001",
+                "portfolio_id": "P1",
+                "security_id": "CASH_USD",
+                "display_name": "USD Operating Cash",
+                "account_currency": "USD",
+                "account_role": "OPERATING_CASH",
+                "lifecycle_status": "ACTIVE",
+                "opened_on": date(2026, 1, 1),
+                "closed_on": None,
+                "source_system": "lotus-manage",
+            }
+        ],
+    }
+
+    response = await client.get("/portfolios/P1/cash-accounts", params={"as_of_date": "2026-03-27"})
+
+    assert response.status_code == 200
+    assert response.json()["cash_accounts"][0]["cash_account_id"] == "CASH-ACC-USD-001"
+
+
+async def test_get_cash_accounts_maps_missing_portfolio_to_404(async_test_client):
+    client, mock_service = async_test_client
+    mock_service.get_cash_accounts.side_effect = ValueError("Portfolio with id P404 not found")
+
+    response = await client.get("/portfolios/P404/cash-accounts")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Portfolio with id P404 not found"

--- a/tests/integration/services/query_service/test_main_app.py
+++ b/tests/integration/services/query_service/test_main_app.py
@@ -151,6 +151,7 @@ async def test_openapi_declares_portfolio_not_found_contracts(async_test_client)
     assert "404" in paths["/portfolios/{portfolio_id}"]["get"]["responses"]
     assert "404" in paths["/portfolios/{portfolio_id}/positions"]["get"]["responses"]
     assert "404" in paths["/portfolios/{portfolio_id}/transactions"]["get"]["responses"]
+    assert "404" in paths["/portfolios/{portfolio_id}/cash-accounts"]["get"]["responses"]
     assert "404" in paths["/portfolios/{portfolio_id}/cashflow-projection"]["get"]["responses"]
     assert "404" in paths["/portfolios/{portfolio_id}/position-history"]["get"]["responses"]
 
@@ -163,8 +164,11 @@ async def test_openapi_includes_reporting_contracts(async_test_client):
     assert "/reporting/assets-under-management/query" in paths
     assert "/reporting/asset-allocation/query" in paths
     assert "/reporting/cash-balances/query" in paths
+    assert "/reporting/portfolio-summary/query" in paths
+    assert "/reporting/holdings-snapshot/query" in paths
     assert "/reporting/income-summary/query" in paths
     assert "/reporting/activity-summary/query" in paths
+    assert "/portfolios/{portfolio_id}/cash-accounts" in paths
 
 
 async def test_openapi_describes_reporting_and_enhanced_discovery_contracts(async_test_client):
@@ -177,9 +181,12 @@ async def test_openapi_describes_reporting_and_enhanced_discovery_contracts(asyn
     aum_query = paths["/reporting/assets-under-management/query"]["post"]
     allocation_query = paths["/reporting/asset-allocation/query"]["post"]
     cash_query = paths["/reporting/cash-balances/query"]["post"]
+    portfolio_summary_query = paths["/reporting/portfolio-summary/query"]["post"]
+    holdings_snapshot_query = paths["/reporting/holdings-snapshot/query"]["post"]
     income_query = paths["/reporting/income-summary/query"]["post"]
     activity_query = paths["/reporting/activity-summary/query"]["post"]
     portfolios_query = paths["/portfolios/"]["get"]
+    cash_accounts_query = paths["/portfolios/{portfolio_id}/cash-accounts"]["get"]
 
     assert (
         "single portfolio, an explicit portfolio list, or a business unit"
@@ -187,8 +194,11 @@ async def test_openapi_describes_reporting_and_enhanced_discovery_contracts(asyn
     )
     assert "classification dimensions" in allocation_query["description"]
     assert "portfolio currency and reporting currency" in cash_query["description"]
+    assert "true historical as-of portfolio summary" in portfolio_summary_query["description"]
+    assert "true historical as-of holdings snapshot" in holdings_snapshot_query["description"]
     assert "requested reporting window and year-to-date" in income_query["description"]
     assert "portfolio-level flow buckets" in activity_query["description"]
+    assert "canonical cash-account master records" in cash_accounts_query["description"]
 
     portfolio_ids = next(
         parameter
@@ -198,18 +208,35 @@ async def test_openapi_describes_reporting_and_enhanced_discovery_contracts(asyn
     assert portfolio_ids["description"] == "Filter by an explicit portfolio identifier list."
 
     aum_request = components["AssetsUnderManagementQueryRequest"]
+    allocation_response = components["AssetAllocationResponse"]
     cash_response = components["CashBalancesResponse"]
+    portfolio_summary_response = components["PortfolioSummaryResponse"]
+    holdings_snapshot_response = components["HoldingsSnapshotResponse"]
     income_response = components["IncomeSummaryResponse"]
     activity_response = components["ActivitySummaryResponse"]
+    cash_account_query_response = components["CashAccountQueryResponse"]
     transaction_record = components["TransactionRecord"]
 
     assert aum_request["properties"]["reporting_currency"]["description"].startswith(
         "Optional reporting currency."
     )
+    assert allocation_response["properties"]["look_through"]["description"].startswith(
+        "Applied look-through mode"
+    )
     assert cash_response["properties"]["totals"]["description"] == "Portfolio-level cash totals."
+    assert (
+        portfolio_summary_response["properties"]["snapshot_metadata"]["description"]
+        == "Resolved snapshot metadata for the summary query."
+    )
+    assert holdings_snapshot_response["properties"]["positions"]["description"].startswith(
+        "Holdings snapshot rows"
+    )
     assert income_response["properties"]["totals"]["description"] == "Scope-level income totals."
     assert (
         activity_response["properties"]["totals"]["description"] == "Scope-level activity totals."
+    )
+    assert cash_account_query_response["properties"]["cash_accounts"]["description"] == (
+        "Canonical cash accounts linked to the portfolio."
     )
     assert transaction_record["properties"]["trade_fee"]["description"] == (
         "Primary trade fee recorded directly on the transaction."

--- a/tests/integration/services/query_service/test_reporting_router.py
+++ b/tests/integration/services/query_service/test_reporting_router.py
@@ -57,6 +57,13 @@ async def test_query_asset_allocation(async_test_client):
         "resolved_as_of_date": date(2026, 3, 27),
         "reporting_currency": "USD",
         "total_market_value_reporting_currency": Decimal("150"),
+        "look_through": {
+            "requested_mode": "direct_only",
+            "applied_mode": "direct_only",
+            "supported": False,
+            "decomposed_position_count": 0,
+            "limitation_reason": None,
+        },
         "views": [],
     }
 
@@ -88,6 +95,76 @@ async def test_query_cash_balances(async_test_client):
 
     assert response.status_code == 200
     assert response.json()["totals"]["cash_account_count"] == 1
+
+
+async def test_query_portfolio_summary(async_test_client):
+    client, mock_service = async_test_client
+    mock_service.get_portfolio_summary.return_value = {
+        "portfolio_id": "P1",
+        "booking_center_code": "SGPB",
+        "client_id": "CIF-1",
+        "portfolio_currency": "USD",
+        "reporting_currency": "USD",
+        "resolved_as_of_date": date(2026, 3, 27),
+        "portfolio_type": "DISCRETIONARY",
+        "objective": "Growth",
+        "risk_exposure": "BALANCED",
+        "status": "ACTIVE",
+        "totals": {
+            "total_market_value_portfolio_currency": Decimal("1000"),
+            "total_market_value_reporting_currency": Decimal("1000"),
+            "cash_balance_portfolio_currency": Decimal("200"),
+            "cash_balance_reporting_currency": Decimal("200"),
+            "invested_market_value_portfolio_currency": Decimal("800"),
+            "invested_market_value_reporting_currency": Decimal("800"),
+        },
+        "snapshot_metadata": {
+            "snapshot_date": date(2026, 3, 27),
+            "position_count": 2,
+            "cash_account_count": 1,
+            "valued_position_count": 1,
+            "unvalued_position_count": 1,
+        },
+    }
+
+    response = await client.post("/reporting/portfolio-summary/query", json={"portfolio_id": "P1"})
+
+    assert response.status_code == 200
+    assert response.json()["totals"]["cash_balance_portfolio_currency"] == "200"
+
+
+async def test_query_holdings_snapshot(async_test_client):
+    client, mock_service = async_test_client
+    mock_service.get_holdings_snapshot.return_value = {
+        "portfolio_id": "P1",
+        "portfolio_currency": "USD",
+        "reporting_currency": "USD",
+        "resolved_as_of_date": date(2026, 3, 27),
+        "snapshot_date": date(2026, 3, 27),
+        "total_market_value_portfolio_currency": Decimal("1000"),
+        "total_market_value_reporting_currency": Decimal("1000"),
+        "positions": [
+            {
+                "security_id": "SEC1",
+                "instrument_name": "Apple Inc.",
+                "asset_class": "EQUITY",
+                "sector": "TECH",
+                "country": "US",
+                "region": "North America",
+                "account_currency": "USD",
+                "quantity": Decimal("10"),
+                "market_value_portfolio_currency": Decimal("1000"),
+                "market_value_reporting_currency": Decimal("1000"),
+                "weight": Decimal("1"),
+                "valuation_status": "VALUED",
+            }
+        ],
+    }
+
+    response = await client.post("/reporting/holdings-snapshot/query", json={"portfolio_id": "P1"})
+
+    assert response.status_code == 200
+    assert response.json()["positions"][0]["region"] == "North America"
 
 
 async def test_reporting_router_maps_value_errors_to_400(async_test_client):

--- a/tests/integration/services/query_service/test_reporting_router.py
+++ b/tests/integration/services/query_service/test_reporting_router.py
@@ -180,6 +180,14 @@ async def test_reporting_router_maps_value_errors_to_400(async_test_client):
     assert "bad scope" in response.json()["detail"]
 
 
+async def test_get_reporting_service_wraps_db_session():
+    db = object()
+    service = get_reporting_service(db)  # type: ignore[arg-type]
+
+    assert isinstance(service, ReportingService)
+    assert service.repo.db is db
+
+
 async def test_query_income_summary(async_test_client):
     client, mock_service = async_test_client
     mock_service.get_income_summary.return_value = {
@@ -265,3 +273,66 @@ async def test_query_activity_summary(async_test_client):
 
     assert response.status_code == 200
     assert response.json()["totals"]["buckets"][0]["bucket"] == "INFLOWS"
+
+
+@pytest.mark.parametrize(
+    ("path", "payload", "method_name", "error_detail"),
+    [
+        (
+            "/reporting/asset-allocation/query",
+            {"scope": {"portfolio_id": "P1"}, "dimensions": ["asset_class"]},
+            "get_asset_allocation",
+            "bad allocation scope",
+        ),
+        (
+            "/reporting/cash-balances/query",
+            {"portfolio_id": "P1"},
+            "get_cash_balances",
+            "bad cash scope",
+        ),
+        (
+            "/reporting/portfolio-summary/query",
+            {"portfolio_id": "P1"},
+            "get_portfolio_summary",
+            "bad snapshot request",
+        ),
+        (
+            "/reporting/holdings-snapshot/query",
+            {"portfolio_id": "P1"},
+            "get_holdings_snapshot",
+            "bad holdings request",
+        ),
+        (
+            "/reporting/income-summary/query",
+            {
+                "scope": {"portfolio_id": "P1"},
+                "window": {"start_date": "2026-03-01", "end_date": "2026-03-27"},
+            },
+            "get_income_summary",
+            "bad income scope",
+        ),
+        (
+            "/reporting/activity-summary/query",
+            {
+                "scope": {"portfolio_id": "P1"},
+                "window": {"start_date": "2026-03-01", "end_date": "2026-03-27"},
+            },
+            "get_activity_summary",
+            "bad activity scope",
+        ),
+    ],
+)
+async def test_reporting_router_maps_all_query_value_errors_to_400(
+    async_test_client,
+    path: str,
+    payload: dict,
+    method_name: str,
+    error_detail: str,
+):
+    client, mock_service = async_test_client
+    getattr(mock_service, method_name).side_effect = ValueError(error_detail)
+
+    response = await client.post(path, json=payload)
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == error_detail

--- a/tests/unit/services/ingestion_service/test_reference_data_ingestion_service.py
+++ b/tests/unit/services/ingestion_service/test_reference_data_ingestion_service.py
@@ -34,3 +34,49 @@ async def test_upsert_portfolio_benchmark_assignments_defaults_assignment_record
     compiled_params = db.execute.await_args.args[0].compile().params
     assert isinstance(compiled_params["assignment_recorded_at_m0"], datetime)
     db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_upsert_cash_account_masters_uses_cash_account_id_conflict_key() -> None:
+    db = AsyncMock(spec=AsyncSession)
+    service = ReferenceDataIngestionService(db)
+
+    await service.upsert_cash_account_masters(
+        [
+            {
+                "cash_account_id": "CASH-ACC-USD-001",
+                "portfolio_id": "PORT_001",
+                "security_id": "CASH_USD",
+                "display_name": "USD Operating Cash",
+                "account_currency": "USD",
+                "lifecycle_status": "ACTIVE",
+            }
+        ]
+    )
+
+    compiled = str(db.execute.await_args.args[0].compile())
+    assert "cash_account_masters" in compiled
+    assert "ON CONFLICT (cash_account_id)" in compiled
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_upsert_lookthrough_components_uses_effective_key_conflict() -> None:
+    db = AsyncMock(spec=AsyncSession)
+    service = ReferenceDataIngestionService(db)
+
+    await service.upsert_instrument_lookthrough_components(
+        [
+            {
+                "parent_security_id": "FUND_001",
+                "component_security_id": "ETF_001",
+                "effective_from": "2026-01-01",
+                "component_weight": "0.6000000000",
+            }
+        ]
+    )
+
+    compiled = str(db.execute.await_args.args[0].compile())
+    assert "instrument_lookthrough_components" in compiled
+    assert "ON CONFLICT (parent_security_id, component_security_id, effective_from)" in compiled
+    db.commit.assert_awaited_once()

--- a/tests/unit/services/ingestion_service/test_reference_data_ingestion_service.py
+++ b/tests/unit/services/ingestion_service/test_reference_data_ingestion_service.py
@@ -8,7 +8,212 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.services.ingestion_service.app.services.reference_data_ingestion_service import (
     ReferenceDataIngestionService,
+    get_reference_data_ingestion_service,
 )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "records", "conflict_columns", "update_columns"),
+    [
+        (
+            "upsert_benchmark_definitions",
+            [{"benchmark_id": "BMK_001", "effective_from": "2026-01-01"}],
+            ["benchmark_id", "effective_from"],
+            [
+                "benchmark_name",
+                "benchmark_type",
+                "benchmark_currency",
+                "return_convention",
+                "benchmark_status",
+                "benchmark_family",
+                "benchmark_provider",
+                "rebalance_frequency",
+                "classification_set_id",
+                "classification_labels",
+                "effective_to",
+                "source_timestamp",
+                "source_vendor",
+                "source_record_id",
+                "quality_status",
+            ],
+        ),
+        (
+            "upsert_benchmark_compositions",
+            [
+                {
+                    "benchmark_id": "BMK_001",
+                    "index_id": "IDX_001",
+                    "composition_effective_from": "2026-01-01",
+                }
+            ],
+            ["benchmark_id", "index_id", "composition_effective_from"],
+            [
+                "composition_effective_to",
+                "composition_weight",
+                "rebalance_event_id",
+                "source_timestamp",
+                "source_vendor",
+                "source_record_id",
+                "quality_status",
+            ],
+        ),
+        (
+            "upsert_indices",
+            [{"index_id": "IDX_001", "effective_from": "2026-01-01"}],
+            ["index_id", "effective_from"],
+            [
+                "index_name",
+                "index_currency",
+                "index_type",
+                "index_status",
+                "index_provider",
+                "index_market",
+                "classification_set_id",
+                "classification_labels",
+                "effective_to",
+                "source_timestamp",
+                "source_vendor",
+                "source_record_id",
+                "quality_status",
+            ],
+        ),
+        (
+            "upsert_index_price_series",
+            [{"series_id": "SER_001", "index_id": "IDX_001", "series_date": "2026-01-01"}],
+            ["series_id", "index_id", "series_date"],
+            [
+                "index_price",
+                "series_currency",
+                "value_convention",
+                "source_timestamp",
+                "source_vendor",
+                "source_record_id",
+                "quality_status",
+            ],
+        ),
+        (
+            "upsert_index_return_series",
+            [{"series_id": "SER_001", "index_id": "IDX_001", "series_date": "2026-01-01"}],
+            ["series_id", "index_id", "series_date"],
+            [
+                "index_return",
+                "return_period",
+                "return_convention",
+                "series_currency",
+                "source_timestamp",
+                "source_vendor",
+                "source_record_id",
+                "quality_status",
+            ],
+        ),
+        (
+            "upsert_benchmark_return_series",
+            [{"series_id": "SER_001", "benchmark_id": "BMK_001", "series_date": "2026-01-01"}],
+            ["series_id", "benchmark_id", "series_date"],
+            [
+                "benchmark_return",
+                "return_period",
+                "return_convention",
+                "series_currency",
+                "source_timestamp",
+                "source_vendor",
+                "source_record_id",
+                "quality_status",
+            ],
+        ),
+        (
+            "upsert_risk_free_series",
+            [
+                {
+                    "series_id": "SER_001",
+                    "risk_free_curve_id": "RFC_001",
+                    "series_date": "2026-01-01",
+                }
+            ],
+            ["series_id", "risk_free_curve_id", "series_date"],
+            [
+                "value",
+                "value_convention",
+                "day_count_convention",
+                "compounding_convention",
+                "series_currency",
+                "source_timestamp",
+                "source_vendor",
+                "source_record_id",
+                "quality_status",
+            ],
+        ),
+        (
+            "upsert_classification_taxonomy",
+            [
+                {
+                    "classification_set_id": "TAX_001",
+                    "taxonomy_scope": "portfolio",
+                    "dimension_name": "asset_class",
+                    "dimension_value": "EQUITY",
+                    "effective_from": "2026-01-01",
+                }
+            ],
+            [
+                "classification_set_id",
+                "taxonomy_scope",
+                "dimension_name",
+                "dimension_value",
+                "effective_from",
+            ],
+            [
+                "dimension_description",
+                "effective_to",
+                "source_timestamp",
+                "source_vendor",
+                "source_record_id",
+                "quality_status",
+            ],
+        ),
+    ],
+)
+async def test_reference_data_upsert_methods_delegate_to_upsert_many(
+    method_name: str,
+    records: list[dict[str, str]],
+    conflict_columns: list[str],
+    update_columns: list[str],
+) -> None:
+    db = AsyncMock(spec=AsyncSession)
+    service = ReferenceDataIngestionService(db)
+    service._upsert_many = AsyncMock()  # type: ignore[method-assign]
+
+    await getattr(service, method_name)(records)
+
+    service._upsert_many.assert_awaited_once()
+    assert service._upsert_many.await_args.kwargs["records"] == records
+    assert service._upsert_many.await_args.kwargs["conflict_columns"] == conflict_columns
+    assert service._upsert_many.await_args.kwargs["update_columns"] == update_columns
+
+
+@pytest.mark.asyncio
+async def test_upsert_many_returns_without_db_calls_for_empty_records() -> None:
+    db = AsyncMock(spec=AsyncSession)
+    service = ReferenceDataIngestionService(db)
+
+    await service._upsert_many(
+        model=object,
+        records=[],
+        conflict_columns=["id"],
+        update_columns=["name"],
+    )
+
+    db.execute.assert_not_awaited()
+    db.commit.assert_not_awaited()
+
+
+def test_get_reference_data_ingestion_service_wraps_db_session() -> None:
+    db = AsyncMock(spec=AsyncSession)
+
+    service = get_reference_data_ingestion_service(db)  # type: ignore[arg-type]
+
+    assert isinstance(service, ReferenceDataIngestionService)
+    assert service._db is db
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/query_service/dtos/test_reporting_dto.py
+++ b/tests/unit/services/query_service/dtos/test_reporting_dto.py
@@ -8,7 +8,9 @@ from src.services.query_service.app.dtos.reporting_dto import (
     AssetAllocationQueryRequest,
     AssetsUnderManagementQueryRequest,
     CashBalancesQueryRequest,
+    HoldingsSnapshotQueryRequest,
     IncomeSummaryQueryRequest,
+    PortfolioSummaryQueryRequest,
     ReportingScope,
     ReportingWindow,
 )
@@ -66,3 +68,31 @@ def test_activity_summary_accepts_single_portfolio_without_reporting_currency() 
 
     assert request.scope.scope_type == "portfolio"
     assert request.reporting_currency is None
+
+
+def test_asset_allocation_request_supports_region_and_lookthrough_mode() -> None:
+    request = AssetAllocationQueryRequest(
+        scope=ReportingScope(portfolio_id="P1"),
+        dimensions=["region", "asset_class"],
+        look_through_mode="prefer_look_through",
+    )
+
+    assert request.dimensions == ["region", "asset_class"]
+    assert request.look_through_mode == "prefer_look_through"
+
+
+def test_portfolio_summary_request_is_single_portfolio_contract() -> None:
+    request = PortfolioSummaryQueryRequest(portfolio_id="P1", reporting_currency="USD")
+
+    assert request.portfolio_id == "P1"
+    assert request.reporting_currency == "USD"
+
+
+def test_holdings_snapshot_request_supports_include_cash_toggle() -> None:
+    request = HoldingsSnapshotQueryRequest(
+        portfolio_id="P1",
+        include_cash_positions=False,
+    )
+
+    assert request.portfolio_id == "P1"
+    assert request.include_cash_positions is False

--- a/tests/unit/services/query_service/repositories/test_cash_account_repository.py
+++ b/tests/unit/services/query_service/repositories/test_cash_account_repository.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.services.query_service.app.repositories.cash_account_repository import (
+    CashAccountRepository,
+)
+
+
+@pytest.mark.asyncio
+async def test_portfolio_exists_returns_true_when_portfolio_present() -> None:
+    execute_result = MagicMock()
+    execute_result.scalar_one_or_none.return_value = "PORT_001"
+    db = AsyncMock()
+    db.execute.return_value = execute_result
+    repo = CashAccountRepository(db)
+
+    exists = await repo.portfolio_exists("PORT_001")
+
+    assert exists is True
+    compiled = str(db.execute.await_args.args[0].compile(compile_kwargs={"literal_binds": True}))
+    assert "FROM portfolios" in compiled
+    assert "WHERE portfolios.portfolio_id = 'PORT_001'" in compiled
+
+
+@pytest.mark.asyncio
+async def test_portfolio_exists_returns_false_when_portfolio_missing() -> None:
+    execute_result = MagicMock()
+    execute_result.scalar_one_or_none.return_value = None
+    db = AsyncMock()
+    db.execute.return_value = execute_result
+    repo = CashAccountRepository(db)
+
+    exists = await repo.portfolio_exists("PORT_MISSING")
+
+    assert exists is False
+
+
+@pytest.mark.asyncio
+async def test_list_cash_accounts_applies_as_of_window_and_sort_order() -> None:
+    scalars_result = MagicMock()
+    scalars_result.all.return_value = ["acc-1", "acc-2"]
+    execute_result = MagicMock()
+    execute_result.scalars.return_value = scalars_result
+    db = AsyncMock()
+    db.execute.return_value = execute_result
+    repo = CashAccountRepository(db)
+
+    rows = await repo.list_cash_accounts("PORT_001", as_of_date=date(2026, 3, 31))
+
+    assert rows == ["acc-1", "acc-2"]
+    compiled = str(db.execute.await_args.args[0].compile(compile_kwargs={"literal_binds": True}))
+    assert "FROM cash_account_masters" in compiled
+    assert "cash_account_masters.portfolio_id = 'PORT_001'" in compiled
+    assert "cash_account_masters.opened_on <=" in compiled
+    assert "cash_account_masters.closed_on >=" in compiled
+    assert "ORDER BY cash_account_masters.account_currency ASC" in compiled
+    assert "cash_account_masters.cash_account_id ASC" in compiled
+
+
+@pytest.mark.asyncio
+async def test_list_cash_accounts_without_as_of_date_uses_portfolio_scope_only() -> None:
+    scalars_result = MagicMock()
+    scalars_result.all.return_value = []
+    execute_result = MagicMock()
+    execute_result.scalars.return_value = scalars_result
+    db = AsyncMock()
+    db.execute.return_value = execute_result
+    repo = CashAccountRepository(db)
+
+    rows = await repo.list_cash_accounts("PORT_001")
+
+    assert rows == []
+    compiled = str(db.execute.await_args.args[0].compile(compile_kwargs={"literal_binds": True}))
+    assert "cash_account_masters.opened_on <=" not in compiled
+    assert "cash_account_masters.closed_on >=" not in compiled

--- a/tests/unit/services/query_service/repositories/test_reporting_repository.py
+++ b/tests/unit/services/query_service/repositories/test_reporting_repository.py
@@ -50,7 +50,7 @@ async def test_reporting_repository_lists_portfolios_with_scope_filters() -> Non
 
 
 @pytest.mark.asyncio
-async def test_reporting_repository_latest_snapshot_query_is_latest_non_zero_current_epoch() -> (
+async def test_reporting_repository_latest_snapshot_query_is_true_historical_as_of_snapshot() -> (
     None
 ):
     db = AsyncMock(spec=AsyncSession)
@@ -80,7 +80,6 @@ async def test_reporting_repository_latest_snapshot_query_is_latest_non_zero_cur
     )
     assert "daily_position_snapshots.date <= '2026-03-27'" in compiled
     assert "daily_position_snapshots.quantity != 0" in compiled
-    assert "JOIN position_state" in compiled
     assert "LEFT OUTER JOIN instruments" in compiled
     assert (
         "ORDER BY daily_position_snapshots.portfolio_id ASC, "
@@ -140,6 +139,42 @@ async def test_reporting_repository_cash_account_resolution_uses_index_friendly_
     assert (
         "row_number() over (partition by transactions.settlement_cash_instrument_id" in normalized
     )
+
+
+@pytest.mark.asyncio
+async def test_reporting_repository_cash_account_master_query_uses_effective_window() -> None:
+    db = AsyncMock(spec=AsyncSession)
+    db.execute.return_value = _FakeExecuteResult([])
+    repo = ReportingRepository(db)
+
+    await repo.list_cash_account_masters(
+        portfolio_id="P1",
+        as_of_date=date(2026, 3, 27),
+    )
+
+    stmt = db.execute.await_args.args[0]
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "cash_account_masters.portfolio_id = 'P1'" in compiled
+    assert "cash_account_masters.opened_on <= '2026-03-27'" in compiled
+    assert "cash_account_masters.closed_on >= '2026-03-27'" in compiled
+
+
+@pytest.mark.asyncio
+async def test_reporting_repository_lookthrough_query_uses_effective_window() -> None:
+    db = AsyncMock(spec=AsyncSession)
+    db.execute.return_value = _FakeExecuteResult([])
+    repo = ReportingRepository(db)
+
+    await repo.list_instrument_lookthrough_components(
+        parent_security_ids=["FUND1", "FUND2"],
+        as_of_date=date(2026, 3, 27),
+    )
+
+    stmt = db.execute.await_args.args[0]
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "instrument_lookthrough_components.parent_security_id IN ('FUND1', 'FUND2')" in compiled
+    assert "instrument_lookthrough_components.effective_from <= '2026-03-27'" in compiled
+    assert "instrument_lookthrough_components.effective_to >= '2026-03-27'" in compiled
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/query_service/services/test_cash_account_service.py
+++ b/tests/unit/services/query_service/services/test_cash_account_service.py
@@ -1,0 +1,53 @@
+from datetime import date
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.services.query_service.app.services.cash_account_service import CashAccountService
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_get_cash_accounts_returns_master_records() -> None:
+    repo = AsyncMock()
+    repo.portfolio_exists.return_value = True
+    repo.list_cash_accounts.return_value = [
+        SimpleNamespace(
+            cash_account_id="CASH-ACC-USD-001",
+            portfolio_id="P1",
+            security_id="CASH_USD",
+            display_name="USD Operating Cash",
+            account_currency="USD",
+            account_role="OPERATING_CASH",
+            lifecycle_status="ACTIVE",
+            opened_on=date(2026, 1, 1),
+            closed_on=None,
+            source_system="lotus-manage",
+        )
+    ]
+
+    with patch(
+        "src.services.query_service.app.services.cash_account_service.CashAccountRepository",
+        return_value=repo,
+    ):
+        service = CashAccountService(AsyncMock(spec=AsyncSession))
+        response = await service.get_cash_accounts("P1", as_of_date=date(2026, 3, 27))
+
+    assert response.portfolio_id == "P1"
+    assert response.resolved_as_of_date == date(2026, 3, 27)
+    assert response.cash_accounts[0].cash_account_id == "CASH-ACC-USD-001"
+
+
+async def test_get_cash_accounts_raises_for_missing_portfolio() -> None:
+    repo = AsyncMock()
+    repo.portfolio_exists.return_value = False
+
+    with patch(
+        "src.services.query_service.app.services.cash_account_service.CashAccountRepository",
+        return_value=repo,
+    ):
+        service = CashAccountService(AsyncMock(spec=AsyncSession))
+        with pytest.raises(ValueError, match="Portfolio with id P404 not found"):
+            await service.get_cash_accounts("P404")

--- a/tests/unit/services/query_service/services/test_reporting_service.py
+++ b/tests/unit/services/query_service/services/test_reporting_service.py
@@ -11,13 +11,16 @@ from src.services.query_service.app.dtos.reporting_dto import (
     AssetAllocationQueryRequest,
     AssetsUnderManagementQueryRequest,
     CashBalancesQueryRequest,
+    HoldingsSnapshotQueryRequest,
     IncomeSummaryQueryRequest,
+    PortfolioSummaryQueryRequest,
     ReportingScope,
     ReportingWindow,
 )
 from src.services.query_service.app.repositories.reporting_repository import (
     ActivitySummaryAggregateRow,
     IncomeSummaryAggregateRow,
+    InstrumentLookthroughComponentRow,
     ReportingSnapshotRow,
 )
 from src.services.query_service.app.services.reporting_service import ReportingService
@@ -76,11 +79,17 @@ def _snapshot(
     *,
     market_value: str,
     market_value_local: str | None = None,
+    quantity: str = "1",
+    valuation_status: str | None = "VALUED",
+    snapshot_date: date = date(2026, 3, 27),
 ):
     return SimpleNamespace(
         security_id=security_id,
+        date=snapshot_date,
         market_value=Decimal(market_value),
         market_value_local=Decimal(market_value_local or market_value),
+        quantity=Decimal(quantity),
+        valuation_status=valuation_status,
     )
 
 
@@ -207,6 +216,274 @@ async def test_get_cash_balances_returns_cash_accounts_and_totals() -> None:
     assert response.totals.total_balance_portfolio_currency == Decimal("250")
     assert response.totals.total_balance_reporting_currency == Decimal("300.0")
     assert response.cash_accounts[0].cash_account_id == "CASH-ACC-USD-001"
+
+
+async def test_get_cash_balances_prefers_cash_account_master_and_keeps_zero_balance_accounts() -> (
+    None
+):
+    repo = AsyncMock()
+    portfolio = _portfolio("P1", base_currency="USD")
+    repo.get_portfolio_by_id.return_value = portfolio
+    repo.get_latest_business_date.return_value = date(2026, 3, 27)
+    repo.list_latest_snapshot_rows.return_value = [
+        ReportingSnapshotRow(
+            portfolio=portfolio,
+            snapshot=_snapshot("CASH_USD", market_value="250", market_value_local="250"),
+            instrument=_instrument(
+                "CASH_USD",
+                name="USD Cash Account",
+                currency="USD",
+                asset_class="CASH",
+                sector="CASH",
+                product_type="CASH",
+            ),
+        )
+    ]
+    repo.list_cash_account_masters.return_value = [
+        SimpleNamespace(
+            cash_account_id="CASH-ACC-USD-001",
+            security_id="CASH_USD",
+            display_name="USD Operating Cash",
+            account_currency="USD",
+        ),
+        SimpleNamespace(
+            cash_account_id="CASH-ACC-SGD-001",
+            security_id="CASH_SGD",
+            display_name="SGD Reserve Cash",
+            account_currency="SGD",
+        ),
+    ]
+    repo.get_latest_cash_account_ids.return_value = {"CASH_USD": "LEGACY-MAP"}
+
+    with patch(
+        "src.services.query_service.app.services.reporting_service.ReportingRepository",
+        return_value=repo,
+    ):
+        service = ReportingService(AsyncMock(spec=AsyncSession))
+        response = await service.get_cash_balances(CashBalancesQueryRequest(portfolio_id="P1"))
+
+    assert [record.cash_account_id for record in response.cash_accounts] == [
+        "CASH-ACC-SGD-001",
+        "CASH-ACC-USD-001",
+    ]
+    assert response.cash_accounts[0].balance_portfolio_currency == Decimal("0")
+    assert response.cash_accounts[1].balance_portfolio_currency == Decimal("250")
+    assert response.totals.cash_account_count == 2
+
+
+async def test_get_portfolio_summary_returns_historical_restated_totals() -> None:
+    repo = AsyncMock()
+    portfolio = _portfolio("P1", base_currency="USD")
+    portfolio.portfolio_type = "DISCRETIONARY"
+    portfolio.objective = "Growth"
+    portfolio.risk_exposure = "BALANCED"
+    portfolio.status = "ACTIVE"
+    repo.get_portfolio_by_id.return_value = portfolio
+    repo.get_latest_business_date.return_value = date(2026, 3, 27)
+    repo.list_latest_snapshot_rows.return_value = [
+        ReportingSnapshotRow(
+            portfolio=portfolio,
+            snapshot=_snapshot(
+                "CASH_USD",
+                market_value="200",
+                quantity="1",
+                snapshot_date=date(2026, 3, 26),
+            ),
+            instrument=_instrument(
+                "CASH_USD",
+                name="USD Cash",
+                currency="USD",
+                asset_class="CASH",
+                sector="CASH",
+                product_type="CASH",
+            ),
+        ),
+        ReportingSnapshotRow(
+            portfolio=portfolio,
+            snapshot=_snapshot(
+                "SEC1",
+                market_value="800",
+                quantity="10",
+                valuation_status="UNVALUED",
+                snapshot_date=date(2026, 3, 27),
+            ),
+            instrument=_instrument("SEC1", asset_class="EQUITY"),
+        ),
+    ]
+    repo.list_cash_account_masters.return_value = [
+        SimpleNamespace(
+            cash_account_id="CASH-ACC-USD-001",
+            security_id="CASH_USD",
+            display_name="USD Operating Cash",
+            account_currency="USD",
+        )
+    ]
+    repo.get_latest_cash_account_ids.return_value = {}
+    repo.get_latest_fx_rate.return_value = Decimal("1.5")
+
+    with patch(
+        "src.services.query_service.app.services.reporting_service.ReportingRepository",
+        return_value=repo,
+    ):
+        service = ReportingService(AsyncMock(spec=AsyncSession))
+        response = await service.get_portfolio_summary(
+            PortfolioSummaryQueryRequest(portfolio_id="P1", reporting_currency="SGD")
+        )
+
+    assert response.totals.total_market_value_portfolio_currency == Decimal("1000")
+    assert response.totals.cash_balance_portfolio_currency == Decimal("200")
+    assert response.totals.invested_market_value_reporting_currency == Decimal("1200.0")
+    assert response.snapshot_metadata.snapshot_date == date(2026, 3, 27)
+    assert response.snapshot_metadata.cash_account_count == 1
+    assert response.snapshot_metadata.valued_position_count == 1
+    assert response.snapshot_metadata.unvalued_position_count == 1
+
+
+async def test_get_holdings_snapshot_restates_reporting_currency_and_region() -> None:
+    repo = AsyncMock()
+    portfolio = _portfolio("P1", base_currency="USD")
+    repo.get_portfolio_by_id.return_value = portfolio
+    repo.get_latest_business_date.return_value = date(2026, 3, 27)
+    repo.list_latest_snapshot_rows.return_value = [
+        ReportingSnapshotRow(
+            portfolio=portfolio,
+            snapshot=_snapshot("SEC1", market_value="100"),
+            instrument=_instrument(
+                "SEC1",
+                asset_class="EQUITY",
+                sector="TECH",
+                country_of_risk="US",
+            ),
+        ),
+        ReportingSnapshotRow(
+            portfolio=portfolio,
+            snapshot=_snapshot("CASH_USD", market_value="50"),
+            instrument=_instrument(
+                "CASH_USD",
+                asset_class="CASH",
+                sector="CASH",
+                product_type="CASH",
+            ),
+        ),
+    ]
+    repo.get_latest_fx_rate.return_value = Decimal("1.2")
+
+    with patch(
+        "src.services.query_service.app.services.reporting_service.ReportingRepository",
+        return_value=repo,
+    ):
+        service = ReportingService(AsyncMock(spec=AsyncSession))
+        response = await service.get_holdings_snapshot(
+            HoldingsSnapshotQueryRequest(
+                portfolio_id="P1",
+                reporting_currency="SGD",
+                include_cash_positions=False,
+            )
+        )
+
+    assert response.total_market_value_portfolio_currency == Decimal("100")
+    assert response.total_market_value_reporting_currency == Decimal("120.0")
+    assert len(response.positions) == 1
+    assert response.positions[0].region == "North America"
+    assert response.positions[0].weight == Decimal("1")
+
+
+async def test_get_asset_allocation_applies_region_and_partial_lookthrough() -> None:
+    repo = AsyncMock()
+    portfolio = _portfolio("P1", base_currency="USD")
+    repo.get_latest_business_date.return_value = date(2026, 3, 27)
+    repo.list_portfolios.return_value = [portfolio]
+    repo.list_latest_snapshot_rows.return_value = [
+        ReportingSnapshotRow(
+            portfolio=portfolio,
+            snapshot=_snapshot("FUND1", market_value="100"),
+            instrument=_instrument("FUND1", asset_class="FUND", country_of_risk="LU"),
+        ),
+        ReportingSnapshotRow(
+            portfolio=portfolio,
+            snapshot=_snapshot("SEC2", market_value="50"),
+            instrument=_instrument("SEC2", asset_class="EQUITY", country_of_risk="US"),
+        ),
+    ]
+    repo.list_instrument_lookthrough_components.return_value = [
+        InstrumentLookthroughComponentRow(
+            parent_security_id="FUND1",
+            component_security_id="ETF1",
+            component_weight=Decimal("0.6"),
+            component_instrument=_instrument("ETF1", asset_class="EQUITY", country_of_risk="US"),
+        ),
+        InstrumentLookthroughComponentRow(
+            parent_security_id="FUND1",
+            component_security_id="ETF2",
+            component_weight=Decimal("0.4"),
+            component_instrument=_instrument("ETF2", asset_class="BOND", country_of_risk="DE"),
+        ),
+    ]
+
+    with patch(
+        "src.services.query_service.app.services.reporting_service.ReportingRepository",
+        return_value=repo,
+    ):
+        service = ReportingService(AsyncMock(spec=AsyncSession))
+        response = await service.get_asset_allocation(
+            AssetAllocationQueryRequest(
+                scope=ReportingScope(portfolio_id="P1"),
+                dimensions=["region", "asset_class"],
+                look_through_mode="prefer_look_through",
+            )
+        )
+
+    assert response.look_through.applied_mode == "prefer_look_through"
+    assert response.look_through.supported is True
+    assert response.look_through.decomposed_position_count == 1
+    assert "remaining positions" in response.look_through.limitation_reason
+    region_view = next(view for view in response.views if view.dimension == "region")
+    north_america_bucket = next(
+        bucket for bucket in region_view.buckets if bucket.dimension_value == "North America"
+    )
+    europe_bucket = next(
+        bucket for bucket in region_view.buckets if bucket.dimension_value == "Europe"
+    )
+    assert north_america_bucket.market_value_reporting_currency == Decimal("110.0")
+    assert europe_bucket.market_value_reporting_currency == Decimal("40.0")
+
+
+async def test_get_asset_allocation_reports_lookthrough_capability_in_direct_mode() -> None:
+    repo = AsyncMock()
+    portfolio = _portfolio("P1", base_currency="USD")
+    repo.get_latest_business_date.return_value = date(2026, 3, 27)
+    repo.list_portfolios.return_value = [portfolio]
+    repo.list_latest_snapshot_rows.return_value = [
+        ReportingSnapshotRow(
+            portfolio=portfolio,
+            snapshot=_snapshot("FUND1", market_value="100"),
+            instrument=_instrument("FUND1", asset_class="FUND", country_of_risk="LU"),
+        )
+    ]
+    repo.list_instrument_lookthrough_components.return_value = [
+        InstrumentLookthroughComponentRow(
+            parent_security_id="FUND1",
+            component_security_id="ETF1",
+            component_weight=Decimal("1"),
+            component_instrument=_instrument("ETF1", asset_class="EQUITY", country_of_risk="US"),
+        )
+    ]
+
+    with patch(
+        "src.services.query_service.app.services.reporting_service.ReportingRepository",
+        return_value=repo,
+    ):
+        service = ReportingService(AsyncMock(spec=AsyncSession))
+        response = await service.get_asset_allocation(
+            AssetAllocationQueryRequest(
+                scope=ReportingScope(portfolio_id="P1"),
+                dimensions=["asset_class"],
+            )
+        )
+
+    assert response.look_through.requested_mode == "direct_only"
+    assert response.look_through.applied_mode == "direct_only"
+    assert response.look_through.supported is True
 
 
 async def test_get_cash_balances_raises_when_portfolio_missing() -> None:


### PR DESCRIPTION
## Summary
- add source-owned PB/WM portfolio summary and holdings snapshot contracts with true historical as-of semantics and reporting-currency restatement
- add region and optional look-through allocation support plus canonical cash-account master ingestion and query contracts
- document and govern the new API family through RFC 084, the feature guide, and the API vocabulary inventory

## Validation
- python -m pytest tests/unit/services/query_service/services/test_reporting_service.py tests/unit/services/query_service/repositories/test_reporting_repository.py tests/unit/services/query_service/dtos/test_reporting_dto.py tests/unit/services/query_service/services/test_cash_account_service.py tests/integration/services/query_service/test_reporting_router.py tests/integration/services/query_service/test_cash_accounts_router.py tests/integration/services/query_service/test_main_app.py tests/unit/services/ingestion_service/test_reference_data_ingestion_service.py tests/integration/services/ingestion_service/test_ingestion_routers.py -q
- python -m pytest tests/unit/services/query_service -q
- python -m pytest tests/integration/services/query_service/test_main_app.py tests/integration/services/query_service/test_reporting_router.py tests/integration/services/query_service/test_cash_accounts_router.py tests/integration/services/query_service/test_portfolios_router_dependency.py tests/integration/services/query_service/test_positions_router_dependency.py tests/integration/services/query_service/test_transactions_router.py -q
- python -m pytest tests/unit/services/ingestion_service/test_reference_data_ingestion_service.py tests/integration/services/ingestion_service/test_ingestion_routers.py -q
- python scripts/openapi_quality_gate.py
- python scripts/api_vocabulary_inventory.py --validate-only

Fixes #271
Fixes #272
Fixes #273
Fixes #274