### PR TITLE
fix(query-service): preserve packaged app module

### DIFF
--- a/src/services/query_service/pyproject.toml
+++ b/src/services/query_service/pyproject.toml
@@ -21,4 +21,5 @@ dependencies = [
 ]
 
 [tool.setuptools.packages.find]
-where = ["app"]
+where = ["."]
+include = ["app*"]

--- a/tests/unit/services/query_service/test_package_contract.py
+++ b/tests/unit/services/query_service/test_package_contract.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SERVICE_ROOT = REPO_ROOT / "src" / "services" / "query_service"
+DOCKERFILE = SERVICE_ROOT / "Dockerfile"
+
+
+def test_query_service_wheel_keeps_app_package(tmp_path: Path) -> None:
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "wheel",
+            "--no-deps",
+            "--wheel-dir",
+            str(tmp_path),
+            str(SERVICE_ROOT),
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    wheel_path = next(tmp_path.glob("query_service-*.whl"))
+    with zipfile.ZipFile(wheel_path) as wheel:
+        names = set(wheel.namelist())
+
+    assert "app/__init__.py" in names
+    assert "app/main.py" in names
+    assert "app/routers/transactions.py" in names
+
+
+def test_query_service_dockerfile_targets_packaged_app_module() -> None:
+    dockerfile_text = DOCKERFILE.read_text(encoding="utf-8")
+    assert 'CMD ["uvicorn", "app.main:app"' in dockerfile_text


### PR DESCRIPTION
## Summary
- preserve the top-level `app` package in the query-service wheel so built images start with `uvicorn app.main:app`
- add package and Dockerfile contract tests that lock the packaged module layout and runtime entrypoint
- validate the built image can import `app.main` successfully

## Validation
- python -m pytest tests/unit/services/query_service/test_package_contract.py tests/unit/test_support/test_docker_stack.py -q
- python -m ruff check src/services/query_service/pyproject.toml tests/unit/services/query_service/test_package_contract.py tests/unit/test_support/test_docker_stack.py

Fixes #262
