### PR TITLE
fix(control-plane): repair advisory simulation import for service image

### DIFF
--- a/src/services/query_control_plane_service/app/routers/advisory_simulation.py
+++ b/src/services/query_control_plane_service/app/routers/advisory_simulation.py
@@ -4,19 +4,20 @@ from typing import Annotated
 
 from fastapi import APIRouter, Header, Response, status
 
-from src.services.query_control_plane_service.app.contracts import (
-    ADVISORY_SIMULATION_CONTRACT_VERSION,
-    ADVISORY_SIMULATION_CONTRACT_VERSION_HEADER,
-    CanonicalSimulationContractError,
-    CanonicalSimulationErrorCode,
-    CanonicalSimulationProblemDetails,
-)
 from src.services.query_service.app.advisory_simulation.models import (
     ProposalResult,
     ProposalSimulateRequest,
 )
 from src.services.query_service.app.services.advisory_simulation_service import (
     execute_advisory_simulation,
+)
+
+from ..contracts import (
+    ADVISORY_SIMULATION_CONTRACT_VERSION,
+    ADVISORY_SIMULATION_CONTRACT_VERSION_HEADER,
+    CanonicalSimulationContractError,
+    CanonicalSimulationErrorCode,
+    CanonicalSimulationProblemDetails,
 )
 
 router = APIRouter(prefix="/integration/advisory/proposals", tags=["Integration"])


### PR DESCRIPTION
## Summary
- fix the advisory simulation router import path so `query_control_plane_service` starts correctly inside the service image

## Why This PR Exists
PR #292 merged the canonical advisory simulation cutover, but the latency/startup job later exposed a real service-image import bug. The control-plane router imported `src.services.query_control_plane_service...` from inside the service image, where that package path is not valid.

## Changes
- switch the advisory simulation router to a local relative import for the control-plane contracts package

## Verification
- `python -m ruff check src/services/query_control_plane_service/app/routers/advisory_simulation.py`
- `python -m mypy src/services/query_control_plane_service/app/routers/advisory_simulation.py`
- `python -m pytest tests/integration/services/query_service/test_advisory_simulation_router.py tests/unit/services/query_service/services/test_advisory_simulation_service.py tests/unit/services/query_service/services/test_advisory_simulation_parity.py`

## Closure
- this is required post-merge stabilization for RFC-085
- it fixes the actual startup failure surfaced by the latency gate on PR #292
