### PR TITLE
fix(ci): wire demo seed loader to control plane service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -538,11 +538,11 @@ services:
     hostname: demo_data_loader
     environment:
       DEMO_DATA_PACK_ENABLED: ${DEMO_DATA_PACK_ENABLED:-true}
-      depends_on:
-        ingestion_service:
-          condition: service_healthy
-        query_service:
-          condition: service_healthy
+    depends_on:
+      ingestion_service:
+        condition: service_healthy
+      query_service:
+        condition: service_healthy
       query_control_plane_service:
         condition: service_healthy
       persistence_service:
@@ -551,12 +551,12 @@ services:
         condition: service_healthy
       valuation_orchestrator_service:
         condition: service_healthy
-        position_valuation_calculator:
-          condition: service_healthy
-        timeseries_generator_service:
-          condition: service_healthy
-        portfolio_aggregation_service:
-          condition: service_healthy
+      position_valuation_calculator:
+        condition: service_healthy
+      timeseries_generator_service:
+        condition: service_healthy
+      portfolio_aggregation_service:
+        condition: service_healthy
     command: >
       sh -c "
       if [ \"$$DEMO_DATA_PACK_ENABLED\" = \"false\" ]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -566,6 +566,7 @@ services:
       python -m tools.demo_data_pack
       --ingestion-base-url http://ingestion_service:8000
       --query-base-url http://query_service:8001
+      --query-control-plane-base-url http://query_control_plane_service:8002
       --force-ingest
       --wait-seconds 420
       --poll-interval-seconds 3

--- a/tests/unit/test_app_local_stack_contract.py
+++ b/tests/unit/test_app_local_stack_contract.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import yaml
 
-
 ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -47,3 +46,15 @@ def test_app_local_compose_keeps_local_overlay_services_available() -> None:
         "demo_data_loader",
     ]:
         assert service_name in services
+
+
+def test_demo_data_loader_uses_internal_service_urls() -> None:
+    compose = _read_yaml(ROOT / "docker-compose.yml")
+    command = compose["services"]["demo_data_loader"]["command"]
+
+    assert "--ingestion-base-url http://ingestion_service:8000" in command
+    assert "--query-base-url http://query_service:8001" in command
+    assert (
+        "--query-control-plane-base-url http://query_control_plane_service:8002"
+        in command
+    )

--- a/tests/unit/test_app_local_stack_contract.py
+++ b/tests/unit/test_app_local_stack_contract.py
@@ -50,7 +50,9 @@ def test_app_local_compose_keeps_local_overlay_services_available() -> None:
 
 def test_demo_data_loader_uses_internal_service_urls() -> None:
     compose = _read_yaml(ROOT / "docker-compose.yml")
-    command = compose["services"]["demo_data_loader"]["command"]
+    demo_loader = compose["services"]["demo_data_loader"]
+    command = demo_loader["command"]
+    depends_on = demo_loader["depends_on"]
 
     assert "--ingestion-base-url http://ingestion_service:8000" in command
     assert "--query-base-url http://query_service:8001" in command
@@ -58,3 +60,15 @@ def test_demo_data_loader_uses_internal_service_urls() -> None:
         "--query-control-plane-base-url http://query_control_plane_service:8002"
         in command
     )
+    assert "depends_on" not in demo_loader["environment"]
+    assert sorted(depends_on) == [
+        "ingestion_service",
+        "persistence_service",
+        "portfolio_aggregation_service",
+        "position_calculator_service",
+        "position_valuation_calculator",
+        "query_control_plane_service",
+        "query_service",
+        "timeseries_generator_service",
+        "valuation_orchestrator_service",
+    ]


### PR DESCRIPTION
## Summary
- fix the app-local compose contract so `demo_data_loader` depends on the real control plane service block, not malformed YAML
- wire the demo seed loader to the Docker-internal query control plane URL
- add a compose contract test that locks the three internal seed-loader base URLs

## Testing
- python -m pytest tests/unit/test_app_local_stack_contract.py -q
- python scripts/test_manifest.py --suite unit-db
- python scripts/test_manifest.py --suite transaction-buy-contract
- python -m ruff check tests/unit/test_app_local_stack_contract.py