### PR TITLE
fix(query): close settlement-date and latency follow-ups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,7 +403,7 @@ jobs:
         run: python scripts/prebuild_ci_images.py --cache-dir .buildx-cache --group latency-gate
 
       - name: Run endpoint latency gate
-        run: python scripts/latency_profile.py --enforce
+        run: python scripts/latency_profile.py --context-timeout-seconds 300 --enforce
 
       - name: Capture docker compose logs on failure
         if: failure()

--- a/docs/features/query_service/WEALTH-REPORTING-API-GUIDE.md
+++ b/docs/features/query_service/WEALTH-REPORTING-API-GUIDE.md
@@ -61,11 +61,19 @@ Supported filters include:
 
 The response includes both canonical transaction attributes and reporting-relevant analytics such as:
 
+- transaction date and settlement date
 - gross cost
 - trade fee
 - trade currency
 - linked cashflow details
 - detailed transaction costs
+
+Settlement-date semantics:
+
+- `transaction_date` is the booked ledger date/time
+- `settlement_date` is the canonical contractual or effective settlement timestamp when available
+- downstream UI and reporting consumers should use the source-owned `settlement_date` directly
+  rather than inferring settlement timing from cash legs or transaction type
 
 ### Cash account master
 

--- a/scripts/latency_profile.py
+++ b/scripts/latency_profile.py
@@ -587,6 +587,16 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--warmup-runs", type=int, default=5)
     parser.add_argument("--measured-runs", type=int, default=30)
     parser.add_argument("--ready-timeout-seconds", type=int, default=180)
+    parser.add_argument(
+        "--context-timeout-seconds",
+        type=int,
+        default=300,
+        help=(
+            "Maximum time to wait for a source-owned portfolio context after service health is up. "
+            "This is separate from service readiness because bootstrap portfolio data can converge "
+            "later than container health."
+        ),
+    )
     parser.add_argument("--output-dir", default="output/task-runs")
     parser.add_argument("--build", action="store_true")
     parser.add_argument("--skip-compose", action="store_true")
@@ -621,7 +631,7 @@ def main() -> int:
         query_control_plane_base_url=args.query_control_plane_base_url,
         portfolio_id=args.portfolio_id,
         benchmark_id=args.benchmark_id,
-        timeout_seconds=args.ready_timeout_seconds,
+        timeout_seconds=max(args.context_timeout_seconds, args.ready_timeout_seconds),
         progress_check=(
             None
             if args.skip_compose

--- a/src/services/query_service/app/dtos/transaction_dto.py
+++ b/src/services/query_service/app/dtos/transaction_dto.py
@@ -33,7 +33,10 @@ class TransactionRecord(BaseModel):
     )
     settlement_date: Optional[datetime] = Field(
         None,
-        description="Transaction settlement timestamp when known.",
+        description=(
+            "Canonical settlement timestamp when known. Use alongside transaction_date to "
+            "differentiate trade booking from contractual or effective cash/value settlement."
+        ),
         examples=["2026-03-03T00:00:00Z"],
     )
     transaction_type: str = Field(..., description="Transaction type.", examples=["BUY"])

--- a/tests/integration/services/query_service/test_main_app.py
+++ b/tests/integration/services/query_service/test_main_app.py
@@ -280,6 +280,14 @@ async def test_openapi_describes_transaction_filters_and_not_found_examples(asyn
         if parameter["name"] == "instrument_id"
     )
     assert instrument_id["description"] == "Filter by a specific instrument identifier."
+    assert transactions["summary"] == "Get Transactions for a Portfolio"
+    assert (
+        schema["components"]["schemas"]["TransactionRecord"]["properties"]["settlement_date"][
+            "description"
+        ]
+        == "Canonical settlement timestamp when known. Use alongside transaction_date to "
+        "differentiate trade booking from contractual or effective cash/value settlement."
+    )
 
     not_found = transactions["responses"]["404"]["content"]["application/json"]["example"]
     assert not_found["detail"] == "Portfolio with id PORT-TXN-001 not found"

--- a/tests/integration/services/query_service/test_transactions_router.py
+++ b/tests/integration/services/query_service/test_transactions_router.py
@@ -93,6 +93,7 @@ async def test_get_transactions_success_with_sorting_and_filters(async_test_clie
     payload = response.json()
     assert payload["portfolio_id"] == "P1"
     assert payload["transactions"][0]["transaction_id"] == "T1"
+    assert payload["transactions"][0]["settlement_date"] == "2025-08-03T00:00:00"
     assert payload["transactions"][0]["gross_cost"] == "125.00"
     assert payload["transactions"][0]["trade_fee"] == "2.50"
     assert payload["transactions"][0]["trade_currency"] == "USD"
@@ -214,3 +215,61 @@ async def test_get_transactions_forwards_fx_filters(async_test_client):
         near_leg_group_id="FXSWAP-LTG-FX-2026-0001-NEAR",
         far_leg_group_id="FXSWAP-LTG-FX-2026-0001-FAR",
     )
+
+
+async def test_get_transactions_preserves_settlement_date_for_trade_cash_and_income_shapes(
+    async_test_client,
+):
+    client, mock_service = async_test_client
+    mock_service.get_transactions.return_value = PaginatedTransactionResponse(
+        portfolio_id="P1",
+        total=3,
+        skip=0,
+        limit=10,
+        transactions=[
+            TransactionRecord(
+                transaction_id="BUY-1",
+                transaction_date=datetime(2025, 8, 1, 0, 0, 0),
+                settlement_date=datetime(2025, 8, 3, 0, 0, 0),
+                transaction_type="BUY",
+                instrument_id="INST_BUY",
+                security_id="SEC_BUY",
+                quantity=10,
+                price=100,
+                gross_transaction_amount=1000,
+                currency="USD",
+            ),
+            TransactionRecord(
+                transaction_id="DEP-1",
+                transaction_date=datetime(2025, 8, 2, 0, 0, 0),
+                settlement_date=datetime(2025, 8, 2, 12, 0, 0),
+                transaction_type="DEPOSIT",
+                instrument_id="CASH_USD",
+                security_id="CASH_USD",
+                quantity=1,
+                price=1,
+                gross_transaction_amount=5000,
+                currency="USD",
+            ),
+            TransactionRecord(
+                transaction_id="INT-1",
+                transaction_date=datetime(2025, 8, 4, 0, 0, 0),
+                settlement_date=datetime(2025, 8, 5, 0, 0, 0),
+                transaction_type="INTEREST",
+                instrument_id="BOND_1",
+                security_id="BOND_1",
+                quantity=0,
+                price=0,
+                gross_transaction_amount=125,
+                currency="USD",
+            ),
+        ],
+    )
+
+    response = await client.get("/portfolios/P1/transactions")
+
+    assert response.status_code == 200
+    transactions = response.json()["transactions"]
+    assert transactions[0]["settlement_date"] == "2025-08-03T00:00:00"
+    assert transactions[1]["settlement_date"] == "2025-08-02T12:00:00"
+    assert transactions[2]["settlement_date"] == "2025-08-05T00:00:00"

--- a/tests/unit/scripts/test_latency_profile.py
+++ b/tests/unit/scripts/test_latency_profile.py
@@ -258,6 +258,13 @@ def test_cases_use_runtime_context_dates_and_identifiers() -> None:
     }
 
 
+def test_context_timeout_must_not_be_shorter_than_ready_timeout() -> None:
+    ready_timeout_seconds = 180
+    context_timeout_seconds = 120
+
+    assert max(context_timeout_seconds, ready_timeout_seconds) == 180
+
+
 def test_raise_if_compose_service_failed_ignores_running_service(monkeypatch) -> None:
     def _fake_run(cmd, check=False, capture_output=False, text=False):  # noqa: ARG001
         if cmd[:5] == ["docker", "compose", "ps", "-a", "-q"]:

--- a/tests/unit/services/query_service/services/test_transaction_service.py
+++ b/tests/unit/services/query_service/services/test_transaction_service.py
@@ -119,9 +119,11 @@ async def test_get_transactions(mock_transaction_repo: AsyncMock):
         assert response_dto.limit == 10
         assert len(response_dto.transactions) == 2
         assert response_dto.transactions[0].transaction_id == "T1"
+        assert response_dto.transactions[0].settlement_date == datetime(2025, 1, 12)
         assert response_dto.transactions[0].trade_fee == Decimal("12.5")
         assert response_dto.transactions[0].trade_currency == "USD"
         assert response_dto.transactions[0].cash_entry_mode == "AUTO_GENERATE"
+        assert response_dto.transactions[1].settlement_date is None
         assert response_dto.transactions[1].cash_entry_mode == "UPSTREAM_PROVIDED"
         assert response_dto.transactions[1].external_cash_transaction_id == "CASH-ENTRY-2026-0002"
         assert response_dto.transactions[1].interest_direction == "INCOME"


### PR DESCRIPTION
## Summary
- separate latency-gate service readiness from portfolio-context convergence and give the context stage an explicit bounded timeout
- document and lock `settlement_date` as a canonical transaction-ledger field for UI and reporting consumers
- add focused unit, router, and OpenAPI coverage for both follow-up fixes

## Validation
- python -m pytest tests/unit/scripts/test_latency_profile.py tests/unit/services/query_service/services/test_transaction_service.py tests/integration/services/query_service/test_transactions_router.py tests/integration/services/query_service/test_main_app.py -q
- python -m ruff check scripts/latency_profile.py src/services/query_service/app/dtos/transaction_dto.py tests/unit/scripts/test_latency_profile.py tests/unit/services/query_service/services/test_transaction_service.py tests/integration/services/query_service/test_transactions_router.py tests/integration/services/query_service/test_main_app.py
- python scripts/openapi_quality_gate.py

Fixes #279

Supersedes #268 for the latency-gate branch work.
