### PR TITLE
fix(ci): widen latency context window for seeded portfolios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,7 +403,7 @@ jobs:
         run: python scripts/prebuild_ci_images.py --cache-dir .buildx-cache --group latency-gate
 
       - name: Run endpoint latency gate
-        run: python scripts/latency_profile.py --enforce
+        run: python scripts/latency_profile.py --context-timeout-seconds 300 --enforce
 
       - name: Capture docker compose logs on failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,7 +403,7 @@ jobs:
         run: python scripts/prebuild_ci_images.py --cache-dir .buildx-cache --group latency-gate
 
       - name: Run endpoint latency gate
-        run: python scripts/latency_profile.py --context-timeout-seconds 300 --enforce
+        run: python scripts/latency_profile.py --context-timeout-seconds 600 --enforce
 
       - name: Capture docker compose logs on failure
         if: failure()

--- a/docs/features/query_service/WEALTH-REPORTING-API-GUIDE.md
+++ b/docs/features/query_service/WEALTH-REPORTING-API-GUIDE.md
@@ -61,11 +61,19 @@ Supported filters include:
 
 The response includes both canonical transaction attributes and reporting-relevant analytics such as:
 
+- transaction date and settlement date
 - gross cost
 - trade fee
 - trade currency
 - linked cashflow details
 - detailed transaction costs
+
+Settlement-date semantics:
+
+- `transaction_date` is the booked ledger date/time
+- `settlement_date` is the canonical contractual or effective settlement timestamp when available
+- downstream UI and reporting consumers should use the source-owned `settlement_date` directly
+  rather than inferring settlement timing from cash legs or transaction type
 
 ### Cash account master
 

--- a/scripts/latency_profile.py
+++ b/scripts/latency_profile.py
@@ -208,8 +208,10 @@ def _resolve_runtime_ids(
                 return None
         for url, payload in post_checks:
             try:
-                response = session.get(url, timeout=15) if payload is None else session.post(
-                    url, json=payload, timeout=15
+                response = (
+                    session.get(url, timeout=15)
+                    if payload is None
+                    else session.post(url, json=payload, timeout=15)
                 )
             except requests.RequestException:
                 return None

--- a/scripts/latency_profile.py
+++ b/scripts/latency_profile.py
@@ -587,6 +587,16 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--warmup-runs", type=int, default=5)
     parser.add_argument("--measured-runs", type=int, default=30)
     parser.add_argument("--ready-timeout-seconds", type=int, default=180)
+    parser.add_argument(
+        "--context-timeout-seconds",
+        type=int,
+        default=300,
+        help=(
+            "Maximum time to wait for a source-owned portfolio context after service health is up. "
+            "This is separate from service readiness because bootstrap portfolio data can converge "
+            "later than container health."
+        ),
+    )
     parser.add_argument("--output-dir", default="output/task-runs")
     parser.add_argument("--build", action="store_true")
     parser.add_argument("--skip-compose", action="store_true")
@@ -621,7 +631,7 @@ def main() -> int:
         query_control_plane_base_url=args.query_control_plane_base_url,
         portfolio_id=args.portfolio_id,
         benchmark_id=args.benchmark_id,
-        timeout_seconds=args.ready_timeout_seconds,
+        timeout_seconds=max(args.context_timeout_seconds, args.ready_timeout_seconds),
         progress_check=(
             None
             if args.skip_compose

--- a/scripts/latency_profile.py
+++ b/scripts/latency_profile.py
@@ -14,7 +14,7 @@ import statistics
 import subprocess
 import time
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from typing import Any, Callable
 
@@ -34,6 +34,17 @@ class EndpointCase:
     payload: dict[str, Any] | None
     p95_budget_ms: float
     timeout_seconds: float = 30.0
+
+
+@dataclass(frozen=True)
+class RuntimeContext:
+    portfolio_id: str
+    benchmark_id: str
+    as_of_date: date
+
+    @property
+    def benchmark_window_start_date(self) -> date:
+        return self.as_of_date - timedelta(days=90)
 
 
 def _percentile_ms(samples: list[float], percentile: int) -> float:
@@ -133,6 +144,15 @@ def _pick_identifier_from_payload(payload: Any, keys: tuple[str, ...]) -> str | 
     return None
 
 
+def _parse_date_value(value: Any) -> date | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        return None
+
+
 def _resolve_runtime_ids(
     session: requests.Session,
     *,
@@ -142,53 +162,60 @@ def _resolve_runtime_ids(
     benchmark_id: str,
     timeout_seconds: int,
     progress_check: Callable[[], None] | None = None,
-) -> tuple[str, str]:
+) -> RuntimeContext:
     resolved_portfolio_id: str | None = None
     resolved_benchmark_id = benchmark_id
+    resolved_as_of_date: date | None = None
 
-    def _portfolio_ready(candidate_id: str) -> bool:
+    def _resolve_candidate_as_of_date(candidate_id: str) -> date | None:
+        try:
+            response = session.get(
+                f"{query_control_plane_base_url}/support/portfolios/{candidate_id}/overview",
+                timeout=10,
+            )
+        except requests.RequestException:
+            return None
+        if 200 <= response.status_code < 300:
+            business_date = _parse_date_value(response.json().get("business_date"))
+            if business_date is not None:
+                return business_date
+
+        try:
+            response = session.get(f"{query_base_url}/portfolios/{candidate_id}", timeout=10)
+        except requests.RequestException:
+            return None
+        if not (200 <= response.status_code < 300):
+            return None
+        return _parse_date_value(response.json().get("open_date"))
+
+    def _portfolio_ready(candidate_id: str) -> date | None:
         get_urls = [
             f"{query_base_url}/portfolios/{candidate_id}/positions",
             f"{query_base_url}/portfolios/{candidate_id}/transactions?limit=1",
-            f"{query_control_plane_base_url}/support/portfolios/{candidate_id}/overview",
         ]
         post_checks = [
             (
-                f"{query_control_plane_base_url}/integration/portfolios/{candidate_id}/analytics/portfolio-timeseries",
-                {
-                    "as_of_date": "2026-03-01",
-                    "period": "three_months",
-                    "frequency": "daily",
-                    "consumer_system": "lotus-performance",
-                    "page": {"page_size": 100},
-                },
-            ),
-            (
-                f"{query_control_plane_base_url}/integration/portfolios/{candidate_id}/analytics/position-timeseries",
-                {
-                    "as_of_date": "2026-03-01",
-                    "period": "three_months",
-                    "frequency": "daily",
-                    "consumer_system": "lotus-performance",
-                    "page": {"page_size": 100},
-                },
+                f"{query_control_plane_base_url}/support/portfolios/{candidate_id}/overview",
+                None,
             ),
         ]
         for url in get_urls:
             try:
                 response = session.get(url, timeout=10)
             except requests.RequestException:
-                return False
+                return None
             if not (200 <= response.status_code < 300):
-                return False
+                return None
         for url, payload in post_checks:
             try:
-                response = session.post(url, json=payload, timeout=15)
+                response = session.get(url, timeout=15) if payload is None else session.post(
+                    url, json=payload, timeout=15
+                )
             except requests.RequestException:
-                return False
+                return None
             if not (200 <= response.status_code < 300):
-                return False
-        return True
+                return None
+        return _resolve_candidate_as_of_date(candidate_id)
 
     deadline = time.time() + timeout_seconds
     while time.time() < deadline:
@@ -224,8 +251,10 @@ def _resolve_runtime_ids(
             pass
 
         for candidate_id in candidate_ids:
-            if _portfolio_ready(candidate_id):
+            candidate_as_of_date = _portfolio_ready(candidate_id)
+            if candidate_as_of_date is not None:
                 resolved_portfolio_id = candidate_id
+                resolved_as_of_date = candidate_as_of_date
                 break
         if resolved_portfolio_id is not None:
             break
@@ -233,8 +262,14 @@ def _resolve_runtime_ids(
 
     if resolved_portfolio_id is None:
         raise RuntimeError(
-            "Latency profile could not resolve a query-ready portfolio before timeout. "
-            "Services were healthy, but portfolio-specific endpoints never became ready."
+            "Latency profile could not resolve a query-ready portfolio context before timeout. "
+            "Services were healthy, but no portfolio exposed a usable support business date or "
+            "fallback open date for latency profiling."
+        )
+    if resolved_as_of_date is None:
+        raise RuntimeError(
+            "Latency profile resolved a portfolio id but no usable as-of date. "
+            "Support overview and portfolio fallback metadata were both missing date anchors."
         )
 
     if resolved_portfolio_id != portfolio_id:
@@ -245,7 +280,7 @@ def _resolve_runtime_ids(
     try:
         response = session.post(
             f"{query_control_plane_base_url}/integration/benchmarks/catalog",
-            json={"as_of_date": "2026-03-01"},
+            json={"as_of_date": resolved_as_of_date.isoformat()},
             timeout=15,
         )
         if response.status_code == 200:
@@ -259,7 +294,11 @@ def _resolve_runtime_ids(
     except requests.RequestException:
         pass
 
-    return resolved_portfolio_id, resolved_benchmark_id
+    return RuntimeContext(
+        portfolio_id=resolved_portfolio_id,
+        benchmark_id=resolved_benchmark_id,
+        as_of_date=resolved_as_of_date,
+    )
 
 
 def _cases(
@@ -267,10 +306,14 @@ def _cases(
     event_replay_base_url: str,
     query_base_url: str,
     query_control_plane_base_url: str,
-    portfolio_id: str,
-    benchmark_id: str,
+    runtime_context: RuntimeContext,
     include_protected_ops: bool,
 ) -> list[EndpointCase]:
+    as_of_date = runtime_context.as_of_date.isoformat()
+    benchmark_window = {
+        "start_date": runtime_context.benchmark_window_start_date.isoformat(),
+        "end_date": as_of_date,
+    }
     baseline = [
         EndpointCase("ing_ready", "GET", f"{ingestion_base_url}/health/ready", None, 300),
         EndpointCase("qry_ready", "GET", f"{query_base_url}/health/ready", None, 240),
@@ -284,21 +327,21 @@ def _cases(
         EndpointCase(
             "portfolio_positions",
             "GET",
-            f"{query_base_url}/portfolios/{portfolio_id}/positions",
+            f"{query_base_url}/portfolios/{runtime_context.portfolio_id}/positions",
             None,
             280,
         ),
         EndpointCase(
             "portfolio_transactions",
             "GET",
-            f"{query_base_url}/portfolios/{portfolio_id}/transactions?limit=50",
+            f"{query_base_url}/portfolios/{runtime_context.portfolio_id}/transactions?limit=50",
             None,
             280,
         ),
         EndpointCase(
             "support_overview",
             "GET",
-            f"{query_control_plane_base_url}/support/portfolios/{portfolio_id}/overview",
+            f"{query_control_plane_base_url}/support/portfolios/{runtime_context.portfolio_id}/overview",
             None,
             240,
         ),
@@ -306,23 +349,23 @@ def _cases(
             "benchmark_catalog",
             "POST",
             f"{query_control_plane_base_url}/integration/benchmarks/catalog",
-            {"as_of_date": "2026-03-01"},
+            {"as_of_date": as_of_date},
             320,
         ),
         EndpointCase(
             "index_catalog",
             "POST",
             f"{query_control_plane_base_url}/integration/indices/catalog",
-            {"as_of_date": "2026-03-01"},
+            {"as_of_date": as_of_date},
             320,
         ),
         EndpointCase(
             "benchmark_market_series",
             "POST",
-            f"{query_control_plane_base_url}/integration/benchmarks/{benchmark_id}/market-series",
+            f"{query_control_plane_base_url}/integration/benchmarks/{runtime_context.benchmark_id}/market-series",
             {
-                "as_of_date": "2026-03-01",
-                "window": {"start_date": "2025-12-01", "end_date": "2026-03-01"},
+                "as_of_date": as_of_date,
+                "window": benchmark_window,
                 "frequency": "daily",
                 "include_components": True,
                 "series_fields": [
@@ -338,9 +381,9 @@ def _cases(
         EndpointCase(
             "analytics_portfolio_timeseries",
             "POST",
-            f"{query_control_plane_base_url}/integration/portfolios/{portfolio_id}/analytics/portfolio-timeseries",
+            f"{query_control_plane_base_url}/integration/portfolios/{runtime_context.portfolio_id}/analytics/portfolio-timeseries",
             {
-                "as_of_date": "2026-03-01",
+                "as_of_date": as_of_date,
                 "period": "one_year",
                 "frequency": "daily",
                 "consumer_system": "lotus-performance",
@@ -352,9 +395,9 @@ def _cases(
         EndpointCase(
             "analytics_position_timeseries",
             "POST",
-            f"{query_control_plane_base_url}/integration/portfolios/{portfolio_id}/analytics/position-timeseries",
+            f"{query_control_plane_base_url}/integration/portfolios/{runtime_context.portfolio_id}/analytics/position-timeseries",
             {
-                "as_of_date": "2026-03-01",
+                "as_of_date": as_of_date,
                 "period": "three_months",
                 "frequency": "daily",
                 "consumer_system": "lotus-performance",
@@ -398,8 +441,7 @@ def run_profile(
     event_replay_base_url: str,
     query_base_url: str,
     query_control_plane_base_url: str,
-    portfolio_id: str,
-    benchmark_id: str,
+    runtime_context: RuntimeContext,
     include_protected_ops: bool,
     warmup_runs: int,
     measured_runs: int,
@@ -412,8 +454,7 @@ def run_profile(
         event_replay_base_url,
         query_base_url,
         query_control_plane_base_url,
-        portfolio_id,
-        benchmark_id,
+        runtime_context,
         include_protected_ops,
     ):
         for _ in range(warmup_runs):
@@ -572,7 +613,7 @@ def main() -> int:
     )
 
     session = requests.Session()
-    resolved_portfolio_id, resolved_benchmark_id = _resolve_runtime_ids(
+    runtime_context = _resolve_runtime_ids(
         session,
         query_base_url=args.query_base_url,
         query_control_plane_base_url=args.query_control_plane_base_url,
@@ -591,8 +632,7 @@ def main() -> int:
         event_replay_base_url=args.event_replay_base_url,
         query_base_url=args.query_base_url,
         query_control_plane_base_url=args.query_control_plane_base_url,
-        portfolio_id=resolved_portfolio_id,
-        benchmark_id=resolved_benchmark_id,
+        runtime_context=runtime_context,
         include_protected_ops=args.include_protected_ops,
         warmup_runs=args.warmup_runs,
         measured_runs=args.measured_runs,

--- a/src/services/query_service/app/dtos/transaction_dto.py
+++ b/src/services/query_service/app/dtos/transaction_dto.py
@@ -33,7 +33,10 @@ class TransactionRecord(BaseModel):
     )
     settlement_date: Optional[datetime] = Field(
         None,
-        description="Transaction settlement timestamp when known.",
+        description=(
+            "Canonical settlement timestamp when known. Use alongside transaction_date to "
+            "differentiate trade booking from contractual or effective cash/value settlement."
+        ),
         examples=["2026-03-03T00:00:00Z"],
     )
     transaction_type: str = Field(..., description="Transaction type.", examples=["BUY"])

--- a/tests/integration/services/query_service/test_main_app.py
+++ b/tests/integration/services/query_service/test_main_app.py
@@ -280,6 +280,14 @@ async def test_openapi_describes_transaction_filters_and_not_found_examples(asyn
         if parameter["name"] == "instrument_id"
     )
     assert instrument_id["description"] == "Filter by a specific instrument identifier."
+    assert transactions["summary"] == "Get Transactions for a Portfolio"
+    assert (
+        schema["components"]["schemas"]["TransactionRecord"]["properties"]["settlement_date"][
+            "description"
+        ]
+        == "Canonical settlement timestamp when known. Use alongside transaction_date to "
+        "differentiate trade booking from contractual or effective cash/value settlement."
+    )
 
     not_found = transactions["responses"]["404"]["content"]["application/json"]["example"]
     assert not_found["detail"] == "Portfolio with id PORT-TXN-001 not found"

--- a/tests/integration/services/query_service/test_transactions_router.py
+++ b/tests/integration/services/query_service/test_transactions_router.py
@@ -93,6 +93,7 @@ async def test_get_transactions_success_with_sorting_and_filters(async_test_clie
     payload = response.json()
     assert payload["portfolio_id"] == "P1"
     assert payload["transactions"][0]["transaction_id"] == "T1"
+    assert payload["transactions"][0]["settlement_date"] == "2025-08-03T00:00:00"
     assert payload["transactions"][0]["gross_cost"] == "125.00"
     assert payload["transactions"][0]["trade_fee"] == "2.50"
     assert payload["transactions"][0]["trade_currency"] == "USD"
@@ -214,3 +215,61 @@ async def test_get_transactions_forwards_fx_filters(async_test_client):
         near_leg_group_id="FXSWAP-LTG-FX-2026-0001-NEAR",
         far_leg_group_id="FXSWAP-LTG-FX-2026-0001-FAR",
     )
+
+
+async def test_get_transactions_preserves_settlement_date_for_trade_cash_and_income_shapes(
+    async_test_client,
+):
+    client, mock_service = async_test_client
+    mock_service.get_transactions.return_value = PaginatedTransactionResponse(
+        portfolio_id="P1",
+        total=3,
+        skip=0,
+        limit=10,
+        transactions=[
+            TransactionRecord(
+                transaction_id="BUY-1",
+                transaction_date=datetime(2025, 8, 1, 0, 0, 0),
+                settlement_date=datetime(2025, 8, 3, 0, 0, 0),
+                transaction_type="BUY",
+                instrument_id="INST_BUY",
+                security_id="SEC_BUY",
+                quantity=10,
+                price=100,
+                gross_transaction_amount=1000,
+                currency="USD",
+            ),
+            TransactionRecord(
+                transaction_id="DEP-1",
+                transaction_date=datetime(2025, 8, 2, 0, 0, 0),
+                settlement_date=datetime(2025, 8, 2, 12, 0, 0),
+                transaction_type="DEPOSIT",
+                instrument_id="CASH_USD",
+                security_id="CASH_USD",
+                quantity=1,
+                price=1,
+                gross_transaction_amount=5000,
+                currency="USD",
+            ),
+            TransactionRecord(
+                transaction_id="INT-1",
+                transaction_date=datetime(2025, 8, 4, 0, 0, 0),
+                settlement_date=datetime(2025, 8, 5, 0, 0, 0),
+                transaction_type="INTEREST",
+                instrument_id="BOND_1",
+                security_id="BOND_1",
+                quantity=0,
+                price=0,
+                gross_transaction_amount=125,
+                currency="USD",
+            ),
+        ],
+    )
+
+    response = await client.get("/portfolios/P1/transactions")
+
+    assert response.status_code == 200
+    transactions = response.json()["transactions"]
+    assert transactions[0]["settlement_date"] == "2025-08-03T00:00:00"
+    assert transactions[1]["settlement_date"] == "2025-08-02T12:00:00"
+    assert transactions[2]["settlement_date"] == "2025-08-05T00:00:00"

--- a/tests/unit/scripts/test_latency_profile.py
+++ b/tests/unit/scripts/test_latency_profile.py
@@ -1,7 +1,10 @@
+from datetime import date
 from subprocess import CompletedProcess
 from unittest.mock import MagicMock
 
 from scripts.latency_profile import (
+    RuntimeContext,
+    _cases,
     _enforce_gate,
     _percentile_ms,
     _pick_identifier_from_payload,
@@ -66,6 +69,7 @@ def test_resolve_runtime_ids_overrides_from_catalogs() -> None:
     not_ready_response.status_code = 404
     ready_response = MagicMock()
     ready_response.status_code = 200
+    ready_response.json.return_value = {"business_date": "2026-02-28"}
     benchmark_response = MagicMock()
     benchmark_response.status_code = 200
     benchmark_response.json.return_value = {"benchmarks": [{"benchmark_id": "BMK_ABC"}]}
@@ -82,7 +86,7 @@ def test_resolve_runtime_ids_overrides_from_catalogs() -> None:
     session.get.side_effect = get_side_effect
     session.post.return_value = benchmark_response
 
-    portfolio_id, benchmark_id = _resolve_runtime_ids(
+    runtime_context = _resolve_runtime_ids(
         session,
         query_base_url="http://localhost:8201",
         query_control_plane_base_url="http://localhost:8202",
@@ -91,8 +95,9 @@ def test_resolve_runtime_ids_overrides_from_catalogs() -> None:
         timeout_seconds=5,
     )
 
-    assert portfolio_id == "PORT_123"
-    assert benchmark_id == "BMK_ABC"
+    assert runtime_context.portfolio_id == "PORT_123"
+    assert runtime_context.benchmark_id == "BMK_ABC"
+    assert runtime_context.as_of_date == date(2026, 2, 28)
 
 
 def test_resolve_runtime_ids_accepts_default_portfolio_when_ready(monkeypatch) -> None:
@@ -102,6 +107,7 @@ def test_resolve_runtime_ids_accepts_default_portfolio_when_ready(monkeypatch) -
     lookup_response.json.return_value = {"items": [{"portfolio_id": "DEMO_DPM_EUR_001"}]}
     ready_response = MagicMock()
     ready_response.status_code = 200
+    ready_response.json.return_value = {"business_date": "2026-03-01"}
     benchmark_response = MagicMock()
     benchmark_response.status_code = 200
     benchmark_response.json.return_value = {"benchmarks": [{"benchmark_id": "BMK_ABC"}]}
@@ -117,7 +123,7 @@ def test_resolve_runtime_ids_accepts_default_portfolio_when_ready(monkeypatch) -
     session.post.return_value = benchmark_response
     monkeypatch.setattr("scripts.latency_profile.time.sleep", lambda _: None)
 
-    portfolio_id, benchmark_id = _resolve_runtime_ids(
+    runtime_context = _resolve_runtime_ids(
         session,
         query_base_url="http://localhost:8201",
         query_control_plane_base_url="http://localhost:8202",
@@ -126,8 +132,60 @@ def test_resolve_runtime_ids_accepts_default_portfolio_when_ready(monkeypatch) -
         timeout_seconds=5,
     )
 
-    assert portfolio_id == "DEMO_DPM_EUR_001"
-    assert benchmark_id == "BMK_ABC"
+    assert runtime_context.portfolio_id == "DEMO_DPM_EUR_001"
+    assert runtime_context.benchmark_id == "BMK_ABC"
+    assert runtime_context.as_of_date == date(2026, 3, 1)
+
+
+def test_resolve_runtime_ids_falls_back_to_portfolio_open_date_when_support_business_date_missing(
+    monkeypatch,
+) -> None:
+    session = MagicMock()
+    lookup_response = MagicMock()
+    lookup_response.status_code = 200
+    lookup_response.json.return_value = {"items": [{"portfolio_id": "PORT_123"}]}
+    positions_response = MagicMock()
+    positions_response.status_code = 200
+    transactions_response = MagicMock()
+    transactions_response.status_code = 200
+    overview_response = MagicMock()
+    overview_response.status_code = 200
+    overview_response.json.return_value = {"business_date": None}
+    portfolio_response = MagicMock()
+    portfolio_response.status_code = 200
+    portfolio_response.json.return_value = {"open_date": "2025-01-15"}
+    benchmark_response = MagicMock()
+    benchmark_response.status_code = 200
+    benchmark_response.json.return_value = {"benchmarks": [{"benchmark_id": "BMK_ABC"}]}
+
+    def get_side_effect(url: str, timeout: int = 10):  # noqa: ARG001
+        if "/lookups/portfolios" in url:
+            return lookup_response
+        if "/positions" in url:
+            return positions_response
+        if "/transactions" in url:
+            return transactions_response
+        if "/support/portfolios/" in url:
+            return overview_response
+        if "/portfolios/PORT_123" in url:
+            return portfolio_response
+        return positions_response
+
+    session.get.side_effect = get_side_effect
+    session.post.return_value = benchmark_response
+    monkeypatch.setattr("scripts.latency_profile.time.sleep", lambda _: None)
+
+    runtime_context = _resolve_runtime_ids(
+        session,
+        query_base_url="http://localhost:8201",
+        query_control_plane_base_url="http://localhost:8202",
+        portfolio_id="DEMO_DPM_EUR_001",
+        benchmark_id="BMK_GLOBAL_BALANCED_60_40",
+        timeout_seconds=5,
+    )
+
+    assert runtime_context.portfolio_id == "PORT_123"
+    assert runtime_context.as_of_date == date(2025, 1, 15)
 
 
 def test_resolve_runtime_ids_raises_when_no_portfolio_becomes_ready(monkeypatch) -> None:
@@ -160,9 +218,44 @@ def test_resolve_runtime_ids_raises_when_no_portfolio_becomes_ready(monkeypatch)
             timeout_seconds=5,
         )
     except RuntimeError as exc:
-        assert "could not resolve a query-ready portfolio" in str(exc)
+        assert "could not resolve a query-ready portfolio context" in str(exc)
     else:
         raise AssertionError("Expected _resolve_runtime_ids to raise when no portfolio is ready.")
+
+
+def test_cases_use_runtime_context_dates_and_identifiers() -> None:
+    runtime_context = RuntimeContext(
+        portfolio_id="PORT_123",
+        benchmark_id="BMK_ABC",
+        as_of_date=date(2026, 3, 5),
+    )
+
+    cases = _cases(
+        ingestion_base_url="http://localhost:8200",
+        event_replay_base_url="http://localhost:8209",
+        query_base_url="http://localhost:8201",
+        query_control_plane_base_url="http://localhost:8202",
+        runtime_context=runtime_context,
+        include_protected_ops=False,
+    )
+
+    analytics_portfolio = next(
+        case for case in cases if case.name == "analytics_portfolio_timeseries"
+    )
+    analytics_position = next(
+        case for case in cases if case.name == "analytics_position_timeseries"
+    )
+    benchmark_series = next(case for case in cases if case.name == "benchmark_market_series")
+
+    assert "/portfolios/PORT_123/" in analytics_portfolio.url
+    assert analytics_portfolio.payload["as_of_date"] == "2026-03-05"
+    assert analytics_position.payload["as_of_date"] == "2026-03-05"
+    assert "/benchmarks/BMK_ABC/market-series" in benchmark_series.url
+    assert benchmark_series.payload["as_of_date"] == "2026-03-05"
+    assert benchmark_series.payload["window"] == {
+        "start_date": "2025-12-05",
+        "end_date": "2026-03-05",
+    }
 
 
 def test_raise_if_compose_service_failed_ignores_running_service(monkeypatch) -> None:

--- a/tests/unit/scripts/test_latency_profile.py
+++ b/tests/unit/scripts/test_latency_profile.py
@@ -258,6 +258,13 @@ def test_cases_use_runtime_context_dates_and_identifiers() -> None:
     }
 
 
+def test_context_timeout_must_not_be_shorter_than_ready_timeout() -> None:
+    ready_timeout_seconds = 180
+    context_timeout_seconds = 120
+
+    assert max(context_timeout_seconds, ready_timeout_seconds) == 180
+
+
 def test_raise_if_compose_service_failed_ignores_running_service(monkeypatch) -> None:
     def _fake_run(cmd, check=False, capture_output=False, text=False):  # noqa: ARG001
         if cmd[:5] == ["docker", "compose", "ps", "-a", "-q"]:

--- a/tests/unit/services/query_service/services/test_transaction_service.py
+++ b/tests/unit/services/query_service/services/test_transaction_service.py
@@ -119,9 +119,11 @@ async def test_get_transactions(mock_transaction_repo: AsyncMock):
         assert response_dto.limit == 10
         assert len(response_dto.transactions) == 2
         assert response_dto.transactions[0].transaction_id == "T1"
+        assert response_dto.transactions[0].settlement_date == datetime(2025, 1, 12)
         assert response_dto.transactions[0].trade_fee == Decimal("12.5")
         assert response_dto.transactions[0].trade_currency == "USD"
         assert response_dto.transactions[0].cash_entry_mode == "AUTO_GENERATE"
+        assert response_dto.transactions[1].settlement_date is None
         assert response_dto.transactions[1].cash_entry_mode == "UPSTREAM_PROVIDED"
         assert response_dto.transactions[1].external_cash_transaction_id == "CASH-ENTRY-2026-0002"
         assert response_dto.transactions[1].interest_direction == "INCOME"


### PR DESCRIPTION
## Summary
- widen the latency gate runtime-context window for seeded portfolio discovery in CI
- keep the stronger runtime-context logic from the merged follow-up while allowing hosted runners enough time for demo portfolio convergence

## Validation
- python -m pytest tests/unit/scripts/test_latency_profile.py -q

Supersedes #268.
