### PR TITLE
fix(ci): widen latency context window for seeded portfolios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,7 +403,7 @@ jobs:
         run: python scripts/prebuild_ci_images.py --cache-dir .buildx-cache --group latency-gate
 
       - name: Run endpoint latency gate
-        run: python scripts/latency_profile.py --context-timeout-seconds 300 --enforce
+        run: python scripts/latency_profile.py --context-timeout-seconds 600 --enforce
 
       - name: Capture docker compose logs on failure
         if: failure()


### PR DESCRIPTION
## Summary
- widen the latency gate runtime-context window for seeded portfolio discovery in CI
- keep the stronger runtime-context logic merged in #280 while allowing hosted runners enough time for demo portfolio convergence

## Validation
- python -m pytest tests/unit/scripts/test_latency_profile.py -q

Supersedes #268.
