### PR TITLE
fix(query): harden security-scoped transaction drill-down contract

### DIFF
--- a/docs/features/query_service/WEALTH-REPORTING-API-GUIDE.md
+++ b/docs/features/query_service/WEALTH-REPORTING-API-GUIDE.md
@@ -68,6 +68,15 @@ The response includes both canonical transaction attributes and reporting-releva
 - linked cashflow details
 - detailed transaction costs
 
+Security drill-down behavior:
+
+- use `security_id` to retrieve the transaction history for a specific holding inside the
+  portfolio
+- this is the source-backed contract for holdings workspace drill-down and "latest transaction for
+  this security" use cases
+- when callers do not override sorting, results are returned latest-first using
+  `transaction_date DESC`
+
 Settlement-date semantics:
 
 - `transaction_date` is the booked ledger date/time

--- a/src/services/query_service/app/routers/transactions.py
+++ b/src/services/query_service/app/routers/transactions.py
@@ -24,11 +24,13 @@ PORTFOLIO_NOT_FOUND_RESPONSE_EXAMPLE = {"detail": "Portfolio with id PORT-TXN-00
             "content": {"application/json": {"example": PORTFOLIO_NOT_FOUND_RESPONSE_EXAMPLE}},
         }
     },
-    summary="Get Transactions for a Portfolio",
+    summary="Get Portfolio Transactions",
     description=(
-        "Returns transactions for a portfolio with date-window filters, optional instrument "
-        "filtering, pagination, and sorting. Designed for transaction ledgers, audit timelines, "
-        "and investigative support."
+        "Returns the canonical portfolio transaction ledger with date-window filters, optional "
+        "instrument and security drill-down, pagination, and sorting. Use `security_id` for "
+        "holdings drill-down and latest transaction retrieval for a specific security within "
+        "the portfolio. Results default to latest-first ordering by `transaction_date` "
+        "descending unless `sort_by` and `sort_order` are provided explicitly."
     ),
 )
 async def get_transactions(
@@ -44,7 +46,10 @@ async def get_transactions(
     ),
     security_id: Optional[str] = Query(
         None,
-        description="Filter by a specific security ID.",
+        description=(
+            "Filter by a specific security identifier for holdings drill-down and latest "
+            "transaction retrieval within the portfolio."
+        ),
         examples=["SEC-US-IBM"],
     ),
     transaction_type: Optional[str] = Query(

--- a/tests/integration/services/query_service/test_main_app.py
+++ b/tests/integration/services/query_service/test_main_app.py
@@ -280,7 +280,24 @@ async def test_openapi_describes_transaction_filters_and_not_found_examples(asyn
         if parameter["name"] == "instrument_id"
     )
     assert instrument_id["description"] == "Filter by a specific instrument identifier."
-    assert transactions["summary"] == "Get Transactions for a Portfolio"
+    security_id = next(
+        parameter
+        for parameter in transactions["parameters"]
+        if parameter["name"] == "security_id"
+    )
+    assert security_id["description"] == (
+        "Filter by a specific security identifier for holdings drill-down and latest "
+        "transaction retrieval within the portfolio."
+    )
+    assert transactions["summary"] == "Get Portfolio Transactions"
+    assert (
+        "Use `security_id` for holdings drill-down and latest transaction retrieval for a "
+        "specific security within the portfolio."
+    ) in transactions["description"]
+    assert (
+        "Results default to latest-first ordering by `transaction_date` descending"
+        in transactions["description"]
+    )
     assert (
         schema["components"]["schemas"]["TransactionRecord"]["properties"]["settlement_date"][
             "description"

--- a/tests/integration/services/query_service/test_transactions_router.py
+++ b/tests/integration/services/query_service/test_transactions_router.py
@@ -178,6 +178,36 @@ async def test_get_transactions_forwards_as_of_and_include_projected(async_test_
     )
 
 
+async def test_get_transactions_for_security_drill_down_defaults_to_latest_first(
+    async_test_client,
+):
+    client, mock_service = async_test_client
+
+    response = await client.get("/portfolios/P1/transactions?security_id=SEC-HOLDING-1")
+
+    assert response.status_code == 200
+    mock_service.get_transactions.assert_awaited_once_with(
+        portfolio_id="P1",
+        instrument_id=None,
+        security_id="SEC-HOLDING-1",
+        transaction_type=None,
+        component_type=None,
+        linked_transaction_group_id=None,
+        fx_contract_id=None,
+        swap_event_id=None,
+        near_leg_group_id=None,
+        far_leg_group_id=None,
+        start_date=None,
+        end_date=None,
+        as_of_date=None,
+        include_projected=False,
+        skip=0,
+        limit=100,
+        sort_by=None,
+        sort_order="desc",
+    )
+
+
 async def test_get_transactions_forwards_fx_filters(async_test_client):
     client, mock_service = async_test_client
 

--- a/tests/unit/services/query_service/repositories/test_transaction_repository.py
+++ b/tests/unit/services/query_service/repositories/test_transaction_repository.py
@@ -53,6 +53,23 @@ async def test_get_transactions_default_sort(
     assert "ORDER BY transactions.transaction_date DESC" in compiled_query
 
 
+async def test_get_transactions_security_drill_down_defaults_to_latest_first(
+    repository: TransactionRepository, mock_db_session: AsyncMock
+):
+    await repository.get_transactions(
+        portfolio_id="P1",
+        security_id="SEC-HOLDING-1",
+        skip=0,
+        limit=25,
+    )
+
+    executed_stmt = mock_db_session.execute.call_args[0][0]
+    compiled_query = str(executed_stmt.compile(compile_kwargs={"literal_binds": True}))
+
+    assert "transactions.security_id = 'SEC-HOLDING-1'" in compiled_query
+    assert "ORDER BY transactions.transaction_date DESC" in compiled_query
+
+
 async def test_get_transactions_custom_sort(
     repository: TransactionRepository, mock_db_session: AsyncMock
 ):


### PR DESCRIPTION
## Summary
- clarify the portfolio transactions contract as the source-backed security-scoped drill-down API
- document latest-first default ordering semantics for holding-level retrieval
- add focused router, repository, and OpenAPI tests for the security-scoped query path

## Validation
- `python -m pytest tests/integration/services/query_service/test_transactions_router.py tests/unit/services/query_service/repositories/test_transaction_repository.py tests/integration/services/query_service/test_main_app.py -q`
- `python -m ruff check src/services/query_service/app/routers/transactions.py tests/integration/services/query_service/test_transactions_router.py tests/unit/services/query_service/repositories/test_transaction_repository.py tests/integration/services/query_service/test_main_app.py`

Fixes #285