### PR TITLE
fix(timeseries): harden bootstrap eligibility and front-office seed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,9 @@ x-lotus-stack-contract:
     - service-local-debugging
     - app-local-observability
 
+x-shared-python-env: &shared_python_env
+  PYTHONPATH: /app/src/libs/portfolio-common
+
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:7.5.0
@@ -120,6 +123,7 @@ services:
     ports:
       - "${LOTUS_INGESTION_HOST_PORT:-8200}:8000"
     environment:
+      <<: *shared_python_env
       KAFKA_BOOTSTRAP_SERVERS: kafka:9093
     depends_on:
       kafka:
@@ -155,6 +159,7 @@ services:
     ports:
       - "${LOTUS_QUERY_HOST_PORT:-8201}:8001"
     environment:
+      <<: *shared_python_env
       DATABASE_URL: ${QUERY_DATABASE_URL:-postgresql://user:password@postgres:5432/portfolio_db}
     depends_on:
       migration-runner:
@@ -182,6 +187,7 @@ services:
     ports:
       - "${LOTUS_QUERY_CONTROL_PLANE_HOST_PORT:-8202}:8002"
     environment:
+      <<: *shared_python_env
       DATABASE_URL: ${QUERY_DATABASE_URL:-postgresql://user:password@postgres:5432/portfolio_db}
     depends_on:
       migration-runner:
@@ -210,6 +216,7 @@ services:
     ports:
       - "${LOTUS_EVENT_REPLAY_HOST_PORT:-8209}:8009"
     environment:
+      <<: *shared_python_env
       KAFKA_BOOTSTRAP_SERVERS: kafka:9093
       DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@postgres:5432/portfolio_db}
     depends_on:
@@ -241,6 +248,7 @@ services:
     ports:
       - "${LOTUS_FINANCIAL_RECONCILIATION_HOST_PORT:-8210}:8010"
     environment:
+      <<: *shared_python_env
       DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@postgres:5432/portfolio_db}
     depends_on:
       migration-runner:
@@ -268,6 +276,7 @@ services:
     ports:
       - "${LOTUS_PERSISTENCE_HOST_PORT:-8080}:8080"
     environment:
+      <<: *shared_python_env
       KAFKA_BOOTSTRAP_SERVERS: kafka:9093
       DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@postgres:5432/portfolio_db}
     depends_on:
@@ -298,6 +307,7 @@ services:
     ports:
       - "${LOTUS_COST_CALCULATOR_HOST_PORT:-8083}:8083"
     environment:
+      <<: *shared_python_env
       KAFKA_BOOTSTRAP_SERVERS: kafka:9093
       DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@postgres:5432/portfolio_db}
     depends_on:
@@ -328,6 +338,7 @@ services:
     ports:
      - "${LOTUS_CASHFLOW_CALCULATOR_HOST_PORT:-8082}:8082"
     environment:
+      <<: *shared_python_env
       KAFKA_BOOTSTRAP_SERVERS: kafka:9093
       DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@postgres:5432/portfolio_db}
     depends_on:
@@ -358,6 +369,7 @@ services:
     ports:
       - "${LOTUS_POSITION_CALCULATOR_HOST_PORT:-8081}:8081"
     environment:
+      <<: *shared_python_env
       KAFKA_BOOTSTRAP_SERVERS: kafka:9093
       DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@postgres:5432/portfolio_db}
     depends_on:
@@ -388,6 +400,7 @@ services:
     ports:
       - "${LOTUS_PIPELINE_ORCHESTRATOR_HOST_PORT:-8086}:8086"
     environment:
+      <<: *shared_python_env
       KAFKA_BOOTSTRAP_SERVERS: kafka:9093
       DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@postgres:5432/portfolio_db}
     depends_on:
@@ -418,6 +431,7 @@ services:
     ports:
       - "${LOTUS_VALUATION_ORCHESTRATOR_HOST_PORT:-8087}:8087"
     environment:
+      <<: *shared_python_env
       KAFKA_BOOTSTRAP_SERVERS: kafka:9093
       DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@postgres:5432/portfolio_db}
       VALUATION_SCHEDULER_POLL_INTERVAL: 2
@@ -449,6 +463,7 @@ services:
     ports:
       - "${LOTUS_POSITION_VALUATION_HOST_PORT:-8084}:8084"
     environment:
+      <<: *shared_python_env
       KAFKA_BOOTSTRAP_SERVERS: kafka:9093
       DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@postgres:5432/portfolio_db}
     depends_on:
@@ -479,6 +494,7 @@ services:
     ports:
       - "${LOTUS_TIMESERIES_GENERATOR_HOST_PORT:-8085}:8085"
     environment:
+      <<: *shared_python_env
       KAFKA_BOOTSTRAP_SERVERS: kafka:9093
       DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@postgres:5432/portfolio_db}
     depends_on:
@@ -509,6 +525,7 @@ services:
     ports:
       - "${LOTUS_PORTFOLIO_AGGREGATION_HOST_PORT:-8088}:8088"
     environment:
+      <<: *shared_python_env
       KAFKA_BOOTSTRAP_SERVERS: kafka:9093
       DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@postgres:5432/portfolio_db}
     depends_on:

--- a/docs/operations/Front-Office-Portfolio-Seed-Contract.md
+++ b/docs/operations/Front-Office-Portfolio-Seed-Contract.md
@@ -1,0 +1,407 @@
+# Front-Office Portfolio Seed Contract
+
+This document defines the target local seed scenario that should be implemented
+in `lotus-core` so gateway and UI teams can build against one realistic,
+feature-complete portfolio instead of a narrow benchmark-only seed.
+
+This is not a generic demo pack requirement. It is a product-development seed
+contract for a single high-value front-office workstation example.
+
+## Objective
+
+Create one realistic discretionary private-banking portfolio seed that can
+surface the majority of current `lotus-core`, `lotus-performance`, gateway, and
+UI features without depending on fake placeholder states.
+
+The seed must support:
+
+- summary-first portfolio workspace
+- holdings and transaction drill-down
+- allocation views
+- liquidity and projected cashflow
+- readiness and exception handling
+- benchmark-linked performance summary
+- benchmark-linked performance analysis
+- performance evidence expansion later
+
+## Seed Design Principles
+
+- one real portfolio scenario is better than many shallow demos
+- data should be business-coherent, not just API-complete
+- each seeded module must support at least one real UI action or drill-down
+- exceptions must be intentional and explainable, not random corruption
+- the seed must be rerunnable and deterministic in local development
+- the seed must not require `lotus-manage`
+
+## Recommended Reference Scenario
+
+Use one discretionary multi-asset relationship-book portfolio with:
+
+- base currency: `USD`
+- client domicile / booking context outside the US
+- multi-currency holdings and cash
+- benchmark assignment
+- funded cash balances
+- income-producing assets
+- fixed income with accrual behavior
+- recent activity across multiple transaction types
+- full valuation coverage through the active analysis window
+
+Recommended example:
+
+- portfolio id: `PB_SG_GLOBAL_BAL_001`
+- client id: `CIF_SG_000184`
+- portfolio display name: `Global Balanced Mandate`
+- client display name: `Anjali Raman`
+- relationship manager id: `RM_SG_001`
+- booking centre: `Singapore`
+- strategy: global balanced discretionary mandate
+- portfolio type: `Discretionary`
+
+## Minimum Product Surface Coverage
+
+The seed must make the following product surfaces materially usable.
+
+### Portfolio context and overview
+
+- portfolio identity
+- client identity
+- booking setup
+- base/reporting currency
+- opened date
+- relationship manager
+
+### Holdings and valuation
+
+- at least 10 current positions
+- mix of:
+  - cash
+  - equities
+  - funds
+  - fixed income
+- non-zero valuations
+- multi-currency valuations translated into reporting currency
+- current holdings must all remain valued through the active analysis window
+- use proper security identifiers and proper display names, not placeholder
+  `MANUAL_*` or `SEC_*` codes in the front-office seed
+
+### Allocation
+
+- asset class allocation
+- sector allocation
+- region allocation
+- currency allocation
+- enough instrument metadata to make allocation filters meaningful
+
+### Transactions and activity
+
+- at least 25-40 transactions across the portfolio lifecycle
+- transaction types should include:
+  - cash funding / inflow
+  - buys
+  - sells
+  - dividend
+  - interest
+  - fee
+  - tax / withholding
+  - FX-related funding or cross-currency settlement where relevant
+- transactions should cover both historical onboarding and recent activity
+- at least one recent transaction window should power activity summaries
+
+### Income
+
+- dividend income
+- coupon / interest income
+- deductions or withholding on at least one income event
+- net and gross income should differ for at least one event
+
+### Liquidity and cashflow
+
+- multiple cash accounts
+- projected cash movements over a forward window
+- future-dated settlement activity or projected cash events
+- benchmark and FX coverage through the forward validation horizon so next-day
+  analytics requests do not fail on missing reference data
+- enough data to show:
+  - current available cash
+  - cash by currency
+  - projected net flow
+  - end-of-window liquidity
+
+### Performance and benchmark
+
+- benchmark assignment effective before portfolio open date or before the
+  analysis window starts
+- daily price history for all relevant securities
+- daily FX for all required currency pairs
+- portfolio timeseries coverage across:
+  - 7D
+  - 30D
+  - MTD
+  - QTD
+  - YTD
+  - 1Y when enough synthetic history exists
+- benchmark-linked summary:
+  - portfolio return
+  - benchmark return
+  - active return
+  - money-weighted return
+- analysis detail:
+  - return path chart
+  - multi-horizon panel
+  - contributors
+  - attribution
+
+### Exceptions and readiness
+
+This canonical portfolio seed must remain analytically usable end to end.
+
+Do not introduce stale-price or missing-price conditions into the primary
+portfolio seed if they would cap `performance_end_date` or distort benchmark,
+contribution, or attribution outputs.
+
+If readiness/error flows need explicit coverage, seed them in a separate
+operator scenario rather than degrading the primary front-office reference
+portfolio.
+
+## Data Shape Requirements
+
+### Instrument metadata
+
+Each non-cash instrument should have enough metadata to support:
+
+- asset class
+- sector
+- region / country
+- instrument type
+- currency
+- issuer or security name
+- benchmark attribution group where relevant
+
+The seed should use proper business labels, for example:
+
+- `asset_class`
+  - `Equity`
+  - `Fixed Income`
+  - `Fund`
+  - `Cash`
+- `sector`
+  - `Information Technology`
+  - `Government`
+  - `Multi-Asset`
+  - `Financials`
+- `region`
+  - `North America`
+  - `Europe`
+  - `Global`
+- `country_of_risk`
+  - `United States`
+  - `Germany`
+  - `Ireland`
+  - `Netherlands`
+- `issuer_name`
+  - `Apple Inc.`
+  - `Microsoft Corporation`
+  - `United States Treasury`
+  - `BlackRock`
+  - `PIMCO`
+  - `Siemens Financieringsmaatschappij NV`
+
+Avoid placeholder values such as:
+
+- `MANUAL_*`
+- `SEC_*`
+- `FUND_1`
+- `BOND_A`
+- generic lower-quality labels like `global` when the business label should be
+  `Global`
+
+Recommended seeded current universe:
+
+- `CASH_USD_BOOK_OPERATING`
+  - display name: `USD Operating Cash`
+- `CASH_EUR_BOOK_OPERATING`
+  - display name: `EUR Operating Cash`
+- `US0378331005`
+  - display name: `Apple Inc.`
+- `US5949181045`
+  - display name: `Microsoft Corporation`
+- `DE0007164600`
+  - display name: `SAP SE`
+- `IE00B4L5Y983`
+  - display name: `iShares Core MSCI World UCITS ETF`
+- `LU0171301533`
+  - display name: `BlackRock Global Allocation Fund`
+- `IE00B11XZ103`
+  - display name: `PIMCO GIS Income Fund`
+- `US91282CHP95`
+  - display name: `United States Treasury 3.875% 2030`
+- `XS2671347285`
+  - display name: `Siemens Financieringsmaatschappij NV 2.500% 2031`
+- `Private Credit Opportunities Fund A`
+
+### History depth
+
+The current manual seed is too short for a realistic performance workstation.
+
+Target minimum history depth:
+
+- prices and FX: 12 months
+- benchmark series: 12 months
+- transactions: at least 3-6 months of realistic activity
+- FX and benchmark component/reference coverage should extend through the active
+  forward cashflow validation horizon, not stop exactly at the report end date
+
+That does not require 12 months of dense transaction flow. It does require
+enough historical market series to make the performance periods meaningful.
+
+### Cross-currency coverage
+
+At minimum support:
+
+- USD
+- EUR
+
+The preferred seed shape is:
+
+- base currency: USD
+- reporting currencies exercised: USD and EUR
+- holdings currencies: USD and EUR
+- optional third-currency exposure only if it drives a real product feature
+  under active development
+
+If the portfolio keeps the current Singapore context, use that as booking and
+client context, not as a reason to add unnecessary FX complexity.
+
+## Transaction Semantics
+
+The seeded transactions should use meaningful business semantics and labels.
+
+Recommended transaction storyline:
+
+- initial funding into USD operating cash
+- staged deployment into:
+  - US equities
+  - global allocation fund
+  - income fund
+  - sovereign bond
+  - corporate bond
+- one partial trim / profit-taking sale
+- one dividend receipt
+- one coupon or interest receipt
+- one advisory or custody fee
+- one withholding-tax event
+- one future-dated settlement or projected cash event
+
+Each transaction should carry meaningful values for all attributes that affect
+downstream surfaces, including where supported:
+
+- transaction type
+- trade date
+- settlement date
+- trade currency
+- gross amount
+- quantity
+- price
+- fees
+- taxes / withholding
+- narrative or reference
+
+Avoid ambiguous paired fake cash rows if a clearer cash-movement contract is
+available in the current ingest model.
+
+## Required Downstream Behaviors
+
+The seed is acceptable only if it supports these behaviors end to end.
+
+### Portfolio workspace
+
+- summary KPIs are populated
+- holdings grid is populated
+- top holdings is populated
+- allocation is populated
+- activity summary is populated
+- income summary is populated
+- projected cashflow is populated
+- readiness shows either zero or a small intentional number of explainable
+  exceptions
+
+### Drill-downs
+
+- clicking a holding can resolve related transactions
+- clicking an activity bucket returns a filtered transaction set
+- clicking an allocation bucket returns a filtered holdings set
+- clicking readiness exceptions resolves the affected securities or holdings set
+
+### Performance workspace
+
+- summary mode is populated
+- analysis mode is populated
+- evidence mode may still be placeholder, but the underlying calculation and
+  lineage-ready fields should not be structurally blocked by missing benchmark
+  data
+
+## Non-Goals
+
+This seed does not need to simulate every future feature.
+
+It does not need:
+
+- proposal generation
+- suitability
+- recommendation engine outputs
+- `lotus-manage` workflows
+- every possible transaction type in the platform
+
+It does need to cover the current gateway/UI build path honestly and
+meaningfully.
+
+## Implementation Recommendation
+
+Implement this as a new dedicated seed tool in `lotus-core`, separate from the
+current narrow benchmark patch tool.
+
+Recommended shape:
+
+- keep `tools/manual_performance_seed.py` as the focused benchmark-repair tool
+- add a new tool for the broader scenario, for example:
+  - `tools/front_office_portfolio_seed.py`
+
+That tool should:
+
+1. seed or refresh the portfolio master and context
+2. seed instruments with classification coverage
+3. seed historical transactions
+4. seed prices and FX with enough history depth
+5. seed benchmark definitions, compositions, return series, and assignments
+6. wait for downstream calculators
+7. run a governed validation checklist across core, performance, and gateway
+
+## Validation Contract
+
+The future seed tool should validate at least:
+
+- positions non-empty
+- cash balances non-empty
+- transactions non-empty
+- allocation views non-empty
+- income summary non-empty
+- activity summary non-empty
+- projected cashflow non-empty
+- benchmark assignment non-empty
+- portfolio timeseries non-empty
+- gateway performance summary non-empty
+- gateway performance details non-empty
+
+## Current Gap
+
+Today we have:
+
+- a manual portfolio bootstrap
+- a separate manual benchmark/performance patch seed
+
+That is enough to unblock narrow UI development, but not enough to provide one
+realistic front-office example covering the product surface coherently.
+
+This contract exists to close that gap with one governed seed scenario rather
+than more ad hoc local fixes.

--- a/docs/operations/Front-Office-Portfolio-Seed-Runbook.md
+++ b/docs/operations/Front-Office-Portfolio-Seed-Runbook.md
@@ -1,0 +1,116 @@
+# Front-Office Portfolio Seed Runbook
+
+This runbook seeds one realistic discretionary portfolio scenario for local
+gateway and UI development.
+
+Use this when you need one portfolio that exercises:
+
+- portfolio context
+- holdings
+- transactions
+- allocation
+- cash balances
+- income summary
+- activity summary
+- benchmark-linked performance
+- forward projected cashflow
+
+This runbook is local-only and does not depend on `lotus-manage`.
+
+## Seeded Portfolio
+
+- portfolio id: `PB_SG_GLOBAL_BAL_001`
+- client id: `CIF_SG_000184`
+- booking centre: `Singapore`
+- mandate: global balanced discretionary
+- base currency: `USD`
+
+## What This Seed Includes
+
+- 10+ current positions
+- USD and EUR cash accounts
+- funded USD and EUR sleeves with no structural negative operating cash
+- equities, funds, and fixed income
+- 12 months of market prices and EUR/USD FX
+- benchmark assignment and benchmark reference data
+- income, fee, tax, sell, and withdrawal activity
+- one future-dated withdrawal inside the forward cashflow horizon
+- canonical paired product-and-cash transactions aligned with the core demo ingest pattern
+- full valuation coverage through the report end date so performance analytics remain valid
+- FX and benchmark component coverage through the forward validation window so
+  next-day analytics requests remain valid
+
+## Operator Command
+
+Run from the `lotus-core` repo root:
+
+```powershell
+python tools/front_office_portfolio_seed.py `
+  --portfolio-id PB_SG_GLOBAL_BAL_001 `
+  --start-date 2025-03-31 `
+  --end-date 2026-03-28 `
+  --benchmark-start-date 2025-01-06 `
+  --wait-seconds 300
+```
+
+## Validation Performed By The Tool
+
+The tool ingests the portfolio bundle plus benchmark reference data and then
+verifies:
+
+- positions are populated
+- valued positions are populated
+- transactions are populated
+- cash accounts are populated
+- allocation views are populated
+- income summary is populated
+- activity summary is populated
+- projected cashflow contains at least one non-zero future point
+- benchmark assignment resolves
+- gateway performance summary resolves with benchmark-linked content
+
+## Validation Evidence
+
+The current seeded scenario was validated directly against the local stack with
+these outcomes:
+
+- `lotus-core query_service`
+  - positions: `11`
+  - transactions: `30`, including future transaction
+    `TXN-WITHDRAWAL-FUTURE-001`
+  - cashflow projection: `31` points with one non-zero point on `2026-04-07`
+    for `-18000`
+  - allocation views: `asset_class`, `sector`, `region`, `currency`
+  - income summary:
+    - gross `2130.75 USD`
+    - net `2037.00 USD`
+  - activity summary:
+    - inflows `40000 USD`
+    - outflows `25000 USD`
+    - fees `275 USD`
+    - taxes `81.75 USD`
+- `lotus-core query_control_plane`
+  - benchmark assignment resolves to `BMK_PB_GLOBAL_BALANCED_60_40`
+  - analytics reference resolves:
+    - `resolved_as_of_date = 2026-03-29`
+    - `performance_end_date = 2026-03-29`
+- `lotus-performance`
+  - `POST /performance/workspace-summary` succeeds for
+    `report_end_date = 2026-03-29`
+  - YTD net portfolio return is populated
+  - benchmark return is populated
+  - contribution and attribution blocks are returned through the workspace
+    contract
+- `lotus-gateway`
+  - performance summary, details, horizon comparison, and attribution trend all
+    resolve for `PB_SG_GLOBAL_BAL_001`
+  - projected cashflow resolves with a non-zero total net flow of `-18000`
+
+## Related Documents
+
+- seed contract:
+  - [Front-Office-Portfolio-Seed-Contract.md](/C:/Users/Sandeep/projects/lotus-core/docs/operations/Front-Office-Portfolio-Seed-Contract.md)
+- benchmark repair seed:
+  - [Manual-Portfolio-Performance-Benchmark-Seed-Runbook.md](/C:/Users/Sandeep/projects/lotus-core/docs/operations/Manual-Portfolio-Performance-Benchmark-Seed-Runbook.md)
+- tool:
+  - [front_office_portfolio_seed.py](/C:/Users/Sandeep/projects/lotus-core/tools/front_office_portfolio_seed.py)

--- a/docs/operations/Manual-Portfolio-Performance-Benchmark-Seed-Runbook.md
+++ b/docs/operations/Manual-Portfolio-Performance-Benchmark-Seed-Runbook.md
@@ -7,22 +7,46 @@ manual portfolio performance workstation to return benchmark-linked data for:
 - gateway performance summary/details
 - `lotus-performance` stateful portfolio analytics inputs
 
-This runbook is intentionally local-stack scoped. It does not depend on `lotus-manage`.
+This runbook is intentionally app-local scoped. It does not depend on
+`lotus-manage`.
 
-## Problem This Fixes
+This is a narrow repair runbook for benchmark-linked performance enablement. It
+is not the full front-office seed target. For the broader realistic seed
+contract that should support gateway and UI development across the portfolio and
+performance workspaces, see:
 
-The manual portfolio bootstrap created:
+- [Front-Office-Portfolio-Seed-Contract.md](/C:/Users/Sandeep/projects/lotus-core/docs/operations/Front-Office-Portfolio-Seed-Contract.md)
 
-- portfolio, instrument, transaction, and current market-value state
+## Safety Scope
 
-but it did not create the historical reference inputs required by `lotus-performance`:
+This runbook is for local development and local validation only.
+
+It is not approved for shared environments, QA environments, or production-like
+data stores because the seed tool performs direct cleanup of previously seeded
+benchmark rows before re-ingesting them.
+
+Do not run this tool against any database you are not prepared to modify
+destructively for the seeded benchmark ids.
+
+## Purpose
+
+The manual portfolio bootstrap creates:
+
+- portfolio
+- instruments
+- transactions
+- current market-value state
+
+but it does not create the historical reference inputs required by
+`lotus-performance`:
 
 - business-date coverage for the manual performance window
-- daily market prices for the manual securities
+- daily market prices for the seeded manual securities
 - daily EUR/USD FX coverage across the same window
-- benchmark assignment, definitions, components, and return/reference series
+- benchmark assignment, definitions, compositions, and return/reference series
 
-Without those inputs, the live gateway performance endpoints returned empty or partial payloads with errors such as:
+Without those inputs, the live gateway performance endpoints return empty or
+partial payloads with errors such as:
 
 - `Missing FX rate for EUR/USD on 2026-03-03`
 - `No effective benchmark assignment found for portfolio and as_of_date`
@@ -31,9 +55,11 @@ Without those inputs, the live gateway performance endpoints returned empty or p
 
 ## Preconditions
 
-The local stack must already be up:
+The following services must already be running:
 
-- `lotus-core` ingestion/query/query-control-plane
+- `lotus-core` ingestion service
+- `lotus-core` query service
+- `lotus-core` query control plane
 - `lotus-performance`
 - `lotus-gateway`
 
@@ -42,6 +68,10 @@ Expected local endpoints:
 - ingestion: `http://127.0.0.1:8200`
 - query control plane: `http://127.0.0.1:8202`
 - gateway: `http://127.0.0.1:8100`
+
+The following portfolio must already exist from the manual portfolio bootstrap:
+
+- `MANUAL_PB_USD_001`
 
 ## Operator Command
 
@@ -60,9 +90,10 @@ python tools/manual_performance_seed.py `
 
 The tool:
 
-1. deletes any existing local benchmark seed rows for the target benchmark and its component indices
+1. deletes any existing local benchmark seed rows for the target benchmark and
+   its component indices
 2. ingests business dates for the manual valuation window
-3. ingests daily market prices for the 9 manual portfolio instruments
+3. ingests daily market prices for the seeded manual instruments
 4. ingests calendar-daily EUR/USD and USD/EUR FX
 5. ingests benchmark reference data:
    - index definitions
@@ -82,15 +113,27 @@ The tool:
 
 The benchmark reference seed is local-runbook data, not production-sourced data.
 
-The tool deletes the prior rows for this local benchmark seed before re-ingesting them so the run remains deterministic. Without cleanup, duplicate local benchmark rows can produce:
+The tool deletes the prior rows for this local benchmark seed before
+re-ingesting them so the run remains deterministic. Without cleanup, duplicate
+local benchmark rows can produce:
 
 - duplicate benchmark options
 - duplicate component observations
 - non-deterministic benchmark selection
 
-## Seed Scope
+Use `--skip-cleanup` only if you are debugging ingestion behavior and explicitly
+want to preserve the currently seeded benchmark rows. Do not use
+`--skip-cleanup` for the normal rerun path.
 
-Current seeded instrument universe:
+## Seed Contract
+
+This runbook asserts the following seeded scope.
+
+### Portfolio
+
+- `MANUAL_PB_USD_001`
+
+### Instrument universe
 
 - `CASH_EUR_MANUAL_PB_001`
 - `CASH_USD_MANUAL_PB_001`
@@ -102,70 +145,112 @@ Current seeded instrument universe:
 - `FI_EU_SIEMENS_2031_MANUAL_001`
 - `FI_US_TSY_2030_MANUAL_001`
 
-Current seeded benchmark:
+### Benchmark scope
 
-- `BMK_GLOBAL_BALANCED_60_40`
+- benchmark: `BMK_GLOBAL_BALANCED_60_40`
+- component indices:
+  - `IDX_GLOBAL_EQUITY_TR`
+  - `IDX_GLOBAL_BOND_TR`
+- benchmark effective start date:
+  - `2026-01-05`
 
-Current seeded component indices:
+### Time window
 
-- `IDX_GLOBAL_EQUITY_TR`
-- `IDX_GLOBAL_BOND_TR`
+- valuation window:
+  - `2026-03-03` to `2026-03-28`
+- benchmark coverage must extend through the requested as-of date
 
-## Live Validation Performed
+### Downstream APIs that must become usable
 
-After running the tool, the following live validations succeeded:
+- `POST /integration/portfolios/{portfolio_id}/benchmark-assignment`
+- `POST /integration/portfolios/{portfolio_id}/analytics/portfolio-timeseries`
+- `GET /api/v1/workbench/{portfolio_id}/performance/summary`
+- `GET /api/v1/workbench/{portfolio_id}/performance/details`
+
+## Happy Path Validation
+
+Run these checks after the seed completes.
 
 ### 1. Benchmark assignment resolves
 
+Request:
+
 `POST http://127.0.0.1:8202/integration/portfolios/MANUAL_PB_USD_001/benchmark-assignment`
 
-Observed result:
+Pass criteria:
 
-- `200`
+- HTTP `200`
 - `benchmark_id = BMK_GLOBAL_BALANCED_60_40`
 - `effective_from = 2026-01-05`
 
+Fail criteria:
+
+- any `4xx` or `5xx`
+- null or empty benchmark assignment
+- assignment start date later than the requested as-of date
+
 ### 2. Portfolio analytics timeseries resolves
+
+Request:
 
 `POST http://127.0.0.1:8202/integration/portfolios/MANUAL_PB_USD_001/analytics/portfolio-timeseries`
 
-Observed result:
+Pass criteria:
 
-- `200`
+- HTTP `200`
 - resolved window `2026-03-03` to `2026-03-28`
-- `returned_row_count = 26`
+- non-zero `returned_row_count`
 - `performance_end_date = 2026-03-28`
+
+Fail criteria:
+
+- empty timeseries payload
+- timeseries stops before the requested end date
+- FX-related failure
 
 ### 3. Gateway performance summary resolves with benchmark-linked data
 
+Request:
+
 `GET http://127.0.0.1:8100/api/v1/workbench/MANUAL_PB_USD_001/performance/summary?period=YTD&chart_frequency=monthly&contribution_dimension=asset_class&attribution_dimension=asset_class&detail_basis=NET`
 
-Observed result:
+Pass criteria:
 
-- `200`
+- HTTP `200`
 - `benchmark_code = BMK_GLOBAL_BALANCED_60_40`
 - net performance block populated
 - benchmark return populated
 - money-weighted return populated
 
-Observed example values at validation time:
+Important interpretation rule:
 
-- `portfolio_return_pct = 47475.898496`
-- `benchmark_return_pct = 3.833325`
-- `active_return_pct = 47472.065171`
-- `money_weighted_return_pct = 6.625621`
+This runbook does not assert specific portfolio return magnitudes as the
+success criterion. A numerically implausible performance value is a warning that
+the performance calculation path may still need review, but it does not mean the
+benchmark seed itself failed.
+
+Treat values like `47475.898496%` as suspicious and escalate them separately as
+a calculation-quality issue, not as proof that the seed run failed.
 
 ### 4. Gateway performance details resolves with analytical content
 
+Request:
+
 `GET http://127.0.0.1:8100/api/v1/workbench/MANUAL_PB_USD_001/performance/details?period=YTD&chart_frequency=monthly&contribution_dimension=asset_class&attribution_dimension=asset_class&detail_basis=NET`
 
-Observed result:
+Pass criteria:
 
-- `200`
+- HTTP `200`
 - `benchmark_code = BMK_GLOBAL_BALANCED_60_40`
 - `net_chart` populated
 - `contribution` populated
 - `attribution` populated
+
+Fail criteria:
+
+- benchmark code missing
+- chart block empty
+- contribution or attribution blocks empty
 
 ## Known Non-Blocking Warning
 
@@ -175,11 +260,25 @@ The gateway performance responses may still contain:
 
 with a partial failure from `lotus-manage`.
 
-That warning does not block the benchmark-linked performance data seeded by this runbook. This runbook is specifically for making the performance UI usable without depending on `lotus-manage`.
+That warning does not block the benchmark-linked performance data seeded by this
+runbook. This runbook is specifically for making the performance UI usable
+without depending on `lotus-manage`.
 
-## Regression Check
+## Troubleshooting Matrix
 
-If the performance endpoints regress back to empty state, check in this order:
+| Symptom | Likely cause | Corrective action |
+| --- | --- | --- |
+| `Missing FX rate for EUR/USD ...` | FX series not ingested or window too short | rerun the seed without `--skip-cleanup`; verify `/ingest/fx-rates` completed and the start/end dates cover the requested window |
+| `No effective benchmark assignment found ...` | benchmark assignment missing or effective date too late | verify benchmark assignment response; rerun with the correct `--benchmark-start-date` |
+| `Benchmark composition window does not cover requested date ...` | benchmark composition/reference series do not extend far enough back or forward | rerun with the correct benchmark start date and ensure the requested end date is still inside seeded coverage |
+| `Benchmark market-series coverage is incomplete` | index price/return series were not fully ingested | rerun the seed and confirm the benchmark/index ingestion steps completed |
+| performance summary/details return `200` but benchmark fields are empty | gateway is reachable but seed contract is incomplete | check benchmark assignment first, then timeseries, then benchmark series coverage |
+| performance summary returns implausible return magnitudes | benchmark seed succeeded but the calculation path may still be wrong | treat as a separate performance-methodology defect; do not rewrite the seed runbook to normalize implausible outputs |
+
+## Regression Check Order
+
+If the performance endpoints regress back to empty or partial state, check in
+this order:
 
 1. benchmark assignment:
    - `POST /integration/portfolios/{portfolio_id}/benchmark-assignment`
@@ -189,7 +288,8 @@ If the performance endpoints regress back to empty state, check in this order:
    - benchmark definitions
    - benchmark composition rows
    - index/benchmark series coverage through the requested end date
-4. local valuation/aggregation catch-up after ingestion
+4. local valuation and aggregation catch-up after ingestion
+5. gateway performance summary/details payload shape
 
 ## Source Files
 

--- a/src/libs/portfolio-common/portfolio_common/timeseries_repository_base.py
+++ b/src/libs/portfolio-common/portfolio_common/timeseries_repository_base.py
@@ -111,6 +111,8 @@ class TimeseriesRepositoryBase:
         p1 = PortfolioAggregationJob
         p2 = aliased(PortfolioAggregationJob)
         pts = PortfolioTimeseries
+        p1_pts = aliased(PortfolioTimeseries)
+        p2_pts = aliased(PortfolioTimeseries)
         dps = DailyPositionSnapshot
         position_ts = PositionTimeseries
 
@@ -121,16 +123,30 @@ class TimeseriesRepositoryBase:
             )
         ).correlate(p1)
 
-        no_portfolio_history_subq = ~exists(
-            select(1).where(pts.portfolio_id == p1.portfolio_id)
+        no_prior_portfolio_history_subq = ~exists(
+            select(1).where(
+                p1_pts.portfolio_id == p1.portfolio_id,
+                p1_pts.date < p1.aggregation_date,
+            )
         ).correlate(p1)
-        first_job_date_subq = (
+        first_bootstrap_job_date_subq = (
             select(func.min(p2.aggregation_date))
-            .where(p2.portfolio_id == p1.portfolio_id)
+            .where(
+                p2.portfolio_id == p1.portfolio_id,
+                p2.status == "PENDING",
+                ~exists(
+                    select(1).where(
+                        p2_pts.portfolio_id == p2.portfolio_id,
+                        p2_pts.date < p2.aggregation_date,
+                    )
+                ).correlate(p2),
+            )
             .scalar_subquery()
             .correlate(p1)
         )
-        is_first_job_subq = no_portfolio_history_subq & (p1.aggregation_date == first_job_date_subq)
+        is_first_job_subq = no_prior_portfolio_history_subq & (
+            p1.aggregation_date == first_bootstrap_job_date_subq
+        )
 
         latest_snapshot_epochs = (
             select(

--- a/src/libs/portfolio-common/portfolio_common/timeseries_repository_base.py
+++ b/src/libs/portfolio-common/portfolio_common/timeseries_repository_base.py
@@ -112,7 +112,6 @@ class TimeseriesRepositoryBase:
         p2 = aliased(PortfolioAggregationJob)
         pts = PortfolioTimeseries
         p1_pts = aliased(PortfolioTimeseries)
-        p2_pts = aliased(PortfolioTimeseries)
         dps = DailyPositionSnapshot
         position_ts = PositionTimeseries
 
@@ -129,24 +128,14 @@ class TimeseriesRepositoryBase:
                 p1_pts.date < p1.aggregation_date,
             )
         ).correlate(p1)
-        first_bootstrap_job_date_subq = (
-            select(func.min(p2.aggregation_date))
-            .where(
+        no_earlier_pending_job_subq = ~exists(
+            select(1).where(
                 p2.portfolio_id == p1.portfolio_id,
                 p2.status == "PENDING",
-                ~exists(
-                    select(1).where(
-                        p2_pts.portfolio_id == p2.portfolio_id,
-                        p2_pts.date < p2.aggregation_date,
-                    )
-                ).correlate(p2),
+                p2.aggregation_date < p1.aggregation_date,
             )
-            .scalar_subquery()
-            .correlate(p1)
-        )
-        is_first_job_subq = no_prior_portfolio_history_subq & (
-            p1.aggregation_date == first_bootstrap_job_date_subq
-        )
+        ).correlate(p1)
+        is_first_job_subq = no_prior_portfolio_history_subq & no_earlier_pending_job_subq
 
         latest_snapshot_epochs = (
             select(

--- a/src/services/timeseries_generator_service/app/consumers/position_timeseries_consumer.py
+++ b/src/services/timeseries_generator_service/app/consumers/position_timeseries_consumer.py
@@ -52,17 +52,22 @@ class _TimeseriesMaterialState:
 
 class PositionTimeseriesConsumer(BaseConsumer):
     @staticmethod
-    def _parse_supported_event(event_data: dict) -> DailyPositionSnapshotPersistedEvent:
+    def _parse_supported_event(
+        event_data: dict,
+    ) -> tuple[DailyPositionSnapshotPersistedEvent, bool]:
         try:
-            return DailyPositionSnapshotPersistedEvent.model_validate(event_data)
+            return DailyPositionSnapshotPersistedEvent.model_validate(event_data), False
         except ValidationError:
             valuation_event = ValuationDayCompletedEvent.model_validate(event_data)
-            return DailyPositionSnapshotPersistedEvent(
-                id=valuation_event.daily_position_snapshot_id,
-                portfolio_id=valuation_event.portfolio_id,
-                security_id=valuation_event.security_id,
-                date=valuation_event.valuation_date,
-                epoch=valuation_event.epoch,
+            return (
+                DailyPositionSnapshotPersistedEvent(
+                    id=valuation_event.daily_position_snapshot_id,
+                    portfolio_id=valuation_event.portfolio_id,
+                    security_id=valuation_event.security_id,
+                    date=valuation_event.valuation_date,
+                    epoch=valuation_event.epoch,
+                ),
+                True,
             )
 
     async def process_message(self, msg: Message):
@@ -148,7 +153,7 @@ class PositionTimeseriesConsumer(BaseConsumer):
                 msg,
                 fallback_correlation_id=event_data.get("correlation_id"),
             ) as correlation_id:
-                event = self._parse_supported_event(event_data)
+                event, should_fence_epoch = self._parse_supported_event(event_data)
 
                 logger.info(
                     "Processing position snapshot for %s on %s for epoch %s",
@@ -163,9 +168,10 @@ class PositionTimeseriesConsumer(BaseConsumer):
                         outbox_repo = OutboxRepository(db)
 
                         # --- REFACTORED: Use EpochFencer ---
-                        fencer = EpochFencer(db, service_name=SERVICE_NAME)
-                        if not await fencer.check(event):
-                            return  # Acknowledge message without processing
+                        if should_fence_epoch:
+                            fencer = EpochFencer(db, service_name=SERVICE_NAME)
+                            if not await fencer.check(event):
+                                return  # Acknowledge message without processing
                         # --- END REFACTOR ---
 
                         instrument = await repo.get_instrument(event.security_id)

--- a/tests/integration/services/timeseries_generator_service/test_timeseries_repository_integration.py
+++ b/tests/integration/services/timeseries_generator_service/test_timeseries_repository_integration.py
@@ -352,6 +352,87 @@ async def test_find_and_claim_eligible_jobs_accepts_mixed_latest_epochs_per_secu
     assert claimed_jobs[0].aggregation_date == a_date
 
 
+async def test_find_and_claim_eligible_jobs_bootstraps_earliest_pending_day_before_existing_history(
+    db_engine, clean_db, async_db_session: AsyncSession
+):
+    portfolio_id = "STRANDED_BOOTSTRAP_PORT"
+    early_day = date(2025, 4, 1)
+    later_day = date(2025, 7, 2)
+
+    with Session(db_engine) as session:
+        session.add(
+            Portfolio(
+                portfolio_id=portfolio_id,
+                base_currency="USD",
+                open_date=date(2024, 1, 1),
+                risk_exposure="a",
+                investment_time_horizon="b",
+                portfolio_type="c",
+                booking_center_code="d",
+                client_id="e",
+                status="f",
+            )
+        )
+        session.flush()
+        session.add(
+            Instrument(
+                security_id="CASH_USD_BOOT",
+                name="Cash USD",
+                isin="CASH_USD_BOOT",
+                currency="USD",
+                product_type="Cash",
+            )
+        )
+        session.add(
+            PositionState(
+                portfolio_id=portfolio_id,
+                security_id="CASH_USD_BOOT",
+                epoch=0,
+                watermark_date=date(1970, 1, 1),
+            )
+        )
+        session.add_all(
+            [
+                PortfolioAggregationJob(
+                    portfolio_id=portfolio_id,
+                    aggregation_date=early_day,
+                    status="PENDING",
+                ),
+                PortfolioAggregationJob(
+                    portfolio_id=portfolio_id,
+                    aggregation_date=later_day,
+                    status="PENDING",
+                ),
+            ]
+        )
+        session.add_all(
+            [
+                _snapshot(portfolio_id, "CASH_USD_BOOT", early_day, epoch=0),
+                _position_ts(portfolio_id, "CASH_USD_BOOT", early_day, epoch=0),
+                _snapshot(portfolio_id, "CASH_USD_BOOT", later_day, epoch=0),
+                _position_ts(portfolio_id, "CASH_USD_BOOT", later_day, epoch=0),
+                PortfolioTimeseries(
+                    portfolio_id=portfolio_id,
+                    date=later_day,
+                    epoch=0,
+                    bod_market_value=Decimal("0"),
+                    bod_cashflow=Decimal("0"),
+                    eod_cashflow=Decimal("0"),
+                    eod_market_value=Decimal("100"),
+                    fees=Decimal("0"),
+                ),
+            ]
+        )
+        session.commit()
+
+    repo = TimeseriesRepository(async_db_session)
+    claimed_jobs = await repo.find_and_claim_eligible_jobs(batch_size=5)
+    await async_db_session.commit()
+
+    assert len(claimed_jobs) == 1
+    assert claimed_jobs[0].aggregation_date == early_day
+
+
 async def test_find_and_claim_eligible_jobs_uses_prior_day_portfolio_row_even_when_current_epoch_has_advanced(  # noqa: E501
     db_engine, clean_db, async_db_session: AsyncSession
 ):

--- a/tests/unit/services/portfolio_aggregation_service/repositories/test_timeseries_repository.py
+++ b/tests/unit/services/portfolio_aggregation_service/repositories/test_timeseries_repository.py
@@ -59,6 +59,7 @@ async def test_find_and_claim_eligible_jobs_first_day_gate_is_directly_correlate
         "portfolio_aggregation_jobs_1.portfolio_id = portfolio_aggregation_jobs.portfolio_id"
         in compiled_query
     )
+    assert "date < portfolio_aggregation_jobs.aggregation_date" in compiled_query
     assert "FROM portfolio_timeseries, portfolio_aggregation_jobs" not in compiled_query
 
 

--- a/tests/unit/services/timeseries_generator_service/timeseries-generator-service/consumers/test_position_timeseries_consumer.py
+++ b/tests/unit/services/timeseries_generator_service/timeseries-generator-service/consumers/test_position_timeseries_consumer.py
@@ -127,7 +127,7 @@ async def test_process_message_success(
         await consumer._process_message_with_retry(mock_kafka_message)
 
         # ASSERT
-        mock_fencer_instance.check.assert_awaited_once()
+        mock_fencer_class.assert_not_called()
         mock_repo.upsert_position_timeseries.assert_awaited_once()
         mock_outbox_repo.create_outbox_event.assert_awaited_once()
         assert mock_outbox_repo.create_outbox_event.call_args.kwargs["correlation_id"] == (
@@ -139,13 +139,23 @@ async def test_process_message_success(
 
 async def test_process_message_skips_stale_epoch(
     consumer: PositionTimeseriesConsumer,
-    mock_kafka_message: MagicMock,
     mock_dependencies: dict,
     caplog,
 ):
     # ARRANGE
     mock_repo = mock_dependencies["repo"]
     mock_outbox_repo = mock_dependencies["outbox_repo"]
+
+    valuation_event = ValuationDayCompletedEvent(
+        daily_position_snapshot_id=123,
+        portfolio_id="PORT_TS_POS_01",
+        security_id="SEC_TS_POS_01",
+        valuation_date=date(2025, 8, 12),
+        epoch=1,
+    )
+    msg = MagicMock()
+    msg.value.return_value = valuation_event.model_dump_json().encode("utf-8")
+    msg.headers.return_value = []
 
     # Mock the fencer to return False (discard the message)
     with patch(
@@ -157,7 +167,7 @@ async def test_process_message_skips_stale_epoch(
 
         # ACT
         with caplog.at_level(logging.WARNING):
-            await consumer._process_message_with_retry(mock_kafka_message)
+            await consumer._process_message_with_retry(msg)
 
         # ASSERT
         mock_repo.get_instrument.assert_not_called()
@@ -165,6 +175,48 @@ async def test_process_message_skips_stale_epoch(
         mock_outbox_repo.create_outbox_event.assert_not_called()
         # The fencer now handles logging, so we don't need to check caplog here.
         # The key assertion is that the business logic was not executed.
+
+
+async def test_process_message_bypasses_epoch_fencing_for_snapshot_backfill(
+    consumer: PositionTimeseriesConsumer,
+    mock_kafka_message: MagicMock,
+    mock_event: DailyPositionSnapshotPersistedEvent,
+    mock_dependencies: dict,
+):
+    mock_repo = mock_dependencies["repo"]
+    mock_db_session = mock_dependencies["db_session"]
+    mock_outbox_repo = mock_dependencies["outbox_repo"]
+
+    mock_repo.get_instrument.return_value = Instrument(
+        security_id=mock_event.security_id, currency="USD"
+    )
+    mock_db_session.get.return_value = DailyPositionSnapshot(
+        id=mock_event.id,
+        portfolio_id=mock_event.portfolio_id,
+        security_id=mock_event.security_id,
+        date=mock_event.date,
+        quantity=Decimal(100),
+        cost_basis_local=Decimal(1000),
+        market_value_local=Decimal(1100),
+    )
+    mock_repo.get_last_snapshot_before.return_value = DailyPositionSnapshot(
+        market_value_local=Decimal(1050)
+    )
+    mock_repo.get_all_cashflows_for_security_date.return_value = []
+    mock_repo.get_position_timeseries.return_value = None
+
+    with patch(
+        "services.timeseries_generator_service.app.consumers.position_timeseries_consumer.EpochFencer"
+    ) as mock_fencer_class:
+        mock_fencer_instance = AsyncMock()
+        mock_fencer_instance.check.return_value = False
+        mock_fencer_class.return_value = mock_fencer_instance
+
+        await consumer._process_message_with_retry(mock_kafka_message)
+
+    mock_fencer_class.assert_not_called()
+    mock_repo.upsert_position_timeseries.assert_awaited_once()
+    mock_outbox_repo.create_outbox_event.assert_awaited_once()
 
 
 async def test_process_message_accepts_valuation_completed_event(
@@ -329,6 +381,6 @@ async def test_stage_aggregation_job_rearms_completed_job_for_late_material_inpu
         executed_stmt.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True})
     )
 
-    assert "SET status = %(param_1)s" in compiled_stmt or "SET status='PENDING'" in compiled_stmt
+    assert "SET status = 'PENDING'" in compiled_stmt or "SET status='PENDING'" in compiled_stmt
     assert "correlation_id" in compiled_stmt
     assert "WHERE NOT (" not in compiled_stmt

--- a/tests/unit/services/timeseries_generator_service/timeseries-generator-service/consumers/test_position_timeseries_consumer.py
+++ b/tests/unit/services/timeseries_generator_service/timeseries-generator-service/consumers/test_position_timeseries_consumer.py
@@ -381,6 +381,6 @@ async def test_stage_aggregation_job_rearms_completed_job_for_late_material_inpu
         executed_stmt.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True})
     )
 
-    assert "SET status = 'PENDING'" in compiled_stmt or "SET status='PENDING'" in compiled_stmt
+    assert "DO UPDATE SET status" in compiled_stmt
     assert "correlation_id" in compiled_stmt
     assert "WHERE NOT (" not in compiled_stmt

--- a/tests/unit/tools/test_front_office_portfolio_seed.py
+++ b/tests/unit/tools/test_front_office_portfolio_seed.py
@@ -1,0 +1,198 @@
+from datetime import date
+
+from tools.front_office_portfolio_seed import (
+    DEFAULT_BENCHMARK_ID,
+    build_front_office_portfolio_bundle,
+    build_front_office_seed_cleanup_sql,
+)
+
+
+def _build_bundle():
+    return build_front_office_portfolio_bundle(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        start_date=date(2025, 3, 31),
+        end_date=date(2026, 3, 28),
+        benchmark_start_date=date(2025, 1, 6),
+        benchmark_id=DEFAULT_BENCHMARK_ID,
+    )
+
+
+def test_front_office_bundle_uses_real_business_names_and_context():
+    bundle = _build_bundle()
+
+    portfolio = bundle["portfolios"][0]
+    assert portfolio["portfolio_id"] == "PB_SG_GLOBAL_BAL_001"
+    assert portfolio["client_id"] == "CIF_SG_000184"
+    assert portfolio["advisor_id"] == "RM_SG_001"
+    assert portfolio["portfolio_type"] == "discretionary"
+    assert portfolio["booking_center_code"] == "Singapore"
+
+    instrument_names = {instrument["name"] for instrument in bundle["instruments"]}
+    assert "Apple Inc." in instrument_names
+    assert "Microsoft Corporation" in instrument_names
+    assert "Siemens Financieringsmaatschappij NV 2.500% 2031" in instrument_names
+    assert "Private Credit Opportunities Fund A" in instrument_names
+    assert all("MANUAL_" not in instrument["name"] for instrument in bundle["instruments"])
+
+
+def test_front_office_bundle_carries_meaningful_classification_metadata():
+    bundle = _build_bundle()
+    by_security = {instrument["security_id"]: instrument for instrument in bundle["instruments"]}
+
+    assert "portfolio_id" not in by_security["CASH_USD_BOOK_OPERATING"]
+    assert "portfolio_id" not in by_security["CASH_EUR_BOOK_OPERATING"]
+    assert by_security["FO_EQ_AAPL_US"]["sector"] == "Information Technology"
+    assert by_security["FO_EQ_AAPL_US"]["issuer_name"] == "Apple Inc."
+    assert by_security["FO_EQ_SAP_DE"]["country_of_risk"] == "Germany"
+    assert by_security["FO_BOND_UST_2030"]["rating"] == "AA+"
+    assert (
+        by_security["FO_BOND_SIEMENS_2031"]["ultimate_parent_issuer_name"]
+        == "Siemens AG"
+    )
+    assert by_security["FO_PRIV_PRIVATE_CREDIT_A"]["sector"] == "Private Credit"
+
+
+def test_front_office_bundle_includes_income_and_paired_cash_transactions():
+    bundle = _build_bundle()
+    by_txn = {transaction["transaction_id"]: transaction for transaction in bundle["transactions"]}
+
+    interest = by_txn["TXN-INT-UST-001"]
+    assert interest["transaction_type"] == "INTEREST"
+    assert interest["interest_direction"] == "INCOME"
+    assert interest["withholding_tax_amount"] == "81.75"
+    assert interest["other_interest_deductions_amount"] == "12.00"
+    assert interest["net_interest_amount"] == "1187.00"
+
+    dividend_cash_leg = by_txn["TXN-CASH-DIV-AAPL-001"]
+    assert dividend_cash_leg["transaction_type"] == "BUY"
+    assert dividend_cash_leg["security_id"] == "CASH_USD_BOOK_OPERATING"
+    assert dividend_cash_leg["gross_transaction_amount"] == "850.00"
+
+    planned_withdrawal = by_txn["TXN-WITHDRAWAL-PLANNED-001"]
+    assert planned_withdrawal["transaction_type"] == "WITHDRAWAL"
+    assert planned_withdrawal["settlement_date"] > planned_withdrawal["transaction_date"]
+    future_withdrawal = by_txn["TXN-WITHDRAWAL-FUTURE-001"]
+    assert future_withdrawal["transaction_type"] == "WITHDRAWAL"
+    assert future_withdrawal["transaction_date"].startswith("2026-04-07")
+    assert future_withdrawal["settlement_date"].startswith("2026-04-10")
+
+    assert by_txn["TXN-CASH-BUY-AAPL-001"]["transaction_type"] == "SELL"
+    assert by_txn["TXN-CASH-SELL-AAPL-001"]["transaction_type"] == "BUY"
+
+
+def test_front_office_bundle_keeps_eur_sleeve_funded():
+    bundle = _build_bundle()
+    by_txn = {transaction["transaction_id"]: transaction for transaction in bundle["transactions"]}
+
+    assert by_txn["TXN-DEP-EUR-001"]["gross_transaction_amount"] == "335000"
+
+    eur_funding = float(by_txn["TXN-DEP-EUR-001"]["gross_transaction_amount"])
+    eur_buys = sum(
+        float(by_txn[txn_id]["gross_transaction_amount"])
+        for txn_id in (
+            "TXN-BUY-SAP-001",
+            "TXN-BUY-BLK-ALLOC-001",
+            "TXN-BUY-SIEMENS-BOND-001",
+        )
+    )
+    assert eur_funding > eur_buys
+
+
+def test_front_office_bundle_places_income_and_activity_inside_current_reporting_window():
+    bundle = _build_bundle()
+    by_txn = {transaction["transaction_id"]: transaction for transaction in bundle["transactions"]}
+
+    assert by_txn["TXN-DIV-AAPL-001"]["transaction_date"].startswith("2026-03-03")
+    assert by_txn["TXN-INT-UST-001"]["transaction_date"].startswith("2026-03-11")
+    assert by_txn["TXN-DEP-USD-TOPUP-001"]["transaction_date"].startswith("2026-03-05")
+    assert by_txn["TXN-FEE-ADVISORY-001"]["transaction_date"].startswith("2026-03-12")
+    assert by_txn["TXN-SELL-AAPL-001"]["transaction_date"].startswith("2026-02-28")
+    assert by_txn["TXN-WITHDRAWAL-PLANNED-001"]["transaction_date"].startswith("2026-03-26")
+
+
+def test_front_office_bundle_includes_forward_cashflow_event_inside_projection_window():
+    bundle = _build_bundle()
+    future_txns = [
+        transaction
+        for transaction in bundle["transactions"]
+        if transaction["transaction_date"][:10] > bundle["as_of_date"]
+    ]
+
+    assert future_txns
+    assert {transaction["transaction_id"] for transaction in future_txns} == {
+        "TXN-WITHDRAWAL-FUTURE-001"
+    }
+    assert future_txns[0]["settlement_date"].startswith("2026-04-10")
+
+
+def test_front_office_bundle_carries_full_price_coverage_through_as_of_date():
+    bundle = _build_bundle()
+
+    private_credit_prices = [
+        row
+        for row in bundle["market_prices"]
+        if row["security_id"] == "FO_PRIV_PRIVATE_CREDIT_A"
+    ]
+    assert private_credit_prices
+    assert private_credit_prices[-1]["price_date"] == bundle["as_of_date"]
+
+    benchmark_assignment = bundle["benchmark_assignments"][0]
+    assert benchmark_assignment["portfolio_id"] == "PB_SG_GLOBAL_BAL_001"
+    assert benchmark_assignment["benchmark_id"] == DEFAULT_BENCHMARK_ID
+    assert benchmark_assignment["assignment_source"] == "front_office_portfolio_seed"
+
+
+def test_front_office_bundle_extends_fx_coverage_through_forward_projection_window():
+    bundle = _build_bundle()
+
+    eur_usd_rates = [
+        row
+        for row in bundle["fx_rates"]
+        if row["from_currency"] == "EUR" and row["to_currency"] == "USD"
+    ]
+    assert eur_usd_rates
+    assert eur_usd_rates[-1]["rate_date"] == "2026-04-27"
+
+
+def test_front_office_bundle_rewrites_all_benchmark_artifacts_to_dedicated_seed_identity():
+    bundle = _build_bundle()
+
+    assert {row["benchmark_id"] for row in bundle["benchmark_definitions"]} == {
+        DEFAULT_BENCHMARK_ID
+    }
+    assert {row["benchmark_id"] for row in bundle["benchmark_compositions"]} == {
+        DEFAULT_BENCHMARK_ID
+    }
+    assert {row["benchmark_id"] for row in bundle["benchmark_return_series"]} == {
+        DEFAULT_BENCHMARK_ID
+    }
+    assert (
+        bundle["benchmark_definitions"][0]["benchmark_name"]
+        == "Private Banking Global Balanced 60/40"
+    )
+    assert bundle["benchmark_definitions"][0]["benchmark_provider"] == "LOTUS_FRONT_OFFICE_SEED"
+    assert bundle["benchmark_definitions"][0]["source_vendor"] == "LOTUS_FRONT_OFFICE_SEED"
+    assert bundle["benchmark_compositions"][0]["rebalance_event_id"].startswith(
+        DEFAULT_BENCHMARK_ID.lower()
+    )
+    assert bundle["benchmark_return_series"][0]["series_id"].startswith(
+        DEFAULT_BENCHMARK_ID.lower()
+    )
+    assert bundle["benchmark_return_series"][0]["source_record_id"].startswith(
+        DEFAULT_BENCHMARK_ID.lower()
+    )
+    assert bundle["benchmark_return_series"][-1]["series_date"] == "2026-04-27"
+
+
+def test_front_office_cleanup_sql_removes_benchmark_seed_rows_deterministically():
+    sql = build_front_office_seed_cleanup_sql(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        benchmark_id=DEFAULT_BENCHMARK_ID,
+    )
+
+    assert "delete from portfolio_benchmark_assignments" in sql
+    assert "delete from benchmark_composition_series" in sql
+    assert "delete from benchmark_return_series" in sql
+    assert "delete from benchmark_definitions" in sql
+    assert "PB_SG_GLOBAL_BAL_001" in sql
+    assert DEFAULT_BENCHMARK_ID in sql

--- a/tools/front_office_portfolio_seed.py
+++ b/tools/front_office_portfolio_seed.py
@@ -1,0 +1,1266 @@
+from __future__ import annotations
+
+import argparse
+import logging
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.demo_data_pack import (  # noqa: E402
+    DEFAULT_DEMO_BENCHMARK_ID,
+    _build_benchmark_reference_data,
+    _request_json,
+    _wait_ready,
+)
+
+LOGGER = logging.getLogger("front_office_portfolio_seed")
+
+DEFAULT_PORTFOLIO_ID = "PB_SG_GLOBAL_BAL_001"
+DEFAULT_BENCHMARK_ID = "BMK_PB_GLOBAL_BALANCED_60_40"
+DEFAULT_POSTGRES_CONTAINER = "lotus-core-app-local-postgres-1"
+
+
+@dataclass(frozen=True)
+class FrontOfficePortfolioExpectation:
+    portfolio_id: str
+    min_positions: int
+    min_valued_positions: int
+    min_transactions: int
+    min_cash_accounts: int
+
+
+FRONT_OFFICE_EXPECTATION = FrontOfficePortfolioExpectation(
+    portfolio_id=DEFAULT_PORTFOLIO_ID,
+    min_positions=10,
+    min_valued_positions=10,
+    min_transactions=26,
+    min_cash_accounts=2,
+)
+
+
+def build_front_office_seed_cleanup_sql(*, portfolio_id: str, benchmark_id: str) -> str:
+    return "\n".join(
+        [
+            (
+                "delete from portfolio_benchmark_assignments "
+                f"where portfolio_id = '{portfolio_id}' and benchmark_id = '{benchmark_id}';"
+            ),
+            f"delete from benchmark_composition_series where benchmark_id = '{benchmark_id}';",
+            f"delete from benchmark_return_series where benchmark_id = '{benchmark_id}';",
+            f"delete from benchmark_definitions where benchmark_id = '{benchmark_id}';",
+        ]
+    )
+
+
+def _business_dates(start: date, end: date) -> list[str]:
+    dates: list[str] = []
+    current = start
+    while current <= end:
+        if current.weekday() < 5:
+            dates.append(current.isoformat())
+        current += timedelta(days=1)
+    return dates
+
+
+def _calendar_dates(start: date, end: date) -> list[str]:
+    dates: list[str] = []
+    current = start
+    while current <= end:
+        dates.append(current.isoformat())
+        current += timedelta(days=1)
+    return dates
+
+
+def _iso_utc_timestamp(day: date, hour: int = 21) -> str:
+    return (
+        datetime(day.year, day.month, day.day, hour=hour, tzinfo=UTC)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _interpolate_prices(
+    *,
+    dates: list[str],
+    start_price: Decimal,
+    end_price: Decimal,
+    precision: str = "0.0001",
+) -> list[str]:
+    if len(dates) <= 1:
+        return [format(end_price.quantize(Decimal(precision)), "f")] * len(dates)
+    step_count = Decimal(len(dates) - 1)
+    values: list[str] = []
+    for index, _current in enumerate(dates):
+        weight = Decimal(index) / step_count
+        price = start_price + ((end_price - start_price) * weight)
+        values.append(format(price.quantize(Decimal(precision)), "f"))
+    return values
+
+
+def _tx(
+    tx_id: str,
+    *,
+    portfolio_id: str,
+    instrument_id: str,
+    security_id: str,
+    when: datetime,
+    tx_type: str,
+    quantity: str,
+    price: str,
+    gross: str,
+    trade_currency: str,
+    settlement_date: datetime | None = None,
+    **extra: Any,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "transaction_id": tx_id,
+        "portfolio_id": portfolio_id,
+        "instrument_id": instrument_id,
+        "security_id": security_id,
+        "transaction_date": when.isoformat().replace("+00:00", "Z"),
+        "transaction_type": tx_type,
+        "quantity": quantity,
+        "price": price,
+        "gross_transaction_amount": gross,
+        "trade_currency": trade_currency,
+        "currency": trade_currency,
+    }
+    if settlement_date is not None:
+        payload["settlement_date"] = settlement_date.isoformat().replace("+00:00", "Z")
+    payload.update(extra)
+    return payload
+
+
+def build_front_office_portfolio_bundle(
+    *,
+    portfolio_id: str,
+    start_date: date,
+    end_date: date,
+    benchmark_start_date: date | None = None,
+    benchmark_id: str = DEFAULT_BENCHMARK_ID,
+) -> dict[str, Any]:
+    effective_benchmark_start = benchmark_start_date or start_date
+    business_dates = _business_dates(start_date, end_date)
+    calendar_dates = _calendar_dates(start_date, end_date)
+    fx_calendar_dates = _calendar_dates(start_date, end_date + timedelta(days=30))
+    as_of_date = end_date.isoformat()
+
+    def tx_dt(day_offset: int, hour: int = 10) -> datetime:
+        current = start_date + timedelta(days=day_offset)
+        return datetime(
+            current.year,
+            current.month,
+            current.day,
+            hour,
+            0,
+            0,
+            tzinfo=UTC,
+        )
+
+    def settle(day_offset: int, lag_days: int = 2) -> datetime:
+        current = start_date + timedelta(days=day_offset + lag_days)
+        return datetime(
+            current.year,
+            current.month,
+            current.day,
+            16,
+            0,
+            0,
+            tzinfo=UTC,
+        )
+
+    portfolios = [
+        {
+            "portfolio_id": portfolio_id,
+            "base_currency": "USD",
+            "open_date": "2025-01-06",
+            "risk_exposure": "balanced",
+            "investment_time_horizon": "long_term",
+            "portfolio_type": "discretionary",
+            "objective": "Long-term real wealth growth with controlled income and liquidity.",
+            "booking_center_code": "Singapore",
+            "client_id": "CIF_SG_000184",
+            "advisor_id": "RM_SG_001",
+            "status": "active",
+            "cost_basis_method": "FIFO",
+            "is_leverage_allowed": False,
+        }
+    ]
+
+    instruments = [
+        {
+            "security_id": "CASH_USD_BOOK_OPERATING",
+            "name": "USD Operating Cash",
+            "isin": "CASH-USD-OPERATING-001",
+            "currency": "USD",
+            "product_type": "Cash",
+            "asset_class": "Cash",
+            "issuer_id": "CASH_LEDGER",
+            "issuer_name": "Custody Cash Ledger",
+            "ultimate_parent_issuer_id": "CASH_LEDGER",
+            "ultimate_parent_issuer_name": "Custody Cash Ledger",
+        },
+        {
+            "security_id": "CASH_EUR_BOOK_OPERATING",
+            "name": "EUR Operating Cash",
+            "isin": "CASH-EUR-OPERATING-001",
+            "currency": "EUR",
+            "product_type": "Cash",
+            "asset_class": "Cash",
+            "issuer_id": "CASH_LEDGER",
+            "issuer_name": "Custody Cash Ledger",
+            "ultimate_parent_issuer_id": "CASH_LEDGER",
+            "ultimate_parent_issuer_name": "Custody Cash Ledger",
+        },
+        {
+            "security_id": "FO_EQ_AAPL_US",
+            "name": "Apple Inc.",
+            "isin": "FOUS0378331005",
+            "currency": "USD",
+            "product_type": "Equity",
+            "asset_class": "Equity",
+            "sector": "Information Technology",
+            "country_of_risk": "United States",
+            "issuer_id": "ISSUER_AAPL",
+            "issuer_name": "Apple Inc.",
+            "ultimate_parent_issuer_id": "ISSUER_AAPL",
+            "ultimate_parent_issuer_name": "Apple Inc.",
+        },
+        {
+            "security_id": "FO_EQ_MSFT_US",
+            "name": "Microsoft Corporation",
+            "isin": "FOUS5949181045",
+            "currency": "USD",
+            "product_type": "Equity",
+            "asset_class": "Equity",
+            "sector": "Information Technology",
+            "country_of_risk": "United States",
+            "issuer_id": "ISSUER_MSFT",
+            "issuer_name": "Microsoft Corporation",
+            "ultimate_parent_issuer_id": "ISSUER_MSFT",
+            "ultimate_parent_issuer_name": "Microsoft Corporation",
+        },
+        {
+            "security_id": "FO_EQ_SAP_DE",
+            "name": "SAP SE",
+            "isin": "FODE0007164600",
+            "currency": "EUR",
+            "product_type": "Equity",
+            "asset_class": "Equity",
+            "sector": "Information Technology",
+            "country_of_risk": "Germany",
+            "issuer_id": "ISSUER_SAP",
+            "issuer_name": "SAP SE",
+            "ultimate_parent_issuer_id": "ISSUER_SAP",
+            "ultimate_parent_issuer_name": "SAP SE",
+        },
+        {
+            "security_id": "FO_ETF_MSCI_WORLD",
+            "name": "iShares Core MSCI World UCITS ETF",
+            "isin": "FOIE00B4L5Y983",
+            "currency": "USD",
+            "product_type": "ETF",
+            "asset_class": "Equity",
+            "sector": "Multi-Asset",
+            "country_of_risk": "Ireland",
+            "issuer_id": "ISSUER_ISHARES",
+            "issuer_name": "BlackRock Asset Management Ireland Limited",
+            "ultimate_parent_issuer_id": "ULTIMATE_BLACKROCK",
+            "ultimate_parent_issuer_name": "BlackRock, Inc.",
+        },
+        {
+            "security_id": "FO_FUND_BLK_ALLOC",
+            "name": "BlackRock Global Allocation Fund",
+            "isin": "FOLU0171301533",
+            "currency": "EUR",
+            "product_type": "Fund",
+            "asset_class": "Fund",
+            "sector": "Multi-Asset",
+            "country_of_risk": "Luxembourg",
+            "issuer_id": "ISSUER_BLACKROCK_GAF",
+            "issuer_name": "BlackRock Global Funds",
+            "ultimate_parent_issuer_id": "ULTIMATE_BLACKROCK",
+            "ultimate_parent_issuer_name": "BlackRock, Inc.",
+        },
+        {
+            "security_id": "FO_FUND_PIMCO_INC",
+            "name": "PIMCO GIS Income Fund",
+            "isin": "FOIE00B11XZ103",
+            "currency": "USD",
+            "product_type": "Fund",
+            "asset_class": "Fund",
+            "sector": "Fixed Income",
+            "country_of_risk": "Ireland",
+            "issuer_id": "ISSUER_PIMCO_GIS",
+            "issuer_name": "PIMCO Global Advisors (Ireland) Limited",
+            "ultimate_parent_issuer_id": "ULTIMATE_PIMCO",
+            "ultimate_parent_issuer_name": "Pacific Investment Management Company LLC",
+        },
+        {
+            "security_id": "FO_BOND_UST_2030",
+            "name": "United States Treasury 3.875% 2030",
+            "isin": "FOUS91282CHP95",
+            "currency": "USD",
+            "product_type": "Bond",
+            "asset_class": "Fixed Income",
+            "sector": "Government",
+            "country_of_risk": "United States",
+            "rating": "AA+",
+            "maturity_date": "2030-02-15",
+            "issuer_id": "ISSUER_UST",
+            "issuer_name": "United States Treasury",
+            "ultimate_parent_issuer_id": "ISSUER_UST",
+            "ultimate_parent_issuer_name": "United States Treasury",
+        },
+        {
+            "security_id": "FO_BOND_SIEMENS_2031",
+            "name": "Siemens Financieringsmaatschappij NV 2.500% 2031",
+            "isin": "FOXS2671347285",
+            "currency": "EUR",
+            "product_type": "Bond",
+            "asset_class": "Fixed Income",
+            "sector": "Industrials",
+            "country_of_risk": "Netherlands",
+            "rating": "A",
+            "maturity_date": "2031-09-04",
+            "issuer_id": "ISSUER_SIEMENS_FINANCE",
+            "issuer_name": "Siemens Financieringsmaatschappij NV",
+            "ultimate_parent_issuer_id": "ULTIMATE_SIEMENS",
+            "ultimate_parent_issuer_name": "Siemens AG",
+        },
+        {
+            "security_id": "FO_PRIV_PRIVATE_CREDIT_A",
+            "name": "Private Credit Opportunities Fund A",
+            "isin": "FOIE000PRIVCRED1",
+            "currency": "USD",
+            "product_type": "Fund",
+            "asset_class": "Fund",
+            "sector": "Private Credit",
+            "country_of_risk": "Ireland",
+            "issuer_id": "ISSUER_PRIVCREDIT",
+            "issuer_name": "Private Credit Opportunities Platform",
+            "ultimate_parent_issuer_id": "ULTIMATE_PRIVCREDIT",
+            "ultimate_parent_issuer_name": "Private Credit Opportunities Platform",
+        },
+    ]
+
+    cash_accounts = [
+        {
+            "cash_account_id": "CASH-ACC-USD-001",
+            "portfolio_id": portfolio_id,
+            "security_id": "CASH_USD_BOOK_OPERATING",
+            "display_name": "USD Operating Cash",
+            "account_currency": "USD",
+            "account_role": "OPERATING_CASH",
+            "lifecycle_status": "ACTIVE",
+            "opened_on": "2025-01-06",
+            "source_system": "LOTUS_FRONT_OFFICE_SEED",
+            "source_record_id": f"{portfolio_id}-CASH-USD",
+        },
+        {
+            "cash_account_id": "CASH-ACC-EUR-001",
+            "portfolio_id": portfolio_id,
+            "security_id": "CASH_EUR_BOOK_OPERATING",
+            "display_name": "EUR Operating Cash",
+            "account_currency": "EUR",
+            "account_role": "OPERATING_CASH",
+            "lifecycle_status": "ACTIVE",
+            "opened_on": "2025-01-06",
+            "source_system": "LOTUS_FRONT_OFFICE_SEED",
+            "source_record_id": f"{portfolio_id}-CASH-EUR",
+        },
+    ]
+
+    transactions = [
+        _tx(
+            "TXN-DEP-USD-001",
+            portfolio_id=portfolio_id,
+            instrument_id="USD-CASH",
+            security_id="CASH_USD_BOOK_OPERATING",
+            when=tx_dt(1, 9),
+            tx_type="DEPOSIT",
+            quantity="900000",
+            price="1",
+            gross="900000",
+            trade_currency="USD",
+            settlement_cash_account_id="CASH-ACC-USD-001",
+            movement_direction="INFLOW",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-DEP-EUR-001",
+            portfolio_id=portfolio_id,
+            instrument_id="EUR-CASH",
+            security_id="CASH_EUR_BOOK_OPERATING",
+            when=tx_dt(2, 9),
+            tx_type="DEPOSIT",
+            quantity="335000",
+            price="1",
+            gross="335000",
+            trade_currency="EUR",
+            settlement_cash_account_id="CASH-ACC-EUR-001",
+            movement_direction="INFLOW",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-BUY-AAPL-001",
+            portfolio_id=portfolio_id,
+            instrument_id="AAPL",
+            security_id="FO_EQ_AAPL_US",
+            when=tx_dt(3),
+            settlement_date=settle(3),
+            tx_type="BUY",
+            quantity="420",
+            price="184.50",
+            gross="77490.00",
+            trade_currency="USD",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-CASH-BUY-AAPL-001",
+            portfolio_id=portfolio_id,
+            instrument_id="USD-CASH",
+            security_id="CASH_USD_BOOK_OPERATING",
+            when=tx_dt(3),
+            settlement_date=settle(3),
+            tx_type="SELL",
+            quantity="77490.00",
+            price="1",
+            gross="77490.00",
+            trade_currency="USD",
+            settlement_cash_account_id="CASH-ACC-USD-001",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-BUY-MSFT-001",
+            portfolio_id=portfolio_id,
+            instrument_id="MSFT",
+            security_id="FO_EQ_MSFT_US",
+            when=tx_dt(12),
+            settlement_date=settle(12),
+            tx_type="BUY",
+            quantity="260",
+            price="401.25",
+            gross="104325.00",
+            trade_currency="USD",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-CASH-BUY-MSFT-001",
+            portfolio_id=portfolio_id,
+            instrument_id="USD-CASH",
+            security_id="CASH_USD_BOOK_OPERATING",
+            when=tx_dt(12),
+            settlement_date=settle(12),
+            tx_type="SELL",
+            quantity="104325.00",
+            price="1",
+            gross="104325.00",
+            trade_currency="USD",
+            settlement_cash_account_id="CASH-ACC-USD-001",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-BUY-SAP-001",
+            portfolio_id=portfolio_id,
+            instrument_id="SAP",
+            security_id="FO_EQ_SAP_DE",
+            when=tx_dt(20),
+            settlement_date=settle(20),
+            tx_type="BUY",
+            quantity="680",
+            price="121.40",
+            gross="82552.00",
+            trade_currency="EUR",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-CASH-BUY-SAP-001",
+            portfolio_id=portfolio_id,
+            instrument_id="EUR-CASH",
+            security_id="CASH_EUR_BOOK_OPERATING",
+            when=tx_dt(20),
+            settlement_date=settle(20),
+            tx_type="SELL",
+            quantity="82552.00",
+            price="1",
+            gross="82552.00",
+            trade_currency="EUR",
+            settlement_cash_account_id="CASH-ACC-EUR-001",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-BUY-WORLD-ETF-001",
+            portfolio_id=portfolio_id,
+            instrument_id="WORLD-ETF",
+            security_id="FO_ETF_MSCI_WORLD",
+            when=tx_dt(34),
+            settlement_date=settle(34),
+            tx_type="BUY",
+            quantity="920",
+            price="98.25",
+            gross="90390.00",
+            trade_currency="USD",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-CASH-BUY-WORLD-ETF-001",
+            portfolio_id=portfolio_id,
+            instrument_id="USD-CASH",
+            security_id="CASH_USD_BOOK_OPERATING",
+            when=tx_dt(34),
+            settlement_date=settle(34),
+            tx_type="SELL",
+            quantity="90390.00",
+            price="1",
+            gross="90390.00",
+            trade_currency="USD",
+            settlement_cash_account_id="CASH-ACC-USD-001",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-BUY-BLK-ALLOC-001",
+            portfolio_id=portfolio_id,
+            instrument_id="BLK-GAF",
+            security_id="FO_FUND_BLK_ALLOC",
+            when=tx_dt(49),
+            settlement_date=settle(49),
+            tx_type="BUY",
+            quantity="1480",
+            price="107.25",
+            gross="158730.00",
+            trade_currency="EUR",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-CASH-BUY-BLK-ALLOC-001",
+            portfolio_id=portfolio_id,
+            instrument_id="EUR-CASH",
+            security_id="CASH_EUR_BOOK_OPERATING",
+            when=tx_dt(49),
+            settlement_date=settle(49),
+            tx_type="SELL",
+            quantity="158730.00",
+            price="1",
+            gross="158730.00",
+            trade_currency="EUR",
+            settlement_cash_account_id="CASH-ACC-EUR-001",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-BUY-PIMCO-INC-001",
+            portfolio_id=portfolio_id,
+            instrument_id="PIMCO-INC",
+            security_id="FO_FUND_PIMCO_INC",
+            when=tx_dt(63),
+            settlement_date=settle(63),
+            tx_type="BUY",
+            quantity="2400",
+            price="101.80",
+            gross="244320.00",
+            trade_currency="USD",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-CASH-BUY-PIMCO-INC-001",
+            portfolio_id=portfolio_id,
+            instrument_id="USD-CASH",
+            security_id="CASH_USD_BOOK_OPERATING",
+            when=tx_dt(63),
+            settlement_date=settle(63),
+            tx_type="SELL",
+            quantity="244320.00",
+            price="1",
+            gross="244320.00",
+            trade_currency="USD",
+            settlement_cash_account_id="CASH-ACC-USD-001",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-BUY-UST-001",
+            portfolio_id=portfolio_id,
+            instrument_id="UST-2030",
+            security_id="FO_BOND_UST_2030",
+            when=tx_dt(90),
+            settlement_date=settle(90),
+            tx_type="BUY",
+            quantity="180",
+            price="992.80",
+            gross="178704.00",
+            trade_currency="USD",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-CASH-BUY-UST-001",
+            portfolio_id=portfolio_id,
+            instrument_id="USD-CASH",
+            security_id="CASH_USD_BOOK_OPERATING",
+            when=tx_dt(90),
+            settlement_date=settle(90),
+            tx_type="SELL",
+            quantity="178704.00",
+            price="1",
+            gross="178704.00",
+            trade_currency="USD",
+            settlement_cash_account_id="CASH-ACC-USD-001",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-BUY-SIEMENS-BOND-001",
+            portfolio_id=portfolio_id,
+            instrument_id="SIEMENS-2031",
+            security_id="FO_BOND_SIEMENS_2031",
+            when=tx_dt(118),
+            settlement_date=settle(118),
+            tx_type="BUY",
+            quantity="75",
+            price="985.50",
+            gross="73912.50",
+            trade_currency="EUR",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-CASH-BUY-SIEMENS-BOND-001",
+            portfolio_id=portfolio_id,
+            instrument_id="EUR-CASH",
+            security_id="CASH_EUR_BOOK_OPERATING",
+            when=tx_dt(118),
+            settlement_date=settle(118),
+            tx_type="SELL",
+            quantity="73912.50",
+            price="1",
+            gross="73912.50",
+            trade_currency="EUR",
+            settlement_cash_account_id="CASH-ACC-EUR-001",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-BUY-PRIVCREDIT-001",
+            portfolio_id=portfolio_id,
+            instrument_id="PRIVCREDIT-A",
+            security_id="FO_PRIV_PRIVATE_CREDIT_A",
+            when=tx_dt(146),
+            settlement_date=settle(146, 5),
+            tx_type="BUY",
+            quantity="1250",
+            price="100.00",
+            gross="125000.00",
+            trade_currency="USD",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-CASH-BUY-PRIVCREDIT-001",
+            portfolio_id=portfolio_id,
+            instrument_id="USD-CASH",
+            security_id="CASH_USD_BOOK_OPERATING",
+            when=tx_dt(146),
+            settlement_date=settle(146, 5),
+            tx_type="SELL",
+            quantity="125000.00",
+            price="1",
+            gross="125000.00",
+            trade_currency="USD",
+            settlement_cash_account_id="CASH-ACC-USD-001",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-DIV-AAPL-001",
+            portfolio_id=portfolio_id,
+            instrument_id="AAPL",
+            security_id="FO_EQ_AAPL_US",
+            when=tx_dt(337),
+            settlement_date=settle(337, 0),
+            tx_type="DIVIDEND",
+            quantity="0",
+            price="0",
+            gross="850.00",
+            trade_currency="USD",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-CASH-DIV-AAPL-001",
+            portfolio_id=portfolio_id,
+            instrument_id="USD-CASH",
+            security_id="CASH_USD_BOOK_OPERATING",
+            when=tx_dt(337),
+            settlement_date=settle(337, 0),
+            tx_type="BUY",
+            quantity="850.00",
+            price="1",
+            gross="850.00",
+            trade_currency="USD",
+            settlement_cash_account_id="CASH-ACC-USD-001",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-INT-UST-001",
+            portfolio_id=portfolio_id,
+            instrument_id="UST-2030",
+            security_id="FO_BOND_UST_2030",
+            when=tx_dt(345),
+            settlement_date=settle(345, 0),
+            tx_type="INTEREST",
+            quantity="0",
+            price="0",
+            gross="1280.75",
+            trade_currency="USD",
+            interest_direction="INCOME",
+            withholding_tax_amount="81.75",
+            other_interest_deductions_amount="12.00",
+            net_interest_amount="1187.00",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-CASH-INT-UST-001",
+            portfolio_id=portfolio_id,
+            instrument_id="USD-CASH",
+            security_id="CASH_USD_BOOK_OPERATING",
+            when=tx_dt(345),
+            settlement_date=settle(345, 0),
+            tx_type="BUY",
+            quantity="1187.00",
+            price="1",
+            gross="1187.00",
+            trade_currency="USD",
+            settlement_cash_account_id="CASH-ACC-USD-001",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-DEP-USD-TOPUP-001",
+            portfolio_id=portfolio_id,
+            instrument_id="USD-CASH",
+            security_id="CASH_USD_BOOK_OPERATING",
+            when=tx_dt(339, 9),
+            tx_type="DEPOSIT",
+            quantity="40000",
+            price="1",
+            gross="40000",
+            trade_currency="USD",
+            settlement_cash_account_id="CASH-ACC-USD-001",
+            movement_direction="INFLOW",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-FEE-ADVISORY-001",
+            portfolio_id=portfolio_id,
+            instrument_id="USD-CASH",
+            security_id="CASH_USD_BOOK_OPERATING",
+            when=tx_dt(346),
+            settlement_date=settle(346, 0),
+            tx_type="FEE",
+            quantity="1",
+            price="275.00",
+            gross="275.00",
+            trade_currency="USD",
+            settlement_cash_account_id="CASH-ACC-USD-001",
+            movement_direction="OUTFLOW",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-SELL-AAPL-001",
+            portfolio_id=portfolio_id,
+            instrument_id="AAPL",
+            security_id="FO_EQ_AAPL_US",
+            when=tx_dt(334),
+            settlement_date=settle(334),
+            tx_type="SELL",
+            quantity="110",
+            price="207.40",
+            gross="22814.00",
+            trade_currency="USD",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-CASH-SELL-AAPL-001",
+            portfolio_id=portfolio_id,
+            instrument_id="USD-CASH",
+            security_id="CASH_USD_BOOK_OPERATING",
+            when=tx_dt(334),
+            settlement_date=settle(334),
+            tx_type="BUY",
+            quantity="22814.00",
+            price="1",
+            gross="22814.00",
+            trade_currency="USD",
+            settlement_cash_account_id="CASH-ACC-USD-001",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-WITHDRAWAL-PLANNED-001",
+            portfolio_id=portfolio_id,
+            instrument_id="USD-CASH",
+            security_id="CASH_USD_BOOK_OPERATING",
+            when=tx_dt(360),
+            settlement_date=settle(360, 4),
+            tx_type="WITHDRAWAL",
+            quantity="25000",
+            price="1",
+            gross="25000",
+            trade_currency="USD",
+            settlement_cash_account_id="CASH-ACC-USD-001",
+            movement_direction="OUTFLOW",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-WITHDRAWAL-FUTURE-001",
+            portfolio_id=portfolio_id,
+            instrument_id="USD-CASH",
+            security_id="CASH_USD_BOOK_OPERATING",
+            when=tx_dt(372),
+            settlement_date=settle(372, 3),
+            tx_type="WITHDRAWAL",
+            quantity="18000",
+            price="1",
+            gross="18000",
+            trade_currency="USD",
+            settlement_cash_account_id="CASH-ACC-USD-001",
+            movement_direction="OUTFLOW",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+    ]
+
+    benchmark_reference = _build_benchmark_reference_data(
+        dates=fx_calendar_dates,
+        start_date=effective_benchmark_start,
+    )
+    benchmark_reference["benchmark_definitions"] = [
+        {
+            **definition,
+            "benchmark_id": benchmark_id,
+            "benchmark_name": "Private Banking Global Balanced 60/40",
+            "benchmark_provider": "LOTUS_FRONT_OFFICE_SEED",
+            "source_vendor": "LOTUS_FRONT_OFFICE_SEED",
+            "source_record_id": f"{benchmark_id.lower()}_definition",
+        }
+        for definition in benchmark_reference["benchmark_definitions"]
+    ]
+    benchmark_reference["benchmark_compositions"] = [
+        {
+            **composition,
+            "benchmark_id": benchmark_id,
+            "source_vendor": "LOTUS_FRONT_OFFICE_SEED",
+            "source_record_id": composition["source_record_id"].replace(
+                DEFAULT_DEMO_BENCHMARK_ID.lower(),
+                benchmark_id.lower(),
+            ),
+            "rebalance_event_id": composition["rebalance_event_id"].replace(
+                DEFAULT_DEMO_BENCHMARK_ID.lower(),
+                benchmark_id.lower(),
+            ),
+        }
+        for composition in benchmark_reference["benchmark_compositions"]
+    ]
+    benchmark_reference["benchmark_return_series"] = [
+        {
+            **series_row,
+            "series_id": series_row["series_id"].replace(
+                DEFAULT_DEMO_BENCHMARK_ID.lower(),
+                benchmark_id.lower(),
+            ),
+            "benchmark_id": benchmark_id,
+            "source_vendor": "LOTUS_FRONT_OFFICE_SEED",
+            "source_record_id": series_row["source_record_id"].replace(
+                DEFAULT_DEMO_BENCHMARK_ID.lower(),
+                benchmark_id.lower(),
+            ),
+        }
+        for series_row in benchmark_reference["benchmark_return_series"]
+    ]
+    benchmark_reference["benchmark_assignments"] = [
+        {
+            **assignment,
+            "portfolio_id": portfolio_id,
+            "benchmark_id": benchmark_id,
+            "effective_from": effective_benchmark_start.isoformat(),
+            "assignment_source": "front_office_portfolio_seed",
+            "source_system": "LOTUS_FRONT_OFFICE_SEED",
+        }
+        for assignment in benchmark_reference["benchmark_assignments"]
+    ]
+
+    market_price_specs = {
+        "FO_EQ_AAPL_US": (Decimal("184.00"), Decimal("212.00")),
+        "FO_EQ_MSFT_US": (Decimal("398.00"), Decimal("428.00")),
+        "FO_EQ_SAP_DE": (Decimal("118.50"), Decimal("129.20")),
+        "FO_ETF_MSCI_WORLD": (Decimal("97.00"), Decimal("103.80")),
+        "FO_FUND_BLK_ALLOC": (Decimal("104.20"), Decimal("108.40")),
+        "FO_FUND_PIMCO_INC": (Decimal("100.10"), Decimal("102.40")),
+        "FO_BOND_UST_2030": (Decimal("98.30"), Decimal("101.35")),
+        "FO_BOND_SIEMENS_2031": (Decimal("97.90"), Decimal("99.25")),
+        "FO_PRIV_PRIVATE_CREDIT_A": (Decimal("99.20"), Decimal("101.10")),
+    }
+
+    market_prices: list[dict[str, Any]] = []
+    for current_date in calendar_dates:
+        market_prices.extend(
+            [
+                {
+                    "security_id": "CASH_USD_BOOK_OPERATING",
+                    "price_date": current_date,
+                    "price": "1.0000000000",
+                    "currency": "USD",
+                },
+                {
+                    "security_id": "CASH_EUR_BOOK_OPERATING",
+                    "price_date": current_date,
+                    "price": "1.0000000000",
+                    "currency": "EUR",
+                },
+            ]
+        )
+
+    for security_id, (start_price, end_price) in market_price_specs.items():
+        security_dates = calendar_dates
+        for current_date, price in zip(
+            security_dates,
+            _interpolate_prices(dates=security_dates, start_price=start_price, end_price=end_price),
+            strict=True,
+        ):
+            currency = next(
+                instrument["currency"]
+                for instrument in instruments
+                if instrument["security_id"] == security_id
+            )
+            market_prices.append(
+                {
+                    "security_id": security_id,
+                    "price_date": current_date,
+                    "price": price,
+                    "currency": currency,
+                }
+            )
+
+    eur_usd = _interpolate_prices(
+        dates=fx_calendar_dates,
+        start_price=Decimal("1.072500"),
+        end_price=Decimal("1.110000"),
+        precision="0.000001",
+    )
+    fx_rates: list[dict[str, Any]] = []
+    for current_date, eur_usd_rate in zip(fx_calendar_dates, eur_usd, strict=True):
+        inverse_rate = format(
+            (Decimal("1") / Decimal(eur_usd_rate)).quantize(Decimal("0.000001")),
+            "f",
+        )
+        fx_rates.extend(
+            [
+                {
+                    "from_currency": "EUR",
+                    "to_currency": "USD",
+                    "rate_date": current_date,
+                    "rate": eur_usd_rate,
+                },
+                {
+                    "from_currency": "USD",
+                    "to_currency": "EUR",
+                    "rate_date": current_date,
+                    "rate": inverse_rate,
+                },
+            ]
+        )
+
+    return {
+        "source_system": "LOTUS_FRONT_OFFICE_SEED",
+        "mode": "UPSERT",
+        "business_dates": [{"business_date": current_date} for current_date in business_dates],
+        "portfolios": portfolios,
+        "instruments": instruments,
+        "cash_accounts": cash_accounts,
+        "transactions": transactions,
+        "market_prices": market_prices,
+        "fx_rates": fx_rates,
+        "as_of_date": as_of_date,
+        **benchmark_reference,
+    }
+
+
+def _build_portfolio_bundle_payload(bundle: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "source_system": bundle["source_system"],
+        "mode": bundle["mode"],
+        "business_dates": bundle["business_dates"],
+        "portfolios": bundle["portfolios"],
+        "instruments": bundle["instruments"],
+        "transactions": bundle["transactions"],
+        "market_prices": bundle["market_prices"],
+        "fx_rates": bundle["fx_rates"],
+        "as_of_date": bundle["as_of_date"],
+    }
+
+
+def _portfolio_exists(query_base_url: str, portfolio_id: str) -> bool:
+    _, payload = _request_json("GET", f"{query_base_url}/portfolios?portfolio_id={portfolio_id}")
+    return any(item.get("portfolio_id") == portfolio_id for item in payload.get("portfolios") or [])
+
+
+def _ingest_reference_data(ingestion_base_url: str, bundle: dict[str, Any]) -> None:
+    reference_payloads = (
+        ("/ingest/reference/cash-accounts", {"cash_accounts": bundle["cash_accounts"]}),
+        ("/ingest/indices", {"indices": bundle["indices"]}),
+        ("/ingest/index-price-series", {"index_price_series": bundle["index_price_series"]}),
+        ("/ingest/index-return-series", {"index_return_series": bundle["index_return_series"]}),
+        (
+            "/ingest/benchmark-definitions",
+            {"benchmark_definitions": bundle["benchmark_definitions"]},
+        ),
+        (
+            "/ingest/benchmark-compositions",
+            {"benchmark_compositions": bundle["benchmark_compositions"]},
+        ),
+        (
+            "/ingest/benchmark-return-series",
+            {"benchmark_return_series": bundle["benchmark_return_series"]},
+        ),
+        (
+            "/ingest/benchmark-assignments",
+            {"benchmark_assignments": bundle["benchmark_assignments"]},
+        ),
+    )
+    for endpoint, payload in reference_payloads:
+        _request_json("POST", f"{ingestion_base_url}{endpoint}", payload=payload)
+
+
+def _cleanup_existing_front_office_seed(
+    *,
+    postgres_container: str,
+    portfolio_id: str,
+    benchmark_id: str,
+) -> None:
+    sql = build_front_office_seed_cleanup_sql(
+        portfolio_id=portfolio_id,
+        benchmark_id=benchmark_id,
+    )
+    subprocess.run(
+        [
+            "docker",
+            "exec",
+            postgres_container,
+            "psql",
+            "-U",
+            "user",
+            "-d",
+            "portfolio_db",
+            "-c",
+            sql,
+        ],
+        check=True,
+    )
+
+
+def _verify_front_office_portfolio(
+    *,
+    query_base_url: str,
+    query_control_plane_base_url: str,
+    gateway_base_url: str,
+    expected: FrontOfficePortfolioExpectation,
+    as_of_date: str,
+    end_date: str,
+    wait_seconds: int,
+    poll_interval_seconds: int,
+) -> dict[str, Any]:
+    deadline = datetime.now(tz=UTC) + timedelta(seconds=wait_seconds)
+    while datetime.now(tz=UTC) < deadline:
+        try:
+            _, positions_payload = _request_json(
+                "GET", f"{query_base_url}/portfolios/{expected.portfolio_id}/positions"
+            )
+            _, transactions_payload = _request_json(
+                "GET", f"{query_base_url}/portfolios/{expected.portfolio_id}/transactions?limit=300"
+            )
+            _, allocation_payload = _request_json(
+                "POST",
+                f"{query_base_url}/reporting/asset-allocation/query",
+                payload={
+                    "scope": {"portfolio_id": expected.portfolio_id},
+                    "as_of_date": as_of_date,
+                    "reporting_currency": "USD",
+                    "dimensions": ["asset_class", "sector", "region", "currency"],
+                },
+            )
+            _, cash_payload = _request_json(
+                "POST",
+                f"{query_base_url}/reporting/cash-balances/query",
+                payload={
+                    "portfolio_id": expected.portfolio_id,
+                    "as_of_date": as_of_date,
+                    "reporting_currency": "USD",
+                },
+            )
+            _, income_payload = _request_json(
+                "POST",
+                f"{query_base_url}/reporting/income-summary/query",
+                payload={
+                    "scope": {"portfolio_id": expected.portfolio_id},
+                    "window": {"start_date": "2026-02-27", "end_date": end_date},
+                    "reporting_currency": "USD",
+                },
+            )
+            _, activity_payload = _request_json(
+                "POST",
+                f"{query_base_url}/reporting/activity-summary/query",
+                payload={
+                    "scope": {"portfolio_id": expected.portfolio_id},
+                    "window": {"start_date": "2026-02-27", "end_date": end_date},
+                    "reporting_currency": "USD",
+                },
+            )
+            _, benchmark_assignment = _request_json(
+                "POST",
+                f"{query_control_plane_base_url}/integration/portfolios/{expected.portfolio_id}/benchmark-assignment",
+                payload={"as_of_date": as_of_date, "consumer_system": "lotus-performance"},
+            )
+            _, cashflow_projection = _request_json(
+                "GET",
+                f"{query_base_url}/portfolios/{expected.portfolio_id}/cashflow-projection"
+                f"?as_of_date={as_of_date}&horizon_days=30&include_projected=true",
+            )
+            _, performance_summary = _request_json(
+                "GET",
+                f"{gateway_base_url}/api/v1/workbench/{expected.portfolio_id}/performance/summary"
+                f"?period=YTD&chart_frequency=monthly&contribution_dimension=asset_class"
+                f"&attribution_dimension=asset_class&detail_basis=NET",
+            )
+        except RuntimeError:
+            LOGGER.info("Verification still waiting on downstream services.")
+            continue
+
+        positions = positions_payload.get("positions") or []
+        valued = [
+            row
+            for row in positions
+            if isinstance(row.get("valuation"), dict)
+            and row["valuation"].get("market_value") is not None
+        ]
+        cash_accounts = cash_payload.get("cash_accounts") or []
+        income_rows = ((income_payload.get("portfolios") or [{}])[0]).get("income_types") or []
+        activity_rows = ((activity_payload.get("portfolios") or [{}])[0]).get("buckets") or []
+        allocation_views = allocation_payload.get("views") or []
+        total_transactions = int(transactions_payload.get("total", 0))
+        projected_cashflow_points = cashflow_projection.get("points") or []
+        has_non_zero_projection = any(
+            str(point.get("net_cashflow")) not in {"0", "0.0", "0.00", "0.0000", "0E-10"}
+            for point in projected_cashflow_points
+            if isinstance(point, dict)
+        )
+
+        if (
+            len(positions) >= expected.min_positions
+            and len(valued) >= expected.min_valued_positions
+            and total_transactions >= expected.min_transactions
+            and len(cash_accounts) >= expected.min_cash_accounts
+            and allocation_views
+            and income_rows
+            and activity_rows
+            and has_non_zero_projection
+            and benchmark_assignment.get("benchmark_id")
+            and performance_summary.get("benchmark_code")
+        ):
+            return {
+                "portfolio_id": expected.portfolio_id,
+                "positions": len(positions),
+                "valued_positions": len(valued),
+                "transactions": total_transactions,
+                "cash_accounts": len(cash_accounts),
+                "allocation_views": len(allocation_views),
+                "income_types": len(income_rows),
+                "activity_buckets": len(activity_rows),
+                "projected_cashflow_points": len(projected_cashflow_points),
+                "benchmark_code": performance_summary.get("benchmark_code"),
+            }
+
+    raise TimeoutError(
+        f"Timed out verifying front-office portfolio seed for {expected.portfolio_id}."
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Seed a realistic front-office portfolio scenario."
+    )
+    parser.add_argument("--portfolio-id", default=DEFAULT_PORTFOLIO_ID)
+    parser.add_argument("--start-date", default="2025-03-31")
+    parser.add_argument("--end-date", default="2026-03-28")
+    parser.add_argument("--benchmark-start-date", default="2025-01-06")
+    parser.add_argument("--benchmark-id", default=DEFAULT_BENCHMARK_ID)
+    parser.add_argument("--ingestion-base-url", default="http://127.0.0.1:8200")
+    parser.add_argument("--query-base-url", default="http://127.0.0.1:8201")
+    parser.add_argument("--query-control-plane-base-url", default="http://127.0.0.1:8202")
+    parser.add_argument("--gateway-base-url", default="http://127.0.0.1:8100")
+    parser.add_argument("--wait-seconds", type=int, default=300)
+    parser.add_argument("--poll-interval-seconds", type=int, default=3)
+    parser.add_argument("--postgres-container", default=DEFAULT_POSTGRES_CONTAINER)
+    parser.add_argument("--skip-cleanup", action="store_true")
+    parser.add_argument("--verify-only", action="store_true")
+    parser.add_argument("--ingest-only", action="store_true")
+    parser.add_argument("--force-ingest", action="store_true")
+    parser.add_argument("--log-level", default="INFO")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+    if args.verify_only and args.ingest_only:
+        raise ValueError("Cannot use --verify-only with --ingest-only")
+
+    start_date = date.fromisoformat(args.start_date)
+    end_date = date.fromisoformat(args.end_date)
+    benchmark_start_date = date.fromisoformat(args.benchmark_start_date)
+
+    ingestion_base_url = args.ingestion_base_url.rstrip("/")
+    query_base_url = args.query_base_url.rstrip("/")
+    query_control_plane_base_url = args.query_control_plane_base_url.rstrip("/")
+    gateway_base_url = args.gateway_base_url.rstrip("/")
+
+    _wait_ready(f"{ingestion_base_url}/health/ready", args.wait_seconds, args.poll_interval_seconds)
+    _wait_ready(f"{query_base_url}/health/ready", args.wait_seconds, args.poll_interval_seconds)
+    _wait_ready(
+        f"{query_control_plane_base_url}/health/ready",
+        args.wait_seconds,
+        args.poll_interval_seconds,
+    )
+
+    bundle = build_front_office_portfolio_bundle(
+        portfolio_id=args.portfolio_id,
+        start_date=start_date,
+        end_date=end_date,
+        benchmark_start_date=benchmark_start_date,
+        benchmark_id=args.benchmark_id,
+    )
+    if not args.verify_only:
+        if not args.skip_cleanup:
+            _cleanup_existing_front_office_seed(
+                postgres_container=args.postgres_container,
+                portfolio_id=args.portfolio_id,
+                benchmark_id=args.benchmark_id,
+            )
+        if args.force_ingest or not _portfolio_exists(query_base_url, args.portfolio_id):
+            payload = _build_portfolio_bundle_payload(bundle)
+            _request_json("POST", f"{ingestion_base_url}/ingest/portfolio-bundle", payload=payload)
+        _ingest_reference_data(ingestion_base_url, bundle)
+
+    if not args.ingest_only:
+        verification = _verify_front_office_portfolio(
+            query_base_url=query_base_url,
+            query_control_plane_base_url=query_control_plane_base_url,
+            gateway_base_url=gateway_base_url,
+            expected=FRONT_OFFICE_EXPECTATION,
+            as_of_date=end_date.isoformat(),
+            end_date=end_date.isoformat(),
+            wait_seconds=args.wait_seconds,
+            poll_interval_seconds=args.poll_interval_seconds,
+        )
+        LOGGER.info("Front-office seed verified: %s", verification)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- harden position-timeseries fan-out so material changes always re-arm portfolio aggregation
- fix bootstrap eligibility for stranded first-day aggregation jobs even when later portfolio history exists
- add a realistic front-office portfolio seed plus runbook and validation contract updates

## Validation
- `python -m pytest tests/integration/services/timeseries_generator_service/test_timeseries_repository_integration.py tests/unit/services/portfolio_aggregation_service/repositories/test_timeseries_repository.py tests/unit/services/timeseries_generator_service/timeseries-generator-service/consumers/test_position_timeseries_consumer.py tests/unit/tools/test_front_office_portfolio_seed.py -q`
- `29 passed`
- `python -m ruff check src/libs/portfolio-common/portfolio_common/timeseries_repository_base.py src/services/timeseries_generator_service/app/consumers/position_timeseries_consumer.py tests/integration/services/timeseries_generator_service/test_timeseries_repository_integration.py tests/unit/services/portfolio_aggregation_service/repositories/test_timeseries_repository.py tests/unit/services/timeseries_generator_service/timeseries-generator-service/consumers/test_position_timeseries_consumer.py tools/front_office_portfolio_seed.py tests/unit/tools/test_front_office_portfolio_seed.py`
- passed