### PR TITLE
feat(core): complete RFC-0020 canonical allocation convergence

### DIFF
--- a/alembic/versions/0d4e5f6a7b8c_feat_add_liquidity_tier_to_instruments.py
+++ b/alembic/versions/0d4e5f6a7b8c_feat_add_liquidity_tier_to_instruments.py
@@ -1,0 +1,29 @@
+"""feat_add_liquidity_tier_to_instruments
+
+Revision ID: 0d4e5f6a7b8c
+Revises: c9e0f1a2b3c4
+Create Date: 2026-04-07 18:20:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0d4e5f6a7b8c"
+down_revision: Union[str, None] = "c9e0f1a2b3c4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "instruments",
+        sa.Column("liquidity_tier", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("instruments", "liquidity_tier")

--- a/docs/RFCs/RFC 085 - Advisory-Grade Canonical Simulation Execution for lotus-advise.md
+++ b/docs/RFCs/RFC 085 - Advisory-Grade Canonical Simulation Execution for lotus-advise.md
@@ -279,9 +279,19 @@ and future drill-down work. They are intentionally excluded from the RFC-0020 pr
 API surface to avoid cluttering the advisor-facing before/after view.
 
 Slice 1 of RFC-0020 adds a guarded contract map in code so changes to live reporting allocation
-dimensions cannot silently drift away from advisory proposal allocation expectations. Later slices
-must use the shared `lotus-core` allocation calculator for both live and projected state instead of
-maintaining advisory-specific bucket logic.
+dimensions cannot silently drift away from advisory proposal allocation expectations.
+
+Slice 2 extracts a shared `lotus-core` allocation calculator and routes both live reporting and
+advisory simulation asset-class aggregation through it. Advisory simulation still retains
+compatibility fields such as instrument allocation and shelf-attribute allocation until the
+canonical allocation-lens response fields are introduced in RFC-0020 Slice 3.
+
+The Slice 2 test baseline covers:
+
+1. every live reporting allocation dimension in the shared calculator;
+2. live reporting regression behavior after the calculator extraction;
+3. advisory valuation parity against the shared calculator; and
+4. no-op advisory before/after allocation parity for the shared calculator path.
 
 ## Follow-on Work
 

--- a/docs/RFCs/RFC 085 - Advisory-Grade Canonical Simulation Execution for lotus-advise.md
+++ b/docs/RFCs/RFC 085 - Advisory-Grade Canonical Simulation Execution for lotus-advise.md
@@ -293,6 +293,17 @@ The Slice 2 test baseline covers:
 3. advisory valuation parity against the shared calculator; and
 4. no-op advisory before/after allocation parity for the shared calculator path.
 
+Slice 3 adds canonical allocation-lens fields to `advisory-simulation.v1` without creating
+`advisory-simulation.v2`:
+
+1. `before.allocation_views`
+2. `after_simulated.allocation_views`
+3. top-level `allocation_lens`
+
+The allocation views expose only the RFC-0020 proposal subset: `asset_class`, `currency`, `sector`,
+`country`, `region`, `product_type`, and `rating`. Legacy allocation fields remain present for
+compatibility while `lotus-advise` migrates callers to the canonical allocation-lens shape.
+
 ## Follow-on Work
 
 1. Continue the platform-level hardening program for canonical simulation governance and duplicate

--- a/docs/RFCs/RFC 085 - Advisory-Grade Canonical Simulation Execution for lotus-advise.md
+++ b/docs/RFCs/RFC 085 - Advisory-Grade Canonical Simulation Execution for lotus-advise.md
@@ -304,6 +304,16 @@ The allocation views expose only the RFC-0020 proposal subset: `asset_class`, `c
 `country`, `region`, `product_type`, and `rating`. Legacy allocation fields remain present for
 compatibility while `lotus-advise` migrates callers to the canonical allocation-lens shape.
 
+RFC-0020 Slice 6 closes the remaining live parity gaps for this contract:
+
+1. stateful advisory requests now preserve the live classification metadata needed by the shared
+   allocation calculator instead of collapsing non-asset-class dimensions into `UNCLASSIFIED`;
+2. proposal cash allocation preserves per-currency rows instead of aggregating all cash into one
+   base-currency bucket;
+3. proposal allocation-view labels and weight precision now align with direct live reporting; and
+4. the cross-service live parity validator passes against seeded portfolios with `lotus-core`,
+   `lotus-risk`, and `lotus-advise` running together.
+
 ## Follow-on Work
 
 1. Continue the platform-level hardening program for canonical simulation governance and duplicate

--- a/docs/RFCs/RFC 085 - Advisory-Grade Canonical Simulation Execution for lotus-advise.md
+++ b/docs/RFCs/RFC 085 - Advisory-Grade Canonical Simulation Execution for lotus-advise.md
@@ -250,6 +250,39 @@ This RFC is complete when:
 1. Should the long-term shared execution logic remain in `lotus-core` directly or later move into a dedicated shared simulation package owned by `lotus-core`?
 2. Should `lotus-risk` eventually consume the same advisory execution lineage metadata for scenario-linked analytics evidence?
 
+## RFC-0020 Allocation Lens Baseline
+
+RFC-0020 extends the implemented advisory simulation contract with canonical allocation-lens
+governance before the Lotus apps are live. Because all callers remain controlled, the allocation
+lens is additive to `advisory-simulation.v1`; RFC-0020 does not introduce
+`advisory-simulation.v2`.
+
+The proposal-facing allocation subset is intentionally front-office oriented:
+
+1. `asset_class`
+2. `currency`
+3. `sector`
+4. `country`
+5. `region`
+6. `product_type`
+7. `rating`
+
+Live reporting still supports issuer dimensions:
+
+1. `issuer_id`
+2. `issuer_name`
+3. `ultimate_parent_issuer_id`
+4. `ultimate_parent_issuer_name`
+
+Those issuer dimensions remain available to live reporting, `lotus-risk` concentration analytics,
+and future drill-down work. They are intentionally excluded from the RFC-0020 proposal allocation
+API surface to avoid cluttering the advisor-facing before/after view.
+
+Slice 1 of RFC-0020 adds a guarded contract map in code so changes to live reporting allocation
+dimensions cannot silently drift away from advisory proposal allocation expectations. Later slices
+must use the shared `lotus-core` allocation calculator for both live and projected state instead of
+maintaining advisory-specific bucket logic.
+
 ## Follow-on Work
 
 1. Continue the platform-level hardening program for canonical simulation governance and duplicate

--- a/src/libs/portfolio-common/portfolio_common/database_models.py
+++ b/src/libs/portfolio-common/portfolio_common/database_models.py
@@ -227,6 +227,7 @@ class Instrument(Base):
     sector = Column(String, nullable=True)
     country_of_risk = Column(String, nullable=True)
     rating = Column(String, nullable=True)
+    liquidity_tier = Column(String, nullable=True)
     maturity_date = Column(Date, nullable=True)
     issuer_id = Column(String, nullable=True, index=True)
     issuer_name = Column(String, nullable=True)

--- a/src/libs/portfolio-common/portfolio_common/events.py
+++ b/src/libs/portfolio-common/portfolio_common/events.py
@@ -103,6 +103,7 @@ class InstrumentEvent(BaseModel):
     sector: Optional[str] = None
     country_of_risk: Optional[str] = Field(None)
     rating: Optional[str] = None
+    liquidity_tier: Optional[str] = Field(None)
     maturity_date: Optional[date] = Field(None)
     issuer_id: Optional[str] = Field(None)
     issuer_name: Optional[str] = Field(None)

--- a/src/services/ingestion_service/app/DTOs/instrument_dto.py
+++ b/src/services/ingestion_service/app/DTOs/instrument_dto.py
@@ -100,6 +100,11 @@ class Instrument(BaseModel):
         description="Credit rating for fixed-income instruments.",
         examples=["BB+"],
     )
+    liquidity_tier: Optional[str] = Field(
+        None,
+        description="Liquidity tier used by advisory suitability and risk workflows.",
+        examples=["L1", "L3"],
+    )
     maturity_date: Optional[date] = Field(
         None,
         description="Maturity date for instruments with contractual maturity.",
@@ -147,6 +152,7 @@ class Instrument(BaseModel):
                 "sector": "Financials",
                 "country_of_risk": "GB",
                 "rating": "BB+",
+                "liquidity_tier": "L2",
                 "maturity_date": None,
                 "issuer_id": "ISSUER_BARC",
                 "issuer_name": "Barclays PLC",
@@ -174,6 +180,7 @@ class InstrumentIngestionRequest(BaseModel):
                     "sector": "financials",
                     "country_of_risk": "GB",
                     "rating": "BB+",
+                    "liquidity_tier": "L2",
                     "issuer_id": "ISSUER_BARC",
                     "issuer_name": "Barclays PLC",
                     "ultimate_parent_issuer_id": "ULTIMATE_BARC",

--- a/src/services/query_service/app/advisory_simulation/allocation_contract.py
+++ b/src/services/query_service/app/advisory_simulation/allocation_contract.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import get_args
+
+from src.services.query_service.app.dtos.reporting_dto import AllocationDimension
+
+ADVISORY_PROPOSAL_ALLOCATION_DIMENSIONS: tuple[AllocationDimension, ...] = (
+    "asset_class",
+    "currency",
+    "sector",
+    "country",
+    "region",
+    "product_type",
+    "rating",
+)
+
+ALLOCATION_DIMENSIONS_RESERVED_FOR_RISK_OR_DRILLDOWN: tuple[AllocationDimension, ...] = (
+    "issuer_id",
+    "issuer_name",
+    "ultimate_parent_issuer_id",
+    "ultimate_parent_issuer_name",
+)
+
+ADVISORY_SIMULATION_ALLOCATION_LENS_CONTRACT_VERSION = "advisory-simulation.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class AllocationLensContract:
+    contract_version: str
+    proposal_dimensions: tuple[AllocationDimension, ...]
+    reserved_dimensions: tuple[AllocationDimension, ...]
+    live_reporting_dimensions: tuple[AllocationDimension, ...]
+
+
+def live_reporting_allocation_dimensions() -> tuple[AllocationDimension, ...]:
+    return get_args(AllocationDimension)
+
+
+def advisory_proposal_allocation_lens_contract() -> AllocationLensContract:
+    live_dimensions = live_reporting_allocation_dimensions()
+    return AllocationLensContract(
+        contract_version=ADVISORY_SIMULATION_ALLOCATION_LENS_CONTRACT_VERSION,
+        proposal_dimensions=ADVISORY_PROPOSAL_ALLOCATION_DIMENSIONS,
+        reserved_dimensions=ALLOCATION_DIMENSIONS_RESERVED_FOR_RISK_OR_DRILLDOWN,
+        live_reporting_dimensions=live_dimensions,
+    )
+
+
+def validate_advisory_proposal_allocation_lens_contract() -> None:
+    contract = advisory_proposal_allocation_lens_contract()
+    classified_dimensions = set(contract.proposal_dimensions) | set(contract.reserved_dimensions)
+    live_dimensions = set(contract.live_reporting_dimensions)
+    if classified_dimensions != live_dimensions:
+        missing = sorted(live_dimensions - classified_dimensions)
+        extra = sorted(classified_dimensions - live_dimensions)
+        raise ValueError(
+            "Advisory proposal allocation lens contract is out of sync with live "
+            f"reporting allocation dimensions. missing={missing}; extra={extra}"
+        )

--- a/src/services/query_service/app/advisory_simulation/models.py
+++ b/src/services/query_service/app/advisory_simulation/models.py
@@ -624,7 +624,7 @@ class ProposalAllocationBucket(BaseModel):
 
     @field_serializer("weight")
     def serialize_weight(self, value: Decimal) -> Decimal:
-        return _quantize_ratio(value)
+        return value
 
 
 class ProposalAllocationView(BaseModel):

--- a/src/services/query_service/app/advisory_simulation/models.py
+++ b/src/services/query_service/app/advisory_simulation/models.py
@@ -602,6 +602,69 @@ class AllocationMetric(BaseModel):
         return _quantize_ratio(value)
 
 
+ProposalAllocationDimension = Literal[
+    "asset_class",
+    "currency",
+    "sector",
+    "country",
+    "region",
+    "product_type",
+    "rating",
+]
+
+
+class ProposalAllocationBucket(BaseModel):
+    key: str = Field(description="Allocation bucket key for the requested dimension.")
+    weight: Decimal = Field(description="Bucket weight in total portfolio value.")
+    value: Money = Field(description="Bucket value in the portfolio reporting currency.")
+    position_count: int = Field(
+        ge=0,
+        description="Number of position or cash rows contributing to this bucket.",
+    )
+
+    @field_serializer("weight")
+    def serialize_weight(self, value: Decimal) -> Decimal:
+        return _quantize_ratio(value)
+
+
+class ProposalAllocationView(BaseModel):
+    dimension: ProposalAllocationDimension = Field(
+        description="Front-office allocation dimension used for proposal before/after review."
+    )
+    total_value: Money = Field(description="Total value used as the allocation denominator.")
+    buckets: List[ProposalAllocationBucket] = Field(
+        default_factory=list,
+        description="Sorted allocation buckets for this dimension.",
+    )
+
+
+class ProposalAllocationLens(BaseModel):
+    contract_version: str = Field(
+        default="advisory-simulation.v1",
+        description="Simulation contract version that governs the allocation lens.",
+    )
+    calculator_version: str = Field(
+        default="lotus-core.allocation-calculator.v1",
+        description="Internal calculator version for replay and audit evidence.",
+    )
+    dimensions: List[ProposalAllocationDimension] = Field(
+        default_factory=lambda: [
+            "asset_class",
+            "currency",
+            "sector",
+            "country",
+            "region",
+            "product_type",
+            "rating",
+        ],
+        description="Curated proposal allocation dimensions included in before/after states.",
+    )
+    source: Literal["LOTUS_CORE"] = Field(
+        default="LOTUS_CORE",
+        description="Authoritative service that computed the allocation lens.",
+    )
+
+
 class PositionSummary(BaseModel):
     instrument_id: str = Field(description="Instrument identifier.")
     quantity: Decimal = Field(description="Simulated quantity.")
@@ -640,6 +703,13 @@ class SimulatedState(BaseModel):
     allocation_by_attribute: Dict[str, List[AllocationMetric]] = Field(
         default_factory=dict,
         description="Allocation grouped by configured shelf attributes.",
+    )
+    allocation_views: List[ProposalAllocationView] = Field(
+        default_factory=list,
+        description=(
+            "Canonical proposal allocation views computed by the lotus-core allocation "
+            "calculator for curated front-office dimensions."
+        ),
     )
 
 
@@ -1422,5 +1492,9 @@ class ProposalResult(BaseModel):
     gate_decision: Optional[GateDecision] = Field(
         default=None,
         description="Deterministic workflow gate decision for advisory workflow routing.",
+    )
+    allocation_lens: ProposalAllocationLens = Field(
+        default_factory=ProposalAllocationLens,
+        description="Canonical allocation-lens metadata for proposal before/after states.",
     )
     lineage: LineageData = Field(description="Lineage identifiers and request hash.")

--- a/src/services/query_service/app/advisory_simulation/valuation.py
+++ b/src/services/query_service/app/advisory_simulation/valuation.py
@@ -132,13 +132,21 @@ def _cash_allocation_instrument(base_ccy: str) -> SimpleNamespace:
         currency=base_ccy,
         sector=None,
         country_of_risk=None,
-        product_type=None,
+        product_type="Cash",
         rating=None,
         issuer_id=None,
         issuer_name=None,
         ultimate_parent_issuer_id=None,
         ultimate_parent_issuer_name=None,
     )
+
+
+def _display_bucket_key(*, dimension: str, bucket_key: str) -> str:
+    if dimension == "asset_class":
+        if bucket_key == "CASH":
+            return "Cash"
+        return bucket_key.title()
+    return bucket_key
 
 
 def _asset_class_allocation_metrics(
@@ -178,7 +186,10 @@ def _proposal_allocation_views(
                 },
                 "buckets": [
                     {
-                        "key": bucket.dimension_value,
+                        "key": _display_bucket_key(
+                            dimension=view.dimension,
+                            bucket_key=bucket.dimension_value,
+                        ),
                         "weight": bucket.weight,
                         "value": {
                             "amount": bucket.market_value_reporting_currency,
@@ -277,7 +288,6 @@ def build_simulated_state(
         for p in pos_summaries
     ]
 
-    total_cash_val = Decimal("0")
     for cash in portfolio.cash_balances:
         val = cash.amount
         if cash.currency != base_ccy:
@@ -286,15 +296,13 @@ def build_simulated_state(
                 val = cash.amount * rate
             else:
                 val = Decimal("0")
-        total_cash_val += val
-
-    allocation_rows.append(
-        AllocationInputRow(
-            instrument=_cash_allocation_instrument(base_ccy),
-            snapshot=SimpleNamespace(security_id=f"CASH_{base_ccy}"),
-            market_value_reporting_currency=total_cash_val,
+        allocation_rows.append(
+            AllocationInputRow(
+                instrument=_cash_allocation_instrument(cash.currency),
+                snapshot=SimpleNamespace(security_id=f"CASH_{cash.currency}"),
+                market_value_reporting_currency=val,
+            )
         )
-    )
 
     allocation_views = _proposal_allocation_views(rows=allocation_rows, base_ccy=base_ccy)
     alloc_asset_class = _asset_class_allocation_metrics(rows=allocation_rows, base_ccy=base_ccy)

--- a/src/services/query_service/app/advisory_simulation/valuation.py
+++ b/src/services/query_service/app/advisory_simulation/valuation.py
@@ -6,6 +6,9 @@ from decimal import Decimal
 from types import SimpleNamespace
 from typing import Dict, List, Optional
 
+from src.services.query_service.app.advisory_simulation.allocation_contract import (
+    ADVISORY_PROPOSAL_ALLOCATION_DIMENSIONS,
+)
 from src.services.query_service.app.advisory_simulation.models import (
     AllocationMetric,
     EngineOptions,
@@ -14,6 +17,7 @@ from src.services.query_service.app.advisory_simulation.models import (
     PortfolioSnapshot,
     Position,
     PositionSummary,
+    ProposalAllocationView,
     ShelfEntry,
     SimulatedState,
     ValuationMode,
@@ -155,6 +159,41 @@ def _asset_class_allocation_metrics(
     ]
 
 
+def _proposal_allocation_views(
+    *,
+    rows: List[AllocationInputRow],
+    base_ccy: str,
+) -> List[ProposalAllocationView]:
+    allocation = calculate_allocation_views(
+        rows=rows,
+        dimensions=list(ADVISORY_PROPOSAL_ALLOCATION_DIMENSIONS),
+    )
+    return [
+        ProposalAllocationView.model_validate(
+            {
+                "dimension": view.dimension,
+                "total_value": {
+                    "amount": view.total_market_value_reporting_currency,
+                    "currency": base_ccy,
+                },
+                "buckets": [
+                    {
+                        "key": bucket.dimension_value,
+                        "weight": bucket.weight,
+                        "value": {
+                            "amount": bucket.market_value_reporting_currency,
+                            "currency": base_ccy,
+                        },
+                        "position_count": bucket.position_count,
+                    }
+                    for bucket in view.buckets
+                ],
+            }
+        )
+        for view in allocation.views
+    ]
+
+
 def build_simulated_state(
     portfolio: PortfolioSnapshot,
     market_data: MarketDataSnapshot,
@@ -257,6 +296,7 @@ def build_simulated_state(
         )
     )
 
+    allocation_views = _proposal_allocation_views(rows=allocation_rows, base_ccy=base_ccy)
     alloc_asset_class = _asset_class_allocation_metrics(rows=allocation_rows, base_ccy=base_ccy)
 
     # Convert attribute map to model output
@@ -281,4 +321,5 @@ def build_simulated_state(
         allocation_by_instrument=alloc_instr,
         allocation=alloc_instr,
         allocation_by_attribute=alloc_by_attr,
+        allocation_views=allocation_views,
     )

--- a/src/services/query_service/app/advisory_simulation/valuation.py
+++ b/src/services/query_service/app/advisory_simulation/valuation.py
@@ -3,6 +3,7 @@ FILE: src/core/valuation.py
 """
 
 from decimal import Decimal
+from types import SimpleNamespace
 from typing import Dict, List, Optional
 
 from src.services.query_service.app.advisory_simulation.models import (
@@ -16,6 +17,10 @@ from src.services.query_service.app.advisory_simulation.models import (
     ShelfEntry,
     SimulatedState,
     ValuationMode,
+)
+from src.services.query_service.app.services.allocation_calculator import (
+    AllocationInputRow,
+    calculate_allocation_views,
 )
 
 
@@ -31,12 +36,12 @@ def get_fx_rate(market_data: MarketDataSnapshot, from_ccy: str, to_ccy: str) -> 
     pair = f"{from_ccy}/{to_ccy}"
     direct = next((r.rate for r in market_data.fx_rates if r.pair == pair), None)
     if direct:
-        return direct
+        return Decimal(str(direct))
 
     pair_inv = f"{to_ccy}/{from_ccy}"
     inverse = next((r.rate for r in market_data.fx_rates if r.pair == pair_inv), None)
     if inverse:
-        return Decimal("1.0") / inverse
+        return Decimal("1.0") / Decimal(str(inverse))
 
     return None
 
@@ -94,6 +99,62 @@ class ValuationService:
         )
 
 
+def _shelf_by_instrument(shelf: List[ShelfEntry]) -> Dict[str, ShelfEntry]:
+    return {entry.instrument_id: entry for entry in shelf}
+
+
+def _allocation_instrument_from_summary(
+    summary: PositionSummary,
+    shelf_entry: ShelfEntry | None,
+) -> SimpleNamespace:
+    attributes = shelf_entry.attributes if shelf_entry else {}
+    return SimpleNamespace(
+        asset_class=summary.asset_class,
+        currency=summary.instrument_currency,
+        sector=attributes.get("sector"),
+        country_of_risk=attributes.get("country"),
+        product_type=attributes.get("product_type"),
+        rating=attributes.get("rating"),
+        issuer_id=shelf_entry.issuer_id if shelf_entry else None,
+        issuer_name=attributes.get("issuer_name"),
+        ultimate_parent_issuer_id=attributes.get("ultimate_parent_issuer_id"),
+        ultimate_parent_issuer_name=attributes.get("ultimate_parent_issuer_name"),
+    )
+
+
+def _cash_allocation_instrument(base_ccy: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        asset_class="CASH",
+        currency=base_ccy,
+        sector=None,
+        country_of_risk=None,
+        product_type=None,
+        rating=None,
+        issuer_id=None,
+        issuer_name=None,
+        ultimate_parent_issuer_id=None,
+        ultimate_parent_issuer_name=None,
+    )
+
+
+def _asset_class_allocation_metrics(
+    *,
+    rows: List[AllocationInputRow],
+    base_ccy: str,
+) -> List[AllocationMetric]:
+    allocation = calculate_allocation_views(rows=rows, dimensions=["asset_class"])
+    if not allocation.views:
+        return []
+    return [
+        AllocationMetric(
+            key=bucket.dimension_value,
+            weight=bucket.weight,
+            value=Money(amount=bucket.market_value_reporting_currency, currency=base_ccy),
+        )
+        for bucket in allocation.views[0].buckets
+    ]
+
+
 def build_simulated_state(
     portfolio: PortfolioSnapshot,
     market_data: MarketDataSnapshot,
@@ -145,14 +206,14 @@ def build_simulated_state(
         total_val_safe = total_val
 
     # Aggregation containers
-    alloc_class_map: Dict[str, Decimal] = {}
     alloc_attr_map: Dict[str, Dict[str, Decimal]] = {}
+    allocation_rows: List[AllocationInputRow] = []
+    shelf_by_id = _shelf_by_instrument(shelf)
 
     for p in pos_summaries:
         p.weight = p.value_in_base_ccy.amount / total_val_safe
-        shelf_entry = next((s for s in shelf if s.instrument_id == p.instrument_id), None)
+        shelf_entry = shelf_by_id.get(p.instrument_id)
 
-        # Asset Class Aggregation
         if shelf_entry:
             p.asset_class = shelf_entry.asset_class
             # Attribute Aggregation
@@ -164,8 +225,13 @@ def build_simulated_state(
                     + p.value_in_base_ccy.amount
                 )
 
-        ac = p.asset_class
-        alloc_class_map[ac] = alloc_class_map.get(ac, Decimal("0")) + p.value_in_base_ccy.amount
+        allocation_rows.append(
+            AllocationInputRow(
+                instrument=_allocation_instrument_from_summary(p, shelf_entry),
+                snapshot=SimpleNamespace(security_id=p.instrument_id),
+                market_value_reporting_currency=p.value_in_base_ccy.amount,
+            )
+        )
 
     alloc_instr = [
         AllocationMetric(key=p.instrument_id, weight=p.weight, value=p.value_in_base_ccy)
@@ -183,16 +249,15 @@ def build_simulated_state(
                 val = Decimal("0")
         total_cash_val += val
 
-    alloc_class_map["CASH"] = alloc_class_map.get("CASH", Decimal("0")) + total_cash_val
-
-    alloc_asset_class = [
-        AllocationMetric(
-            key=k,
-            weight=v / total_val_safe,
-            value=Money(amount=v, currency=base_ccy),
+    allocation_rows.append(
+        AllocationInputRow(
+            instrument=_cash_allocation_instrument(base_ccy),
+            snapshot=SimpleNamespace(security_id=f"CASH_{base_ccy}"),
+            market_value_reporting_currency=total_cash_val,
         )
-        for k, v in alloc_class_map.items()
-    ]
+    )
+
+    alloc_asset_class = _asset_class_allocation_metrics(rows=allocation_rows, base_ccy=base_ccy)
 
     # Convert attribute map to model output
     alloc_by_attr = {}

--- a/src/services/query_service/app/dtos/core_snapshot_dto.py
+++ b/src/services/query_service/app/dtos/core_snapshot_dto.py
@@ -381,6 +381,11 @@ class CoreSnapshotInstrumentEnrichmentRecord(BaseModel):
         description="Display name for ultimate parent issuer.",
         examples=["Apple Holdings PLC"],
     )
+    liquidity_tier: Optional[str] = Field(
+        None,
+        description="Liquidity tier used by suitability and concentration workflows.",
+        examples=["L1", "L5"],
+    )
 
 
 class CoreSnapshotPortfolioTotals(BaseModel):

--- a/src/services/query_service/app/dtos/instrument_dto.py
+++ b/src/services/query_service/app/dtos/instrument_dto.py
@@ -55,6 +55,11 @@ class InstrumentRecord(BaseModel):
         description="Optional credit rating used for allocation and analytics.",
         examples=["AA+"],
     )
+    liquidity_tier: Optional[str] = Field(
+        None,
+        description="Optional liquidity tier used by suitability and concentration workflows.",
+        examples=["L1", "L5"],
+    )
     portfolio_id: Optional[str] = Field(
         None,
         description="Optional portfolio identifier when the instrument is portfolio-scoped.",

--- a/src/services/query_service/app/dtos/instrument_dto.py
+++ b/src/services/query_service/app/dtos/instrument_dto.py
@@ -40,6 +40,21 @@ class InstrumentRecord(BaseModel):
         description="Optional asset-class classification.",
         examples=["Equity"],
     )
+    sector: Optional[str] = Field(
+        None,
+        description="Optional sector classification.",
+        examples=["Information Technology"],
+    )
+    country_of_risk: Optional[str] = Field(
+        None,
+        description="Optional country-of-risk classification.",
+        examples=["United States"],
+    )
+    rating: Optional[str] = Field(
+        None,
+        description="Optional credit rating used for allocation and analytics.",
+        examples=["AA+"],
+    )
     portfolio_id: Optional[str] = Field(
         None,
         description="Optional portfolio identifier when the instrument is portfolio-scoped.",

--- a/src/services/query_service/app/dtos/integration_dto.py
+++ b/src/services/query_service/app/dtos/integration_dto.py
@@ -117,6 +117,14 @@ class InstrumentEnrichmentRecord(BaseModel):
         description="Display name for ultimate parent issuer, when available.",
         examples=["Apple Holdings PLC"],
     )
+    liquidity_tier: str | None = Field(
+        None,
+        description=(
+            "Liquidity tier used by suitability and concentration workflows, "
+            "when available."
+        ),
+        examples=["L1", "L5"],
+    )
 
     model_config = ConfigDict()
 
@@ -133,6 +141,7 @@ class InstrumentEnrichmentBulkResponse(BaseModel):
                     "issuer_name": "Apple Inc.",
                     "ultimate_parent_issuer_id": "ISSUER_APPLE_HOLDING",
                     "ultimate_parent_issuer_name": "Apple Holdings PLC",
+                    "liquidity_tier": "L1",
                 }
             ]
         ],

--- a/src/services/query_service/app/dtos/position_dto.py
+++ b/src/services/query_service/app/dtos/position_dto.py
@@ -32,7 +32,19 @@ class Position(BaseModel):
         None, description="Instrument sector classification.", examples=["Technology"]
     )
     country_of_risk: Optional[str] = Field(
-        None, description="Instrument country of risk (ISO 3166-1 alpha-2).", examples=["US"]
+        None,
+        description="Instrument country-of-risk classification.",
+        examples=["United States"],
+    )
+    product_type: Optional[str] = Field(
+        None,
+        description="Instrument product-type classification.",
+        examples=["ETF"],
+    )
+    rating: Optional[str] = Field(
+        None,
+        description="Credit rating used for reporting and analytics.",
+        examples=["AA+"],
     )
     cost_basis: Decimal = Field(
         ..., description="Cost basis in portfolio base currency.", examples=[15000.0]

--- a/src/services/query_service/app/dtos/position_dto.py
+++ b/src/services/query_service/app/dtos/position_dto.py
@@ -46,6 +46,11 @@ class Position(BaseModel):
         description="Credit rating used for reporting and analytics.",
         examples=["AA+"],
     )
+    liquidity_tier: Optional[str] = Field(
+        None,
+        description="Liquidity tier used by advisory suitability and concentration workflows.",
+        examples=["L1", "L5"],
+    )
     cost_basis: Decimal = Field(
         ..., description="Cost basis in portfolio base currency.", examples=[15000.0]
     )

--- a/src/services/query_service/app/repositories/reference_data_repository.py
+++ b/src/services/query_service/app/repositories/reference_data_repository.py
@@ -318,7 +318,7 @@ class ReferenceDataRepository:
             .order_by(RiskFreeSeries.series_date.asc())
         )
         result = await self._db.execute(stmt)
-        return list(result.scalars().all())
+        return self._canonicalize_risk_free_series_rows(list(result.scalars().all()))
 
     async def list_taxonomy(
         self,
@@ -429,6 +429,27 @@ class ReferenceDataRepository:
             "observed_end_date": observed_end,
             "quality_status_counts": dict(quality_counts),
         }
+
+    @staticmethod
+    def _canonicalize_risk_free_series_rows(rows: list[RiskFreeSeries]) -> list[RiskFreeSeries]:
+        if not rows:
+            return []
+
+        def sort_key(row: RiskFreeSeries) -> tuple[date, int, str, str, str]:
+            quality_status = getattr(row, "quality_status", "") or ""
+            source_timestamp = getattr(row, "source_timestamp", None)
+            return (
+                row.series_date,
+                0 if quality_status.lower() == "accepted" else 1,
+                source_timestamp.isoformat() if source_timestamp else "",
+                getattr(row, "risk_free_curve_id", "") or "",
+                getattr(row, "series_id", "") or "",
+            )
+
+        selected_by_date: dict[date, RiskFreeSeries] = {}
+        for row in sorted(rows, key=sort_key):
+            selected_by_date[row.series_date] = row
+        return [selected_by_date[current_date] for current_date in sorted(selected_by_date)]
 
     async def get_fx_rates(
         self,

--- a/src/services/query_service/app/services/allocation_calculator.py
+++ b/src/services/query_service/app/services/allocation_calculator.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Callable
+
+from src.services.query_service.app.dtos.reporting_dto import AllocationDimension
+
+from .reporting_classification import resolve_region
+
+ZERO = Decimal("0")
+UNCLASSIFIED_BUCKET = "UNCLASSIFIED"
+
+
+@dataclass(frozen=True, slots=True)
+class AllocationInputRow:
+    instrument: Any | None
+    snapshot: Any
+    market_value_reporting_currency: Decimal
+
+
+@dataclass(frozen=True, slots=True)
+class AllocationBucketResult:
+    dimension_value: str
+    market_value_reporting_currency: Decimal
+    weight: Decimal
+    position_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class AllocationViewResult:
+    dimension: AllocationDimension
+    total_market_value_reporting_currency: Decimal
+    buckets: tuple[AllocationBucketResult, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class AllocationCalculationResult:
+    total_market_value_reporting_currency: Decimal
+    views: tuple[AllocationViewResult, ...]
+
+
+AllocationAccessor = Callable[[Any | None, Any], object | None]
+
+ALLOCATION_DIMENSION_ACCESSORS: dict[AllocationDimension, AllocationAccessor] = {
+    "asset_class": lambda instrument, snapshot: instrument.asset_class if instrument else None,
+    "currency": lambda instrument, snapshot: (
+        instrument.currency if instrument and instrument.currency else snapshot.security_id
+    ),
+    "sector": lambda instrument, snapshot: instrument.sector if instrument else None,
+    "country": lambda instrument, snapshot: instrument.country_of_risk if instrument else None,
+    "region": lambda instrument, snapshot: (
+        resolve_region(instrument.country_of_risk) if instrument else None
+    ),
+    "product_type": lambda instrument, snapshot: instrument.product_type if instrument else None,
+    "rating": lambda instrument, snapshot: instrument.rating if instrument else None,
+    "issuer_id": lambda instrument, snapshot: instrument.issuer_id if instrument else None,
+    "issuer_name": lambda instrument, snapshot: instrument.issuer_name if instrument else None,
+    "ultimate_parent_issuer_id": (
+        lambda instrument, snapshot: instrument.ultimate_parent_issuer_id if instrument else None
+    ),
+    "ultimate_parent_issuer_name": (
+        lambda instrument, snapshot: instrument.ultimate_parent_issuer_name if instrument else None
+    ),
+}
+
+
+def calculate_allocation_views(
+    *,
+    rows: list[AllocationInputRow],
+    dimensions: list[AllocationDimension],
+) -> AllocationCalculationResult:
+    total_market_value = sum(
+        (row.market_value_reporting_currency for row in rows),
+        ZERO,
+    )
+    views_payload: dict[AllocationDimension, dict[str, Decimal]] = {
+        dimension: defaultdict(lambda: ZERO) for dimension in dimensions
+    }
+    views_position_counts: dict[AllocationDimension, dict[str, int]] = {
+        dimension: defaultdict(int) for dimension in dimensions
+    }
+
+    for row in rows:
+        for dimension in dimensions:
+            accessor = ALLOCATION_DIMENSION_ACCESSORS[dimension]
+            raw_value = accessor(row.instrument, row.snapshot)
+            bucket_key = str(raw_value or UNCLASSIFIED_BUCKET)
+            views_payload[dimension][bucket_key] += row.market_value_reporting_currency
+            views_position_counts[dimension][bucket_key] += 1
+
+    views: list[AllocationViewResult] = []
+    for dimension in dimensions:
+        buckets = [
+            AllocationBucketResult(
+                dimension_value=bucket_key,
+                market_value_reporting_currency=bucket_value,
+                weight=(bucket_value / total_market_value if total_market_value else ZERO),
+                position_count=views_position_counts[dimension][bucket_key],
+            )
+            for bucket_key, bucket_value in sorted(views_payload[dimension].items())
+        ]
+        views.append(
+            AllocationViewResult(
+                dimension=dimension,
+                total_market_value_reporting_currency=total_market_value,
+                buckets=tuple(buckets),
+            )
+        )
+
+    return AllocationCalculationResult(
+        total_market_value_reporting_currency=total_market_value,
+        views=tuple(views),
+    )

--- a/src/services/query_service/app/services/allocation_calculator.py
+++ b/src/services/query_service/app/services/allocation_calculator.py
@@ -5,8 +5,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import Any, Callable
 
-from src.services.query_service.app.dtos.reporting_dto import AllocationDimension
-
+from ..dtos.reporting_dto import AllocationDimension
 from .reporting_classification import resolve_region
 
 ZERO = Decimal("0")

--- a/src/services/query_service/app/services/core_snapshot_service.py
+++ b/src/services/query_service/app/services/core_snapshot_service.py
@@ -204,6 +204,7 @@ class CoreSnapshotService:
                     issuer_name=item["issuer_name"],
                     ultimate_parent_issuer_id=item["ultimate_parent_issuer_id"],
                     ultimate_parent_issuer_name=item["ultimate_parent_issuer_name"],
+                    liquidity_tier=item["liquidity_tier"],
                 )
                 for item in baseline_positions.values()
             ]
@@ -358,6 +359,7 @@ class CoreSnapshotService:
                 "ultimate_parent_issuer_name": (
                     instrument.ultimate_parent_issuer_name if instrument else None
                 ),
+                "liquidity_tier": instrument.liquidity_tier if instrument else None,
             }
 
         total_base = self._total_market_value_baseline(baseline)
@@ -416,6 +418,7 @@ class CoreSnapshotService:
                     "issuer_name": instrument.issuer_name,
                     "ultimate_parent_issuer_id": instrument.ultimate_parent_issuer_id,
                     "ultimate_parent_issuer_name": instrument.ultimate_parent_issuer_name,
+                    "liquidity_tier": instrument.liquidity_tier,
                 }
 
         for change in changes:
@@ -480,11 +483,12 @@ class CoreSnapshotService:
 
     @staticmethod
     def _change_quantity_effect(change) -> Decimal:
-        return transaction_quantity_effect_decimal(
+        effect = transaction_quantity_effect_decimal(
             transaction_type=getattr(change, "transaction_type", None),
             quantity=getattr(change, "quantity", None),
             amount=getattr(change, "amount", None),
         )
+        return Decimal(str(effect))
 
     async def get_instrument_enrichment_bulk(
         self, security_ids: list[str]
@@ -510,6 +514,7 @@ class CoreSnapshotService:
                     ultimate_parent_issuer_name=(
                         instrument.ultimate_parent_issuer_name if instrument else None
                     ),
+                    liquidity_tier=(instrument.liquidity_tier if instrument else None),
                 )
             )
         return records
@@ -533,15 +538,19 @@ class CoreSnapshotService:
 
     @staticmethod
     def _total_market_value_baseline(items: dict[str, dict[str, Any]]) -> Decimal:
-        return sum(
-            (item["market_value_base"] or Decimal(0))
-            for item in items.values()
-            if item["market_value_base"] is not None
-        )
+        total = Decimal(0)
+        for item in items.values():
+            market_value = item.get("market_value_base")
+            if market_value is not None:
+                total += Decimal(str(market_value))
+        return total
 
     @staticmethod
     def _total_market_value_projected(items: dict[str, dict[str, Any]]) -> Decimal:
-        return sum((item["market_value_base"] or Decimal(0)) for item in items.values())
+        total = Decimal(0)
+        for item in items.values():
+            total += Decimal(str(item.get("market_value_base") or Decimal(0)))
+        return total
 
     @staticmethod
     def _assign_baseline_weights(items: dict[str, dict[str, Any]], total: Decimal) -> None:

--- a/src/services/query_service/app/services/position_service.py
+++ b/src/services/query_service/app/services/position_service.py
@@ -150,6 +150,8 @@ class PositionService:
                 currency=instrument.currency if instrument else None,
                 sector=instrument.sector if instrument else None,
                 country_of_risk=instrument.country_of_risk if instrument else None,
+                product_type=instrument.product_type if instrument else None,
+                rating=instrument.rating if instrument else None,
                 valuation=valuation_dto,
                 reprocessing_status=pos_state.status if pos_state else None,
             )

--- a/src/services/query_service/app/services/position_service.py
+++ b/src/services/query_service/app/services/position_service.py
@@ -152,6 +152,7 @@ class PositionService:
                 country_of_risk=instrument.country_of_risk if instrument else None,
                 product_type=instrument.product_type if instrument else None,
                 rating=instrument.rating if instrument else None,
+                liquidity_tier=instrument.liquidity_tier if instrument else None,
                 valuation=valuation_dto,
                 reprocessing_status=pos_state.status if pos_state else None,
             )

--- a/src/services/query_service/app/services/reporting_service.py
+++ b/src/services/query_service/app/services/reporting_service.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from datetime import date
 from decimal import Decimal
 from types import SimpleNamespace
+from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -48,31 +49,11 @@ from ..repositories.reporting_repository import (
     InstrumentLookthroughComponentRow,
     ReportingRepository,
 )
+from .allocation_calculator import AllocationInputRow, calculate_allocation_views
 from .reporting_classification import resolve_region
 
 ZERO = Decimal("0")
 CASH_ASSET_CLASS = "CASH"
-ALLOCATION_DIMENSION_ACCESSORS = {
-    "asset_class": lambda instrument, snapshot: instrument.asset_class if instrument else None,
-    "currency": lambda instrument, snapshot: (
-        instrument.currency if instrument and instrument.currency else snapshot.security_id
-    ),
-    "sector": lambda instrument, snapshot: instrument.sector if instrument else None,
-    "country": lambda instrument, snapshot: instrument.country_of_risk if instrument else None,
-    "region": lambda instrument, snapshot: (
-        resolve_region(instrument.country_of_risk) if instrument else None
-    ),
-    "product_type": lambda instrument, snapshot: instrument.product_type if instrument else None,
-    "rating": lambda instrument, snapshot: instrument.rating if instrument else None,
-    "issuer_id": lambda instrument, snapshot: instrument.issuer_id if instrument else None,
-    "issuer_name": lambda instrument, snapshot: instrument.issuer_name if instrument else None,
-    "ultimate_parent_issuer_id": (
-        lambda instrument, snapshot: instrument.ultimate_parent_issuer_id if instrument else None
-    ),
-    "ultimate_parent_issuer_name": (
-        lambda instrument, snapshot: instrument.ultimate_parent_issuer_name if instrument else None
-    ),
-}
 
 
 class ReportingService:
@@ -171,49 +152,47 @@ class ReportingService:
             reporting_currency=reporting_currency,
         )
 
-        total_market_value = ZERO
-        views_payload: dict[str, dict[str, Decimal]] = {
-            dimension: defaultdict(lambda: ZERO) for dimension in request.dimensions
-        }
-        views_position_counts: dict[str, dict[str, int]] = {
-            dimension: defaultdict(int) for dimension in request.dimensions
-        }
+        allocation_result = calculate_allocation_views(
+            rows=[
+                AllocationInputRow(
+                    instrument=instrument,
+                    snapshot=snapshot,
+                    market_value_reporting_currency=reporting_value,
+                )
+                for instrument, snapshot, reporting_value in allocation_rows
+            ],
+            dimensions=request.dimensions,
+        )
 
-        for instrument, snapshot, reporting_value in allocation_rows:
-            total_market_value += reporting_value
-            for dimension in request.dimensions:
-                accessor = ALLOCATION_DIMENSION_ACCESSORS[dimension]
-                raw_value = accessor(instrument, snapshot)
-                bucket_key = str(raw_value or "UNCLASSIFIED")
-                views_payload[dimension][bucket_key] += reporting_value
-                views_position_counts[dimension][bucket_key] += 1
-
-        views: list[AllocationView] = []
-        for dimension in request.dimensions:
-            buckets = []
-            for bucket_key, bucket_value in sorted(views_payload[dimension].items()):
-                buckets.append(
+        views = [
+            AllocationView(
+                dimension=view.dimension,
+                total_market_value_reporting_currency=(
+                    view.total_market_value_reporting_currency
+                ),
+                buckets=[
                     AllocationBucket(
-                        dimension_value=bucket_key,
-                        market_value_reporting_currency=bucket_value,
-                        weight=(bucket_value / total_market_value if total_market_value else ZERO),
-                        position_count=views_position_counts[dimension][bucket_key],
+                        dimension_value=bucket.dimension_value,
+                        market_value_reporting_currency=(
+                            bucket.market_value_reporting_currency
+                        ),
+                        weight=bucket.weight,
+                        position_count=bucket.position_count,
                     )
-                )
-            views.append(
-                AllocationView(
-                    dimension=dimension,
-                    total_market_value_reporting_currency=total_market_value,
-                    buckets=buckets,
-                )
+                    for bucket in view.buckets
+                ],
             )
+            for view in allocation_result.views
+        ]
 
         return AssetAllocationResponse(
             scope_type=request.scope.scope_type,
             scope=request.scope,
             resolved_as_of_date=resolved_as_of_date,
             reporting_currency=reporting_currency,
-            total_market_value_reporting_currency=total_market_value,
+            total_market_value_reporting_currency=(
+                allocation_result.total_market_value_reporting_currency
+            ),
             look_through=look_through_info,
             views=views,
         )
@@ -612,7 +591,7 @@ class ReportingService:
                 )
 
         if decomposed_position_count == 0:
-            limitation_reason = (
+            limitation_reason: str | None = (
                 "Look-through components were requested but no fully weighted source-owned "
                 "decomposition set was available for the resolved holdings."
             )
@@ -932,13 +911,13 @@ class ReportingService:
         self,
         *,
         scope: ReportingScope,
-        portfolios: list[object],
+        portfolios: list[Any],
         requested_reporting_currency: str | None,
     ) -> str:
         if requested_reporting_currency:
             return requested_reporting_currency
         if scope.scope_type == "portfolio":
-            return portfolios[0].base_currency
+            return str(portfolios[0].base_currency)
         raise ValueError(
             "reporting_currency is required for portfolio-list and business-unit reporting queries."
         )
@@ -974,6 +953,7 @@ class ReportingService:
             raise ValueError(
                 f"FX rate not found for {from_currency}/{to_currency} as of {as_of_date}."
             )
+        rate = Decimal(str(rate))
         self._fx_cache[cache_key] = rate
         return rate
 

--- a/tests/integration/tools/test_demo_data_pack.py
+++ b/tests/integration/tools/test_demo_data_pack.py
@@ -34,6 +34,17 @@ def test_build_demo_bundle_contains_benchmark_seed_data():
     } == {"0.6000000000", "0.4000000000"}
 
 
+def test_build_demo_bundle_contains_usd_risk_free_reference_series():
+    bundle = demo_data_pack.build_demo_bundle()
+
+    risk_free_series = bundle["risk_free_series"]
+    assert risk_free_series
+    assert risk_free_series[0]["series_currency"] == "USD"
+    assert risk_free_series[0]["risk_free_curve_id"] == "USD_SOFR_3M"
+    assert risk_free_series[0]["value_convention"] == "annualized_rate"
+    assert risk_free_series[-1]["series_date"] == bundle["as_of_date"]
+
+
 def test_expectations_cover_five_portfolios_with_terminal_holdings():
     expected_ids = {
         "DEMO_ADV_USD_001",

--- a/tests/integration/tools/test_demo_data_pack.py
+++ b/tests/integration/tools/test_demo_data_pack.py
@@ -20,8 +20,13 @@ def test_build_demo_bundle_contains_multi_product_coverage():
 def test_build_demo_bundle_contains_benchmark_seed_data():
     bundle = demo_data_pack.build_demo_bundle()
 
-    assert bundle["benchmark_verification"]["benchmark_id"] == demo_data_pack.DEFAULT_DEMO_BENCHMARK_ID
-    assert bundle["benchmark_verification"]["portfolio_id"] == demo_data_pack.DEFAULT_DEMO_BENCHMARK_PORTFOLIO_ID
+    assert (
+        bundle["benchmark_verification"]["benchmark_id"] == demo_data_pack.DEFAULT_DEMO_BENCHMARK_ID
+    )
+    assert (
+        bundle["benchmark_verification"]["portfolio_id"]
+        == demo_data_pack.DEFAULT_DEMO_BENCHMARK_PORTFOLIO_ID
+    )
     assert len(bundle["benchmark_assignments"]) == 1
     assert len(bundle["benchmark_definitions"]) == 1
     assert len(bundle["benchmark_compositions"]) == 2

--- a/tests/unit/services/query_control_plane_service/routers/test_integration_router.py
+++ b/tests/unit/services/query_control_plane_service/routers/test_integration_router.py
@@ -448,6 +448,7 @@ async def test_get_instrument_enrichment_bulk_router_function() -> None:
             "issuer_name": "Apple Inc.",
             "ultimate_parent_issuer_id": "ISSUER_APPLE_HOLDING",
             "ultimate_parent_issuer_name": "Apple Holdings PLC",
+            "liquidity_tier": "L1",
         }
     ]
 
@@ -457,6 +458,7 @@ async def test_get_instrument_enrichment_bulk_router_function() -> None:
     )
 
     assert response.records[0].security_id == "SEC_AAPL_US"
+    assert response.records[0].liquidity_tier == "L1"
     mock_service.get_instrument_enrichment_bulk.assert_called_once_with(["SEC_AAPL_US"])
 
 

--- a/tests/unit/services/query_service/advisory_simulation/test_allocation_contract.py
+++ b/tests/unit/services/query_service/advisory_simulation/test_allocation_contract.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pytest
+
+from src.services.query_service.app.advisory_simulation.allocation_contract import (
+    ADVISORY_PROPOSAL_ALLOCATION_DIMENSIONS,
+    ADVISORY_SIMULATION_ALLOCATION_LENS_CONTRACT_VERSION,
+    ALLOCATION_DIMENSIONS_RESERVED_FOR_RISK_OR_DRILLDOWN,
+    AllocationLensContract,
+    advisory_proposal_allocation_lens_contract,
+    validate_advisory_proposal_allocation_lens_contract,
+)
+from src.services.query_service.app.dtos.reporting_dto import AllocationDimension
+
+
+def test_advisory_proposal_allocation_contract_classifies_every_live_dimension() -> None:
+    contract = advisory_proposal_allocation_lens_contract()
+
+    assert set(contract.proposal_dimensions).isdisjoint(contract.reserved_dimensions)
+    assert set(contract.proposal_dimensions) | set(contract.reserved_dimensions) == set(
+        contract.live_reporting_dimensions
+    )
+
+
+def test_advisory_proposal_allocation_contract_exposes_curated_front_office_subset() -> None:
+    contract = advisory_proposal_allocation_lens_contract()
+
+    assert contract.contract_version == ADVISORY_SIMULATION_ALLOCATION_LENS_CONTRACT_VERSION
+    assert contract.proposal_dimensions == (
+        "asset_class",
+        "currency",
+        "sector",
+        "country",
+        "region",
+        "product_type",
+        "rating",
+    )
+
+
+def test_advisory_proposal_allocation_contract_reserves_issuer_dimensions_for_risk() -> None:
+    contract = advisory_proposal_allocation_lens_contract()
+
+    assert contract.reserved_dimensions == (
+        "issuer_id",
+        "issuer_name",
+        "ultimate_parent_issuer_id",
+        "ultimate_parent_issuer_name",
+    )
+
+
+def test_advisory_proposal_allocation_contract_fails_when_reporting_dimensions_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    drifted_contract = AllocationLensContract(
+        contract_version=ADVISORY_SIMULATION_ALLOCATION_LENS_CONTRACT_VERSION,
+        proposal_dimensions=ADVISORY_PROPOSAL_ALLOCATION_DIMENSIONS,
+        reserved_dimensions=ALLOCATION_DIMENSIONS_RESERVED_FOR_RISK_OR_DRILLDOWN,
+        live_reporting_dimensions=(
+            *advisory_proposal_allocation_lens_contract().live_reporting_dimensions,
+            "strategy",  # type: ignore[misc]
+        ),
+    )
+    monkeypatch.setattr(
+        "src.services.query_service.app.advisory_simulation.allocation_contract."
+        "advisory_proposal_allocation_lens_contract",
+        lambda: drifted_contract,
+    )
+
+    with pytest.raises(ValueError, match="missing=\\['strategy'\\]"):
+        validate_advisory_proposal_allocation_lens_contract()
+
+
+def test_advisory_proposal_allocation_contract_uses_live_reporting_literal() -> None:
+    contract = advisory_proposal_allocation_lens_contract()
+
+    # Type-level guard: the public contract stays aligned to the reporting DTO literal.
+    _: tuple[AllocationDimension, ...] = contract.proposal_dimensions
+    _: tuple[AllocationDimension, ...] = contract.reserved_dimensions

--- a/tests/unit/services/query_service/advisory_simulation/test_valuation.py
+++ b/tests/unit/services/query_service/advisory_simulation/test_valuation.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from types import SimpleNamespace
 
 from src.services.query_service.app.advisory_simulation.models import (
     EngineOptions,
@@ -9,6 +10,10 @@ from src.services.query_service.app.advisory_simulation.valuation import (
     ValuationService,
     build_simulated_state,
     get_fx_rate,
+)
+from src.services.query_service.app.services.allocation_calculator import (
+    AllocationInputRow,
+    calculate_allocation_views,
 )
 from tests.shared.factories import (
     cash,
@@ -131,3 +136,57 @@ def test_build_simulated_state_aggregates_asset_classes_attributes_and_cash() ->
     assert asset_classes["CASH"] == Decimal("50") / Decimal("450")
     assert sectors["TECH"] == Decimal("200") / Decimal("450")
     assert sectors["GOVT"] == Decimal("200") / Decimal("450")
+
+
+def test_build_simulated_state_asset_class_matches_shared_allocation_calculator() -> None:
+    portfolio = portfolio_snapshot(
+        base_currency="USD",
+        positions=[position("EQ_1", "2"), position("BOND_1", "1")],
+        cash_balances=[cash("USD", "50")],
+    )
+    market_data = market_data_snapshot(
+        prices=[price("EQ_1", "100", "USD"), price("BOND_1", "200", "USD")],
+    )
+    shelf = [
+        shelf_entry("EQ_1", asset_class="EQUITY"),
+        shelf_entry("BOND_1", asset_class="FIXED_INCOME"),
+    ]
+
+    state = build_simulated_state(
+        portfolio,
+        market_data,
+        shelf,
+        {"price_missing": [], "fx_missing": [], "shelf_missing": []},
+        [],
+    )
+    expected_view = calculate_allocation_views(
+        rows=[
+            AllocationInputRow(
+                instrument=SimpleNamespace(asset_class="EQUITY"),
+                snapshot=SimpleNamespace(security_id="EQ_1"),
+                market_value_reporting_currency=Decimal("200"),
+            ),
+            AllocationInputRow(
+                instrument=SimpleNamespace(asset_class="FIXED_INCOME"),
+                snapshot=SimpleNamespace(security_id="BOND_1"),
+                market_value_reporting_currency=Decimal("200"),
+            ),
+            AllocationInputRow(
+                instrument=SimpleNamespace(asset_class="CASH"),
+                snapshot=SimpleNamespace(security_id="CASH_USD"),
+                market_value_reporting_currency=Decimal("50"),
+            ),
+        ],
+        dimensions=["asset_class"],
+    ).views[0]
+
+    actual = {
+        metric.key: (metric.value.amount, metric.weight)
+        for metric in state.allocation_by_asset_class
+    }
+    expected = {
+        bucket.dimension_value: (bucket.market_value_reporting_currency, bucket.weight)
+        for bucket in expected_view.buckets
+    }
+
+    assert actual == expected

--- a/tests/unit/services/query_service/advisory_simulation/test_valuation.py
+++ b/tests/unit/services/query_service/advisory_simulation/test_valuation.py
@@ -227,8 +227,8 @@ def test_build_simulated_state_emits_curated_canonical_allocation_views() -> Non
 
     assert tuple(views_by_dimension) == ADVISORY_PROPOSAL_ALLOCATION_DIMENSIONS
     assert {bucket.key for bucket in views_by_dimension["asset_class"].buckets} == {
-        "CASH",
-        "EQUITY",
+        "Cash",
+        "Equity",
     }
     assert {bucket.key for bucket in views_by_dimension["currency"].buckets} == {"USD"}
     assert {bucket.key for bucket in views_by_dimension["sector"].buckets} == {
@@ -244,8 +244,8 @@ def test_build_simulated_state_emits_curated_canonical_allocation_views() -> Non
         "UNCLASSIFIED",
     }
     assert {bucket.key for bucket in views_by_dimension["product_type"].buckets} == {
+        "Cash",
         "EQUITY",
-        "UNCLASSIFIED",
     }
     assert {bucket.key for bucket in views_by_dimension["rating"].buckets} == {
         "A",
@@ -274,7 +274,7 @@ def test_legacy_asset_class_allocation_is_derived_from_canonical_lens() -> None:
         view for view in state.allocation_views if view.dimension == "asset_class"
     )
     canonical = {
-        bucket.key: (bucket.value.amount, bucket.weight)
+        bucket.key.upper(): (bucket.value.amount, bucket.weight)
         for bucket in canonical_asset_class.buckets
     }
     legacy = {

--- a/tests/unit/services/query_service/advisory_simulation/test_valuation.py
+++ b/tests/unit/services/query_service/advisory_simulation/test_valuation.py
@@ -1,6 +1,9 @@
 from decimal import Decimal
 from types import SimpleNamespace
 
+from src.services.query_service.app.advisory_simulation.allocation_contract import (
+    ADVISORY_PROPOSAL_ALLOCATION_DIMENSIONS,
+)
 from src.services.query_service.app.advisory_simulation.models import (
     EngineOptions,
     Money,
@@ -190,3 +193,93 @@ def test_build_simulated_state_asset_class_matches_shared_allocation_calculator(
     }
 
     assert actual == expected
+
+
+def test_build_simulated_state_emits_curated_canonical_allocation_views() -> None:
+    portfolio = portfolio_snapshot(
+        base_currency="USD",
+        positions=[position("EQ_1", "2")],
+        cash_balances=[cash("USD", "50")],
+    )
+    market_data = market_data_snapshot(prices=[price("EQ_1", "100", "USD")])
+    shelf = [
+        shelf_entry("EQ_1", asset_class="EQUITY").model_copy(
+            update={
+                "attributes": {
+                    "sector": "TECHNOLOGY",
+                    "country": "US",
+                    "product_type": "EQUITY",
+                    "rating": "A",
+                }
+            }
+        )
+    ]
+
+    state = build_simulated_state(
+        portfolio,
+        market_data,
+        shelf,
+        {"price_missing": [], "fx_missing": [], "shelf_missing": []},
+        [],
+    )
+
+    views_by_dimension = {view.dimension: view for view in state.allocation_views}
+
+    assert tuple(views_by_dimension) == ADVISORY_PROPOSAL_ALLOCATION_DIMENSIONS
+    assert {bucket.key for bucket in views_by_dimension["asset_class"].buckets} == {
+        "CASH",
+        "EQUITY",
+    }
+    assert {bucket.key for bucket in views_by_dimension["currency"].buckets} == {"USD"}
+    assert {bucket.key for bucket in views_by_dimension["sector"].buckets} == {
+        "TECHNOLOGY",
+        "UNCLASSIFIED",
+    }
+    assert {bucket.key for bucket in views_by_dimension["country"].buckets} == {
+        "US",
+        "UNCLASSIFIED",
+    }
+    assert {bucket.key for bucket in views_by_dimension["region"].buckets} == {
+        "North America",
+        "UNCLASSIFIED",
+    }
+    assert {bucket.key for bucket in views_by_dimension["product_type"].buckets} == {
+        "EQUITY",
+        "UNCLASSIFIED",
+    }
+    assert {bucket.key for bucket in views_by_dimension["rating"].buckets} == {
+        "A",
+        "UNCLASSIFIED",
+    }
+
+
+def test_legacy_asset_class_allocation_is_derived_from_canonical_lens() -> None:
+    portfolio = portfolio_snapshot(
+        base_currency="USD",
+        positions=[position("EQ_1", "2")],
+        cash_balances=[cash("USD", "50")],
+    )
+    market_data = market_data_snapshot(prices=[price("EQ_1", "100", "USD")])
+    shelf = [shelf_entry("EQ_1", asset_class="EQUITY")]
+
+    state = build_simulated_state(
+        portfolio,
+        market_data,
+        shelf,
+        {"price_missing": [], "fx_missing": [], "shelf_missing": []},
+        [],
+    )
+
+    canonical_asset_class = next(
+        view for view in state.allocation_views if view.dimension == "asset_class"
+    )
+    canonical = {
+        bucket.key: (bucket.value.amount, bucket.weight)
+        for bucket in canonical_asset_class.buckets
+    }
+    legacy = {
+        metric.key: (metric.value.amount, metric.weight)
+        for metric in state.allocation_by_asset_class
+    }
+
+    assert legacy == canonical

--- a/tests/unit/services/query_service/repositories/test_reference_data_repository.py
+++ b/tests/unit/services/query_service/repositories/test_reference_data_repository.py
@@ -256,3 +256,41 @@ async def test_get_benchmark_coverage_marks_internal_gap_when_component_missing(
     coverage = await repo.get_benchmark_coverage("B1", date(2026, 1, 1), date(2026, 1, 3))
 
     assert coverage["observed_dates"] == [date(2026, 1, 1), date(2026, 1, 3)]
+
+
+@pytest.mark.asyncio
+async def test_list_risk_free_series_canonicalizes_duplicate_dates() -> None:
+    db = AsyncMock(spec=AsyncSession)
+    db.execute.return_value = _FakeExecuteResult(
+        [
+            SimpleNamespace(
+                series_date=date(2026, 1, 1),
+                quality_status="accepted",
+                source_timestamp=None,
+                risk_free_curve_id="USD_FRONT_OFFICE",
+                series_id="front_office",
+            ),
+            SimpleNamespace(
+                series_date=date(2026, 1, 1),
+                quality_status="accepted",
+                source_timestamp=None,
+                risk_free_curve_id="USD_DEMO",
+                series_id="demo",
+            ),
+            SimpleNamespace(
+                series_date=date(2026, 1, 2),
+                quality_status="accepted",
+                source_timestamp=None,
+                risk_free_curve_id="USD_DEMO",
+                series_id="demo",
+            ),
+        ]
+    )
+
+    repo = ReferenceDataRepository(db)
+
+    rows = await repo.list_risk_free_series("USD", date(2026, 1, 1), date(2026, 1, 2))
+
+    assert [row.series_date for row in rows] == [date(2026, 1, 1), date(2026, 1, 2)]
+    assert rows[0].series_id == "front_office"
+    assert rows[1].series_id == "demo"

--- a/tests/unit/services/query_service/services/test_advisory_simulation_service.py
+++ b/tests/unit/services/query_service/services/test_advisory_simulation_service.py
@@ -1,6 +1,13 @@
+from decimal import Decimal
+from types import SimpleNamespace
+
 from src.services.query_service.app.advisory_simulation.models import ProposalSimulateRequest
 from src.services.query_service.app.services.advisory_simulation_service import (
     execute_advisory_simulation,
+)
+from src.services.query_service.app.services.allocation_calculator import (
+    AllocationInputRow,
+    calculate_allocation_views,
 )
 
 
@@ -57,3 +64,81 @@ def test_execute_advisory_simulation_computes_request_hash_when_missing():
     assert result.lineage.request_hash.startswith("sha256:")
     assert result.correlation_id == "corr-core-002"
     assert result.lineage.simulation_contract_version == "advisory-simulation.v1"
+
+
+def test_noop_advisory_before_allocation_matches_shared_live_calculator():
+    request = ProposalSimulateRequest.model_validate(
+        {
+            "portfolio_snapshot": {
+                "portfolio_id": "pf_core_alloc_noop",
+                "base_currency": "USD",
+                "positions": [
+                    {"instrument_id": "EQ_1", "quantity": "2"},
+                    {"instrument_id": "BOND_1", "quantity": "1"},
+                ],
+                "cash_balances": [{"currency": "USD", "amount": "50"}],
+            },
+            "market_data_snapshot": {
+                "prices": [
+                    {"instrument_id": "EQ_1", "price": "100", "currency": "USD"},
+                    {"instrument_id": "BOND_1", "price": "200", "currency": "USD"},
+                ],
+                "fx_rates": [],
+            },
+            "shelf_entries": [
+                {"instrument_id": "EQ_1", "status": "APPROVED", "asset_class": "EQUITY"},
+                {
+                    "instrument_id": "BOND_1",
+                    "status": "APPROVED",
+                    "asset_class": "FIXED_INCOME",
+                },
+            ],
+            "options": {"enable_proposal_simulation": True},
+            "proposed_cash_flows": [],
+            "proposed_trades": [],
+        }
+    )
+
+    result = execute_advisory_simulation(
+        request=request,
+        request_hash="sha256:no-op-allocation",
+        idempotency_key=None,
+        correlation_id="corr-core-noop-allocation",
+        simulation_contract_version="advisory-simulation.v1",
+    )
+    expected_view = calculate_allocation_views(
+        rows=[
+            AllocationInputRow(
+                instrument=SimpleNamespace(asset_class="EQUITY"),
+                snapshot=SimpleNamespace(security_id="EQ_1"),
+                market_value_reporting_currency=Decimal("200"),
+            ),
+            AllocationInputRow(
+                instrument=SimpleNamespace(asset_class="FIXED_INCOME"),
+                snapshot=SimpleNamespace(security_id="BOND_1"),
+                market_value_reporting_currency=Decimal("200"),
+            ),
+            AllocationInputRow(
+                instrument=SimpleNamespace(asset_class="CASH"),
+                snapshot=SimpleNamespace(security_id="CASH_USD"),
+                market_value_reporting_currency=Decimal("50"),
+            ),
+        ],
+        dimensions=["asset_class"],
+    ).views[0]
+
+    before = {
+        metric.key: (metric.value.amount, metric.weight)
+        for metric in result.before.allocation_by_asset_class
+    }
+    after = {
+        metric.key: (metric.value.amount, metric.weight)
+        for metric in result.after_simulated.allocation_by_asset_class
+    }
+    expected = {
+        bucket.dimension_value: (bucket.market_value_reporting_currency, bucket.weight)
+        for bucket in expected_view.buckets
+    }
+
+    assert before == expected
+    assert after == expected

--- a/tests/unit/services/query_service/services/test_advisory_simulation_service.py
+++ b/tests/unit/services/query_service/services/test_advisory_simulation_service.py
@@ -1,6 +1,9 @@
 from decimal import Decimal
 from types import SimpleNamespace
 
+from src.services.query_service.app.advisory_simulation.allocation_contract import (
+    ADVISORY_PROPOSAL_ALLOCATION_DIMENSIONS,
+)
 from src.services.query_service.app.advisory_simulation.models import ProposalSimulateRequest
 from src.services.query_service.app.services.advisory_simulation_service import (
     execute_advisory_simulation,
@@ -142,3 +145,23 @@ def test_noop_advisory_before_allocation_matches_shared_live_calculator():
 
     assert before == expected
     assert after == expected
+
+
+def test_advisory_simulation_exposes_allocation_lens_metadata_and_views():
+    result = execute_advisory_simulation(
+        request=_request(),
+        request_hash="sha256:allocation-lens",
+        idempotency_key=None,
+        correlation_id="corr-core-allocation-lens",
+        simulation_contract_version="advisory-simulation.v1",
+    )
+
+    assert result.allocation_lens.contract_version == "advisory-simulation.v1"
+    assert result.allocation_lens.source == "LOTUS_CORE"
+    assert tuple(result.allocation_lens.dimensions) == ADVISORY_PROPOSAL_ALLOCATION_DIMENSIONS
+    assert [view.dimension for view in result.before.allocation_views] == list(
+        ADVISORY_PROPOSAL_ALLOCATION_DIMENSIONS
+    )
+    assert [view.dimension for view in result.after_simulated.allocation_views] == list(
+        ADVISORY_PROPOSAL_ALLOCATION_DIMENSIONS
+    )

--- a/tests/unit/services/query_service/services/test_advisory_simulation_service.py
+++ b/tests/unit/services/query_service/services/test_advisory_simulation_service.py
@@ -165,3 +165,88 @@ def test_advisory_simulation_exposes_allocation_lens_metadata_and_views():
     assert [view.dimension for view in result.after_simulated.allocation_views] == list(
         ADVISORY_PROPOSAL_ALLOCATION_DIMENSIONS
     )
+
+
+def test_advisory_simulation_preserves_cash_currency_split_in_allocation_views() -> None:
+    request = ProposalSimulateRequest.model_validate(
+        {
+            "portfolio_snapshot": {
+                "portfolio_id": "pf_core_currency_split",
+                "base_currency": "USD",
+                "positions": [],
+                "cash_balances": [
+                    {"currency": "USD", "amount": "100"},
+                    {"currency": "EUR", "amount": "100"},
+                ],
+            },
+            "market_data_snapshot": {
+                "prices": [],
+                "fx_rates": [{"pair": "EUR/USD", "rate": "1.2"}],
+            },
+            "shelf_entries": [],
+            "options": {"enable_proposal_simulation": True},
+            "proposed_cash_flows": [],
+            "proposed_trades": [],
+        }
+    )
+
+    result = execute_advisory_simulation(
+        request=request,
+        request_hash="sha256:cash-currency-split",
+        idempotency_key=None,
+        correlation_id="corr-core-cash-currency-split",
+        simulation_contract_version="advisory-simulation.v1",
+    )
+
+    currency_view = next(
+        view for view in result.before.allocation_views if view.dimension == "currency"
+    )
+    product_type_view = next(
+        view for view in result.before.allocation_views if view.dimension == "product_type"
+    )
+
+    assert {bucket.key: bucket.value.amount for bucket in currency_view.buckets} == {
+        "EUR": Decimal("120.0"),
+        "USD": Decimal("100"),
+    }
+    assert {bucket.key: bucket.value.amount for bucket in product_type_view.buckets} == {
+        "Cash": Decimal("220.0")
+    }
+
+
+def test_advisory_simulation_uses_reporting_labels_for_asset_class_allocation_views() -> None:
+    request = ProposalSimulateRequest.model_validate(
+        {
+            "portfolio_snapshot": {
+                "portfolio_id": "pf_core_asset_class_labels",
+                "base_currency": "USD",
+                "positions": [{"instrument_id": "EQ_1", "quantity": "1"}],
+                "cash_balances": [{"currency": "USD", "amount": "50"}],
+            },
+            "market_data_snapshot": {
+                "prices": [{"instrument_id": "EQ_1", "price": "100", "currency": "USD"}],
+                "fx_rates": [],
+            },
+            "shelf_entries": [
+                {"instrument_id": "EQ_1", "status": "APPROVED", "asset_class": "EQUITY"}
+            ],
+            "options": {"enable_proposal_simulation": True},
+            "proposed_cash_flows": [],
+            "proposed_trades": [],
+        }
+    )
+
+    result = execute_advisory_simulation(
+        request=request,
+        request_hash="sha256:asset-class-view-labels",
+        idempotency_key=None,
+        correlation_id="corr-core-asset-class-view-labels",
+        simulation_contract_version="advisory-simulation.v1",
+    )
+
+    asset_class_view = next(
+        view for view in result.before.allocation_views if view.dimension == "asset_class"
+    )
+
+    assert [bucket.key for bucket in asset_class_view.buckets] == ["Cash", "Equity"]
+    assert asset_class_view.buckets[0].weight == Decimal("0.3333333333333333333333333333")

--- a/tests/unit/services/query_service/services/test_allocation_calculator.py
+++ b/tests/unit/services/query_service/services/test_allocation_calculator.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+
+from src.services.query_service.app.services.allocation_calculator import (
+    AllocationInputRow,
+    calculate_allocation_views,
+)
+
+
+def _instrument(
+    security_id: str,
+    *,
+    currency: str = "USD",
+    asset_class: str | None = "EQUITY",
+    sector: str | None = "TECH",
+    country_of_risk: str | None = "US",
+    product_type: str | None = "EQUITY",
+    rating: str | None = "A",
+    issuer_id: str | None = "ISSUER_A",
+    issuer_name: str | None = "Issuer A",
+    ultimate_parent_issuer_id: str | None = "PARENT_A",
+    ultimate_parent_issuer_name: str | None = "Parent A",
+):
+    return SimpleNamespace(
+        security_id=security_id,
+        currency=currency,
+        asset_class=asset_class,
+        sector=sector,
+        country_of_risk=country_of_risk,
+        product_type=product_type,
+        rating=rating,
+        issuer_id=issuer_id,
+        issuer_name=issuer_name,
+        ultimate_parent_issuer_id=ultimate_parent_issuer_id,
+        ultimate_parent_issuer_name=ultimate_parent_issuer_name,
+    )
+
+
+def _snapshot(security_id: str):
+    return SimpleNamespace(security_id=security_id)
+
+
+def _bucket_values(result, dimension: str) -> dict[str, Decimal]:
+    view = next(view for view in result.views if view.dimension == dimension)
+    return {
+        bucket.dimension_value: bucket.market_value_reporting_currency
+        for bucket in view.buckets
+    }
+
+
+def test_calculate_allocation_views_supports_all_reporting_dimensions() -> None:
+    result = calculate_allocation_views(
+        rows=[
+            AllocationInputRow(
+                instrument=_instrument("SEC1", country_of_risk="US"),
+                snapshot=_snapshot("SEC1"),
+                market_value_reporting_currency=Decimal("100"),
+            )
+        ],
+        dimensions=[
+            "asset_class",
+            "currency",
+            "sector",
+            "country",
+            "region",
+            "product_type",
+            "rating",
+            "issuer_id",
+            "issuer_name",
+            "ultimate_parent_issuer_id",
+            "ultimate_parent_issuer_name",
+        ],
+    )
+
+    assert result.total_market_value_reporting_currency == Decimal("100")
+    assert _bucket_values(result, "asset_class") == {"EQUITY": Decimal("100")}
+    assert _bucket_values(result, "currency") == {"USD": Decimal("100")}
+    assert _bucket_values(result, "sector") == {"TECH": Decimal("100")}
+    assert _bucket_values(result, "country") == {"US": Decimal("100")}
+    assert _bucket_values(result, "region") == {"North America": Decimal("100")}
+    assert _bucket_values(result, "product_type") == {"EQUITY": Decimal("100")}
+    assert _bucket_values(result, "rating") == {"A": Decimal("100")}
+    assert _bucket_values(result, "issuer_id") == {"ISSUER_A": Decimal("100")}
+    assert _bucket_values(result, "issuer_name") == {"Issuer A": Decimal("100")}
+    assert _bucket_values(result, "ultimate_parent_issuer_id") == {"PARENT_A": Decimal("100")}
+    assert _bucket_values(result, "ultimate_parent_issuer_name") == {
+        "Parent A": Decimal("100")
+    }
+
+
+def test_calculate_allocation_views_groups_weights_and_position_counts() -> None:
+    result = calculate_allocation_views(
+        rows=[
+            AllocationInputRow(
+                instrument=_instrument("SEC1", asset_class="EQUITY"),
+                snapshot=_snapshot("SEC1"),
+                market_value_reporting_currency=Decimal("100"),
+            ),
+            AllocationInputRow(
+                instrument=_instrument("SEC2", asset_class="EQUITY"),
+                snapshot=_snapshot("SEC2"),
+                market_value_reporting_currency=Decimal("50"),
+            ),
+            AllocationInputRow(
+                instrument=_instrument("SEC3", asset_class="BOND"),
+                snapshot=_snapshot("SEC3"),
+                market_value_reporting_currency=Decimal("50"),
+            ),
+        ],
+        dimensions=["asset_class"],
+    )
+
+    view = result.views[0]
+    buckets = {bucket.dimension_value: bucket for bucket in view.buckets}
+
+    assert result.total_market_value_reporting_currency == Decimal("200")
+    assert buckets["EQUITY"].market_value_reporting_currency == Decimal("150")
+    assert buckets["EQUITY"].weight == Decimal("0.75")
+    assert buckets["EQUITY"].position_count == 2
+    assert buckets["BOND"].market_value_reporting_currency == Decimal("50")
+    assert buckets["BOND"].weight == Decimal("0.25")
+    assert buckets["BOND"].position_count == 1
+
+
+def test_calculate_allocation_views_uses_unclassified_for_missing_dimension_values() -> None:
+    result = calculate_allocation_views(
+        rows=[
+            AllocationInputRow(
+                instrument=_instrument("SEC1", sector=None),
+                snapshot=_snapshot("SEC1"),
+                market_value_reporting_currency=Decimal("100"),
+            )
+        ],
+        dimensions=["sector"],
+    )
+
+    assert _bucket_values(result, "sector") == {"UNCLASSIFIED": Decimal("100")}
+
+
+def test_calculate_allocation_views_uses_snapshot_id_as_cash_currency_fallback() -> None:
+    result = calculate_allocation_views(
+        rows=[
+            AllocationInputRow(
+                instrument=None,
+                snapshot=_snapshot("CASH_USD"),
+                market_value_reporting_currency=Decimal("25"),
+            )
+        ],
+        dimensions=["currency"],
+    )
+
+    assert _bucket_values(result, "currency") == {"CASH_USD": Decimal("25")}
+
+
+def test_calculate_allocation_views_keeps_zero_total_weights_at_zero() -> None:
+    result = calculate_allocation_views(
+        rows=[
+            AllocationInputRow(
+                instrument=_instrument("SEC1", asset_class="EQUITY"),
+                snapshot=_snapshot("SEC1"),
+                market_value_reporting_currency=Decimal("0"),
+            )
+        ],
+        dimensions=["asset_class"],
+    )
+
+    bucket = result.views[0].buckets[0]
+    assert result.total_market_value_reporting_currency == Decimal("0")
+    assert bucket.weight == Decimal("0")

--- a/tests/unit/services/query_service/services/test_allocation_calculator_import_contract.py
+++ b/tests/unit/services/query_service/services/test_allocation_calculator_import_contract.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+
+def test_allocation_calculator_imports_from_packaged_query_service_namespace():
+    query_service_root = Path(__file__).resolve().parents[5] / "src" / "services" / "query_service"
+    sys.path.insert(0, str(query_service_root))
+    try:
+        module = importlib.import_module("app.services.allocation_calculator")
+    finally:
+        sys.path.pop(0)
+
+    assert hasattr(module, "calculate_allocation_views")

--- a/tests/unit/services/query_service/services/test_core_snapshot_service.py
+++ b/tests/unit/services/query_service/services/test_core_snapshot_service.py
@@ -53,6 +53,7 @@ def _instrument(
         issuer_name=f"{security_id} issuer",
         ultimate_parent_issuer_id=f"PARENT_{security_id}",
         ultimate_parent_issuer_name=f"{security_id} parent",
+        liquidity_tier="L2",
     )
 
 
@@ -142,6 +143,7 @@ async def test_core_snapshot_baseline_success(mock_dependencies):
     assert response.sections.instrument_enrichment[0].issuer_name is not None
     assert response.sections.instrument_enrichment[0].ultimate_parent_issuer_id is not None
     assert response.sections.instrument_enrichment[0].ultimate_parent_issuer_name is not None
+    assert response.sections.instrument_enrichment[0].liquidity_tier == "L2"
     assert response.contract_version == "rfc_081_v1"
     assert response.request_fingerprint
     assert response.freshness.baseline_source == "position_state"
@@ -170,8 +172,11 @@ async def test_get_instrument_enrichment_bulk_preserves_order_and_unknowns(mock_
         "SEC_MSFT_US",
     ]
     assert records[0].issuer_id == "ISSUER_SEC_AAPL_US"
+    assert records[0].liquidity_tier == "L2"
     assert records[1].issuer_id is None
+    assert records[1].liquidity_tier is None
     assert records[2].issuer_id == "ISSUER_SEC_MSFT_US"
+    assert records[2].liquidity_tier == "L2"
 
 
 async def test_core_snapshot_simulation_success(mock_dependencies):

--- a/tests/unit/services/query_service/services/test_instrument_service.py
+++ b/tests/unit/services/query_service/services/test_instrument_service.py
@@ -24,6 +24,9 @@ def mock_instrument_repo() -> AsyncMock:
             isin="ISIN1",
             currency="USD",
             product_type="Equity",
+            sector="Information Technology",
+            country_of_risk="United States",
+            rating=None,
         ),
         Instrument(
             security_id="SEC2",
@@ -31,6 +34,9 @@ def mock_instrument_repo() -> AsyncMock:
             isin="ISIN2",
             currency="SGD",
             product_type="Bond",
+            sector="Industrials",
+            country_of_risk="Singapore",
+            rating="AA+",
         ),
     ]
     repo.get_by_security_ids.return_value = repo.get_instruments.return_value
@@ -99,7 +105,10 @@ async def test_get_instruments(mock_instrument_repo: AsyncMock):
 
         # 3. Assert the mapping from DB model to DTO is correct
         assert response_dto.instruments[0].security_id == "SEC1"
+        assert response_dto.instruments[0].sector == "Information Technology"
         assert response_dto.instruments[1].product_type == "Bond"
+        assert response_dto.instruments[1].country_of_risk == "Singapore"
+        assert response_dto.instruments[1].rating == "AA+"
 
 
 async def test_get_instruments_by_ids_returns_empty_when_ids_empty(mock_instrument_repo: AsyncMock):

--- a/tests/unit/services/query_service/services/test_position_service.py
+++ b/tests/unit/services/query_service/services/test_position_service.py
@@ -41,8 +41,10 @@ def mock_position_repo() -> AsyncMock:
         isin="ISIN123",
         currency="USD",
         asset_class="Equity",
+        product_type="Equity",
         sector="Technology",
         country_of_risk="US",
+        rating="AA+",
     )
     mock_state = PositionState(status="CURRENT", epoch=1)
 
@@ -113,6 +115,8 @@ async def test_get_latest_positions(mock_position_repo: AsyncMock):
         assert response.positions[0].currency == "USD"
         assert response.positions[0].sector == "Technology"
         assert response.positions[0].country_of_risk == "US"
+        assert response.positions[0].product_type == "Equity"
+        assert response.positions[0].rating == "AA+"
         assert response.positions[0].held_since_date == date(2024, 12, 31)
         assert response.positions[0].weight == Decimal("1")
 
@@ -136,8 +140,10 @@ async def test_get_latest_positions_falls_back_to_position_history(mock_position
             isin="ISIN456",
             currency="USD",
             asset_class="Bond",
+            product_type="Bond",
             sector="N/A",
             country_of_risk="US",
+            rating="A",
         )
         mock_state = PositionState(status="CURRENT", epoch=1)
         mock_position_repo.get_latest_position_history_by_portfolio_as_of_date.return_value = [
@@ -168,6 +174,8 @@ async def test_get_latest_positions_falls_back_to_position_history(mock_position
         assert response.positions[0].security_id == "S2"
         assert response.positions[0].position_date == date(2025, 1, 2)
         assert response.positions[0].instrument_name == "Fallback Instrument"
+        assert response.positions[0].product_type == "Bond"
+        assert response.positions[0].rating == "A"
         assert response.positions[0].asset_class == "Bond"
         assert response.positions[0].valuation is not None
         assert response.positions[0].valuation.market_value == Decimal("5582.5")

--- a/tests/unit/services/query_service/services/test_position_service.py
+++ b/tests/unit/services/query_service/services/test_position_service.py
@@ -45,6 +45,7 @@ def mock_position_repo() -> AsyncMock:
         sector="Technology",
         country_of_risk="US",
         rating="AA+",
+        liquidity_tier="L2",
     )
     mock_state = PositionState(status="CURRENT", epoch=1)
 
@@ -117,6 +118,7 @@ async def test_get_latest_positions(mock_position_repo: AsyncMock):
         assert response.positions[0].country_of_risk == "US"
         assert response.positions[0].product_type == "Equity"
         assert response.positions[0].rating == "AA+"
+        assert response.positions[0].liquidity_tier == "L2"
         assert response.positions[0].held_since_date == date(2024, 12, 31)
         assert response.positions[0].weight == Decimal("1")
 
@@ -144,6 +146,7 @@ async def test_get_latest_positions_falls_back_to_position_history(mock_position
             sector="N/A",
             country_of_risk="US",
             rating="A",
+            liquidity_tier="L3",
         )
         mock_state = PositionState(status="CURRENT", epoch=1)
         mock_position_repo.get_latest_position_history_by_portfolio_as_of_date.return_value = [
@@ -176,6 +179,7 @@ async def test_get_latest_positions_falls_back_to_position_history(mock_position
         assert response.positions[0].instrument_name == "Fallback Instrument"
         assert response.positions[0].product_type == "Bond"
         assert response.positions[0].rating == "A"
+        assert response.positions[0].liquidity_tier == "L3"
         assert response.positions[0].asset_class == "Bond"
         assert response.positions[0].valuation is not None
         assert response.positions[0].valuation.market_value == Decimal("5582.5")

--- a/tests/unit/tools/test_front_office_portfolio_seed.py
+++ b/tests/unit/tools/test_front_office_portfolio_seed.py
@@ -45,10 +45,13 @@ def test_front_office_bundle_carries_meaningful_classification_metadata():
     assert by_security["FO_EQ_AAPL_US"]["issuer_name"] == "Apple Inc."
     assert by_security["FO_EQ_SAP_DE"]["country_of_risk"] == "Germany"
     assert by_security["FO_BOND_UST_2030"]["rating"] == "AA+"
+    assert by_security["FO_ETF_MSCI_WORLD"]["liquidity_tier"] == "L1"
+    assert by_security["FO_FUND_PIMCO_INC"]["liquidity_tier"] == "L3"
     assert (
         by_security["FO_BOND_SIEMENS_2031"]["ultimate_parent_issuer_name"]
         == "Siemens AG"
     )
+    assert by_security["FO_PRIV_PRIVATE_CREDIT_A"]["liquidity_tier"] == "L5"
     assert by_security["FO_PRIV_PRIVATE_CREDIT_A"]["sector"] == "Private Credit"
 
 

--- a/tests/unit/tools/test_front_office_portfolio_seed.py
+++ b/tests/unit/tools/test_front_office_portfolio_seed.py
@@ -154,6 +154,17 @@ def test_front_office_bundle_extends_fx_coverage_through_forward_projection_wind
     assert eur_usd_rates[-1]["rate_date"] == "2026-04-27"
 
 
+def test_front_office_bundle_extends_usd_risk_free_coverage_through_forward_window():
+    bundle = _build_bundle()
+
+    risk_free_series = bundle["risk_free_series"]
+    assert risk_free_series
+    assert risk_free_series[0]["series_currency"] == "USD"
+    assert risk_free_series[0]["risk_free_curve_id"] == "USD_SOFR_3M"
+    assert risk_free_series[0]["source_vendor"] == "LOTUS_FRONT_OFFICE_SEED"
+    assert risk_free_series[-1]["series_date"] == "2026-04-27"
+
+
 def test_front_office_bundle_rewrites_all_benchmark_artifacts_to_dedicated_seed_identity():
     bundle = _build_bundle()
 

--- a/tools/demo_data_pack.py
+++ b/tools/demo_data_pack.py
@@ -349,6 +349,39 @@ def _build_benchmark_reference_data(*, dates: list[str], start_date: date) -> di
     }
 
 
+def build_risk_free_reference_data(
+    *,
+    start_date: date,
+    end_date: date,
+    currency: str = "USD",
+    curve_id: str | None = None,
+    annualized_rate: Decimal = Decimal("0.0435000000"),
+    source_vendor: str = "LOTUS_DEMO",
+    source_prefix: str = "risk_free",
+) -> dict[str, Any]:
+    normalized_currency = currency.upper()
+    normalized_curve_id = curve_id or f"{normalized_currency}_SOFR_3M"
+    risk_free_series: list[dict[str, Any]] = []
+    for current_date in _calendar_dates(start_date, end_date):
+        risk_free_series.append(
+            {
+                "series_id": f"{source_prefix}_{normalized_currency.lower()}_annualized_rate",
+                "risk_free_curve_id": normalized_curve_id,
+                "series_date": current_date,
+                "value": f"{annualized_rate:.10f}",
+                "value_convention": "annualized_rate",
+                "day_count_convention": "ACT_360",
+                "compounding_convention": "simple",
+                "series_currency": normalized_currency,
+                "source_timestamp": _iso_utc_timestamp(date.fromisoformat(current_date)),
+                "source_vendor": source_vendor,
+                "source_record_id": f"{source_prefix}_{normalized_currency.lower()}_{current_date}",
+                "quality_status": "accepted",
+            }
+        )
+    return {"risk_free_series": risk_free_series}
+
+
 def build_demo_bundle() -> dict[str, Any]:
     start_date = date.today() - timedelta(days=365)
     end_date = date.today()
@@ -526,6 +559,13 @@ def build_demo_bundle() -> dict[str, Any]:
             rate = round(start_rate + ((end_rate - start_rate) * idx / (len(dates) - 1)), 6)
             fx_rates.append({"from_currency": from_ccy, "to_currency": to_ccy, "rate_date": d, "rate": rate})
     benchmark_reference = _build_benchmark_reference_data(dates=dates, start_date=start_date)
+    risk_free_reference = build_risk_free_reference_data(
+        start_date=start_date,
+        end_date=end_date,
+        currency="USD",
+        source_vendor="LOTUS_DEMO",
+        source_prefix="demo_risk_free",
+    )
     return {
         "source_system": "LOTUS_CORE_DEMO_DATA_PACK",
         "mode": "UPSERT",
@@ -537,6 +577,7 @@ def build_demo_bundle() -> dict[str, Any]:
         "fx_rates": fx_rates,
         "as_of_date": as_of,
         **benchmark_reference,
+        **risk_free_reference,
     }
 
 
@@ -563,6 +604,7 @@ def _ingest_demo_reference_data(ingestion_base_url: str, bundle: dict[str, Any])
         ("/ingest/benchmark-compositions", {"benchmark_compositions": bundle["benchmark_compositions"]}),
         ("/ingest/benchmark-return-series", {"benchmark_return_series": bundle["benchmark_return_series"]}),
         ("/ingest/benchmark-assignments", {"benchmark_assignments": bundle["benchmark_assignments"]}),
+        ("/ingest/risk-free-series", {"risk_free_series": bundle["risk_free_series"]}),
     )
     for endpoint, payload in reference_payloads:
         _request_json("POST", f"{ingestion_base_url}{endpoint}", payload=payload)

--- a/tools/demo_data_pack.py
+++ b/tools/demo_data_pack.py
@@ -8,8 +8,8 @@ import logging
 import math
 import time
 from dataclasses import dataclass
-from decimal import Decimal
 from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
 from typing import Any
 from urllib import error, parse, request
 
@@ -219,9 +219,7 @@ def _build_benchmark_reference_data(*, dates: list[str], start_date: date) -> di
     for current_date, equity_return, bond_return in zip(
         series_dates, equity_daily_returns, bond_daily_returns, strict=True
     ):
-        benchmark_return = (equity_return * Decimal("0.6")) + (
-            bond_return * Decimal("0.4")
-        )
+        benchmark_return = (equity_return * Decimal("0.6")) + (bond_return * Decimal("0.4"))
         benchmark_return_series.append(
             {
                 "series_id": "bmk_global_balanced_60_40_return",
@@ -400,6 +398,7 @@ def build_demo_bundle() -> dict[str, Any]:
             tzinfo=UTC,
         )
         return stamp.isoformat().replace("+00:00", "Z")
+
     portfolios = [
         {
             "portfolio_id": "DEMO_ADV_USD_001",
@@ -463,58 +462,568 @@ def build_demo_bundle() -> dict[str, Any]:
         },
     ]
     instruments = [
-        {"security_id": "CASH_USD", "name": "US Dollar Cash", "isin": "CASH_USD_DEMO", "currency": "USD", "product_type": "Cash", "asset_class": "Cash"},
-        {"security_id": "CASH_EUR", "name": "Euro Cash", "isin": "CASH_EUR_DEMO", "currency": "EUR", "product_type": "Cash", "asset_class": "Cash"},
-        {"security_id": "CASH_CHF", "name": "Swiss Franc Cash", "isin": "CASH_CHF_DEMO", "currency": "CHF", "product_type": "Cash", "asset_class": "Cash"},
-        {"security_id": "CASH_SGD", "name": "Singapore Dollar Cash", "isin": "CASH_SGD_DEMO", "currency": "SGD", "product_type": "Cash", "asset_class": "Cash"},
-        {"security_id": "SEC_AAPL_US", "name": "Apple Inc.", "isin": "US0378331005", "currency": "USD", "product_type": "Equity", "asset_class": "Equity", "sector": "Technology", "country_of_risk": "US"},
-        {"security_id": "SEC_SAP_DE", "name": "SAP SE", "isin": "DE0007164600", "currency": "EUR", "product_type": "Equity", "asset_class": "Equity", "sector": "Technology", "country_of_risk": "DE"},
-        {"security_id": "SEC_NOVN_CH", "name": "Novartis AG", "isin": "CH0012005267", "currency": "CHF", "product_type": "Equity", "asset_class": "Equity", "sector": "Healthcare", "country_of_risk": "CH"},
-        {"security_id": "SEC_SONY_JP", "name": "Sony Group Corp.", "isin": "JP3435000009", "currency": "JPY", "product_type": "Equity", "asset_class": "Equity", "sector": "Consumer Discretionary", "country_of_risk": "JP"},
-        {"security_id": "SEC_UST_5Y", "name": "US Treasury 5Y", "isin": "US91282CGM73", "currency": "USD", "product_type": "Bond", "asset_class": "Fixed Income", "rating": "AA+", "maturity_date": "2029-08-31"},
-        {"security_id": "SEC_CORP_IG_USD", "name": "Global Corp 4.2% 2030", "isin": "US0000000001", "currency": "USD", "product_type": "Bond", "asset_class": "Fixed Income", "rating": "A-", "maturity_date": "2030-06-15"},
-        {"security_id": "SEC_ETF_WORLD_USD", "name": "Global Equity ETF", "isin": "US0000000002", "currency": "USD", "product_type": "ETF", "asset_class": "Equity"},
-        {"security_id": "SEC_FUND_EM_EQ", "name": "Emerging Markets Equity Fund", "isin": "LU0000000003", "currency": "USD", "product_type": "Fund", "asset_class": "Equity"},
-        {"security_id": "SEC_GOLD_ETC_USD", "name": "Gold ETC", "isin": "JE00B1VS3770", "currency": "USD", "product_type": "ETC", "asset_class": "Commodity"},
+        {
+            "security_id": "CASH_USD",
+            "name": "US Dollar Cash",
+            "isin": "CASH_USD_DEMO",
+            "currency": "USD",
+            "product_type": "Cash",
+            "asset_class": "Cash",
+        },
+        {
+            "security_id": "CASH_EUR",
+            "name": "Euro Cash",
+            "isin": "CASH_EUR_DEMO",
+            "currency": "EUR",
+            "product_type": "Cash",
+            "asset_class": "Cash",
+        },
+        {
+            "security_id": "CASH_CHF",
+            "name": "Swiss Franc Cash",
+            "isin": "CASH_CHF_DEMO",
+            "currency": "CHF",
+            "product_type": "Cash",
+            "asset_class": "Cash",
+        },
+        {
+            "security_id": "CASH_SGD",
+            "name": "Singapore Dollar Cash",
+            "isin": "CASH_SGD_DEMO",
+            "currency": "SGD",
+            "product_type": "Cash",
+            "asset_class": "Cash",
+        },
+        {
+            "security_id": "SEC_AAPL_US",
+            "name": "Apple Inc.",
+            "isin": "US0378331005",
+            "currency": "USD",
+            "product_type": "Equity",
+            "asset_class": "Equity",
+            "sector": "Technology",
+            "country_of_risk": "US",
+        },
+        {
+            "security_id": "SEC_SAP_DE",
+            "name": "SAP SE",
+            "isin": "DE0007164600",
+            "currency": "EUR",
+            "product_type": "Equity",
+            "asset_class": "Equity",
+            "sector": "Technology",
+            "country_of_risk": "DE",
+        },
+        {
+            "security_id": "SEC_NOVN_CH",
+            "name": "Novartis AG",
+            "isin": "CH0012005267",
+            "currency": "CHF",
+            "product_type": "Equity",
+            "asset_class": "Equity",
+            "sector": "Healthcare",
+            "country_of_risk": "CH",
+        },
+        {
+            "security_id": "SEC_SONY_JP",
+            "name": "Sony Group Corp.",
+            "isin": "JP3435000009",
+            "currency": "JPY",
+            "product_type": "Equity",
+            "asset_class": "Equity",
+            "sector": "Consumer Discretionary",
+            "country_of_risk": "JP",
+        },
+        {
+            "security_id": "SEC_UST_5Y",
+            "name": "US Treasury 5Y",
+            "isin": "US91282CGM73",
+            "currency": "USD",
+            "product_type": "Bond",
+            "asset_class": "Fixed Income",
+            "rating": "AA+",
+            "maturity_date": "2029-08-31",
+        },
+        {
+            "security_id": "SEC_CORP_IG_USD",
+            "name": "Global Corp 4.2% 2030",
+            "isin": "US0000000001",
+            "currency": "USD",
+            "product_type": "Bond",
+            "asset_class": "Fixed Income",
+            "rating": "A-",
+            "maturity_date": "2030-06-15",
+        },
+        {
+            "security_id": "SEC_ETF_WORLD_USD",
+            "name": "Global Equity ETF",
+            "isin": "US0000000002",
+            "currency": "USD",
+            "product_type": "ETF",
+            "asset_class": "Equity",
+        },
+        {
+            "security_id": "SEC_FUND_EM_EQ",
+            "name": "Emerging Markets Equity Fund",
+            "isin": "LU0000000003",
+            "currency": "USD",
+            "product_type": "Fund",
+            "asset_class": "Equity",
+        },
+        {
+            "security_id": "SEC_GOLD_ETC_USD",
+            "name": "Gold ETC",
+            "isin": "JE00B1VS3770",
+            "currency": "USD",
+            "product_type": "ETC",
+            "asset_class": "Commodity",
+        },
     ]
     txs = [
-        _tx("DEMO_ADV_DEP_01", "DEMO_ADV_USD_001", "CASH", "CASH_USD", tx_ts(1, 9), "DEPOSIT", 500000, 1, 500000, "USD"),
-        _tx("DEMO_ADV_BUY_AAPL_01", "DEMO_ADV_USD_001", "AAPL", "SEC_AAPL_US", tx_ts(2), "BUY", 800, 185, 148000, "USD"),
-        _tx("DEMO_ADV_CASH_OUT_01", "DEMO_ADV_USD_001", "CASH", "CASH_USD", tx_ts(2), "SELL", 148000, 1, 148000, "USD"),
-        _tx("DEMO_ADV_BUY_UST_01", "DEMO_ADV_USD_001", "UST5Y", "SEC_UST_5Y", tx_ts(5), "BUY", 120, 980, 117600, "USD"),
-        _tx("DEMO_ADV_CASH_OUT_02", "DEMO_ADV_USD_001", "CASH", "CASH_USD", tx_ts(5), "SELL", 117600, 1, 117600, "USD"),
-        _tx("DEMO_ADV_DIV_01", "DEMO_ADV_USD_001", "AAPL", "SEC_AAPL_US", tx_ts(160), "DIVIDEND", 0, 0, 1200, "USD"),
-        _tx("DEMO_ADV_CASH_IN_01", "DEMO_ADV_USD_001", "CASH", "CASH_USD", tx_ts(160), "BUY", 1200, 1, 1200, "USD"),
-        _tx("DEMO_ADV_FEE_01", "DEMO_ADV_USD_001", "CASH", "CASH_USD", tx_ts(330), "FEE", 1, 250, 250, "USD"),
-        _tx("DEMO_DPM_DEP_01", "DEMO_DPM_EUR_001", "CASH", "CASH_EUR", tx_ts(1, 9), "DEPOSIT", 600000, 1, 600000, "EUR"),
-        _tx("DEMO_DPM_BUY_SAP_01", "DEMO_DPM_EUR_001", "SAP", "SEC_SAP_DE", tx_ts(3), "BUY", 1500, 120, 180000, "EUR"),
-        _tx("DEMO_DPM_CASH_OUT_01", "DEMO_DPM_EUR_001", "CASH", "CASH_EUR", tx_ts(3), "SELL", 180000, 1, 180000, "EUR"),
-        _tx("DEMO_DPM_BUY_ETF_01", "DEMO_DPM_EUR_001", "WORLD_ETF", "SEC_ETF_WORLD_USD", tx_ts(12), "BUY", 1000, 95, 95000, "USD"),
-        _tx("DEMO_DPM_CASH_OUT_02", "DEMO_DPM_EUR_001", "CASH", "CASH_EUR", tx_ts(12), "SELL", 86000, 1, 86000, "EUR"),
-        _tx("DEMO_DPM_SELL_SAP_01", "DEMO_DPM_EUR_001", "SAP", "SEC_SAP_DE", tx_ts(220), "SELL", 300, 128, 38400, "EUR"),
-        _tx("DEMO_DPM_CASH_IN_01", "DEMO_DPM_EUR_001", "CASH", "CASH_EUR", tx_ts(220), "BUY", 38400, 1, 38400, "EUR"),
-        _tx("DEMO_INCOME_DEP_01", "DEMO_INCOME_CHF_001", "CASH", "CASH_CHF", tx_ts(1, 9), "DEPOSIT", 420000, 1, 420000, "CHF"),
-        _tx("DEMO_INCOME_BUY_NOVN_01", "DEMO_INCOME_CHF_001", "NOVN", "SEC_NOVN_CH", tx_ts(4), "BUY", 1000, 92, 92000, "CHF"),
-        _tx("DEMO_INCOME_CASH_OUT_01", "DEMO_INCOME_CHF_001", "CASH", "CASH_CHF", tx_ts(4), "SELL", 92000, 1, 92000, "CHF"),
-        _tx("DEMO_INCOME_BUY_BOND_01", "DEMO_INCOME_CHF_001", "CORP_IG", "SEC_CORP_IG_USD", tx_ts(8), "BUY", 90, 1010, 90900, "USD"),
-        _tx("DEMO_INCOME_CASH_OUT_02", "DEMO_INCOME_CHF_001", "CASH", "CASH_CHF", tx_ts(8), "SELL", 82000, 1, 82000, "CHF"),
-        _tx("DEMO_INCOME_COUPON_01", "DEMO_INCOME_CHF_001", "CORP_IG", "SEC_CORP_IG_USD", tx_ts(190), "DIVIDEND", 0, 0, 650, "USD"),
-        _tx("DEMO_INCOME_CASH_IN_01", "DEMO_INCOME_CHF_001", "CASH", "CASH_CHF", tx_ts(190), "BUY", 580, 1, 580, "CHF"),
-        _tx("DEMO_BAL_DEP_01", "DEMO_BALANCED_SGD_001", "CASH", "CASH_SGD", tx_ts(1, 9), "DEPOSIT", 700000, 1, 700000, "SGD"),
-        _tx("DEMO_BAL_BUY_SONY_01", "DEMO_BALANCED_SGD_001", "SONY", "SEC_SONY_JP", tx_ts(3), "BUY", 1200, 1750, 2100000, "JPY"),
-        _tx("DEMO_BAL_CASH_OUT_01", "DEMO_BALANCED_SGD_001", "CASH", "CASH_SGD", tx_ts(3), "SELL", 19800, 1, 19800, "SGD"),
-        _tx("DEMO_BAL_BUY_GOLD_01", "DEMO_BALANCED_SGD_001", "GOLD_ETC", "SEC_GOLD_ETC_USD", tx_ts(30), "BUY", 500, 210, 105000, "USD"),
-        _tx("DEMO_BAL_CASH_OUT_02", "DEMO_BALANCED_SGD_001", "CASH", "CASH_SGD", tx_ts(30), "SELL", 141000, 1, 141000, "SGD"),
-        _tx("DEMO_BAL_SELL_SONY_01", "DEMO_BALANCED_SGD_001", "SONY", "SEC_SONY_JP", tx_ts(280), "SELL", 200, 1820, 364000, "JPY"),
-        _tx("DEMO_BAL_CASH_IN_01", "DEMO_BALANCED_SGD_001", "CASH", "CASH_SGD", tx_ts(280), "BUY", 3300, 1, 3300, "SGD"),
-        _tx("DEMO_REBAL_DEP_01", "DEMO_REBAL_USD_001", "CASH", "CASH_USD", tx_ts(1, 9), "DEPOSIT", 300000, 1, 300000, "USD"),
-        _tx("DEMO_REBAL_BUY_FUND_01", "DEMO_REBAL_USD_001", "EM_FUND", "SEC_FUND_EM_EQ", tx_ts(10), "BUY", 2000, 55, 110000, "USD"),
-        _tx("DEMO_REBAL_CASH_OUT_01", "DEMO_REBAL_USD_001", "CASH", "CASH_USD", tx_ts(10), "SELL", 110000, 1, 110000, "USD"),
-        _tx("DEMO_REBAL_BUY_BOND_01", "DEMO_REBAL_USD_001", "CORP_IG", "SEC_CORP_IG_USD", tx_ts(20), "BUY", 60, 1012, 60720, "USD"),
-        _tx("DEMO_REBAL_CASH_OUT_02", "DEMO_REBAL_USD_001", "CASH", "CASH_USD", tx_ts(20), "SELL", 60720, 1, 60720, "USD"),
-        _tx("DEMO_REBAL_TRANSFER_OUT_01", "DEMO_REBAL_USD_001", "EM_FUND", "SEC_FUND_EM_EQ", tx_ts(240), "TRANSFER_OUT", 200, 56, 11200, "USD"),
-        _tx("DEMO_REBAL_CASH_IN_01", "DEMO_REBAL_USD_001", "CASH", "CASH_USD", tx_ts(240), "BUY", 11200, 1, 11200, "USD"),
-        _tx("DEMO_REBAL_WITHDRAW_01", "DEMO_REBAL_USD_001", "CASH", "CASH_USD", tx_ts(340), "WITHDRAWAL", 15000, 1, 15000, "USD"),
+        _tx(
+            "DEMO_ADV_DEP_01",
+            "DEMO_ADV_USD_001",
+            "CASH",
+            "CASH_USD",
+            tx_ts(1, 9),
+            "DEPOSIT",
+            500000,
+            1,
+            500000,
+            "USD",
+        ),
+        _tx(
+            "DEMO_ADV_BUY_AAPL_01",
+            "DEMO_ADV_USD_001",
+            "AAPL",
+            "SEC_AAPL_US",
+            tx_ts(2),
+            "BUY",
+            800,
+            185,
+            148000,
+            "USD",
+        ),
+        _tx(
+            "DEMO_ADV_CASH_OUT_01",
+            "DEMO_ADV_USD_001",
+            "CASH",
+            "CASH_USD",
+            tx_ts(2),
+            "SELL",
+            148000,
+            1,
+            148000,
+            "USD",
+        ),
+        _tx(
+            "DEMO_ADV_BUY_UST_01",
+            "DEMO_ADV_USD_001",
+            "UST5Y",
+            "SEC_UST_5Y",
+            tx_ts(5),
+            "BUY",
+            120,
+            980,
+            117600,
+            "USD",
+        ),
+        _tx(
+            "DEMO_ADV_CASH_OUT_02",
+            "DEMO_ADV_USD_001",
+            "CASH",
+            "CASH_USD",
+            tx_ts(5),
+            "SELL",
+            117600,
+            1,
+            117600,
+            "USD",
+        ),
+        _tx(
+            "DEMO_ADV_DIV_01",
+            "DEMO_ADV_USD_001",
+            "AAPL",
+            "SEC_AAPL_US",
+            tx_ts(160),
+            "DIVIDEND",
+            0,
+            0,
+            1200,
+            "USD",
+        ),
+        _tx(
+            "DEMO_ADV_CASH_IN_01",
+            "DEMO_ADV_USD_001",
+            "CASH",
+            "CASH_USD",
+            tx_ts(160),
+            "BUY",
+            1200,
+            1,
+            1200,
+            "USD",
+        ),
+        _tx(
+            "DEMO_ADV_FEE_01",
+            "DEMO_ADV_USD_001",
+            "CASH",
+            "CASH_USD",
+            tx_ts(330),
+            "FEE",
+            1,
+            250,
+            250,
+            "USD",
+        ),
+        _tx(
+            "DEMO_DPM_DEP_01",
+            "DEMO_DPM_EUR_001",
+            "CASH",
+            "CASH_EUR",
+            tx_ts(1, 9),
+            "DEPOSIT",
+            600000,
+            1,
+            600000,
+            "EUR",
+        ),
+        _tx(
+            "DEMO_DPM_BUY_SAP_01",
+            "DEMO_DPM_EUR_001",
+            "SAP",
+            "SEC_SAP_DE",
+            tx_ts(3),
+            "BUY",
+            1500,
+            120,
+            180000,
+            "EUR",
+        ),
+        _tx(
+            "DEMO_DPM_CASH_OUT_01",
+            "DEMO_DPM_EUR_001",
+            "CASH",
+            "CASH_EUR",
+            tx_ts(3),
+            "SELL",
+            180000,
+            1,
+            180000,
+            "EUR",
+        ),
+        _tx(
+            "DEMO_DPM_BUY_ETF_01",
+            "DEMO_DPM_EUR_001",
+            "WORLD_ETF",
+            "SEC_ETF_WORLD_USD",
+            tx_ts(12),
+            "BUY",
+            1000,
+            95,
+            95000,
+            "USD",
+        ),
+        _tx(
+            "DEMO_DPM_CASH_OUT_02",
+            "DEMO_DPM_EUR_001",
+            "CASH",
+            "CASH_EUR",
+            tx_ts(12),
+            "SELL",
+            86000,
+            1,
+            86000,
+            "EUR",
+        ),
+        _tx(
+            "DEMO_DPM_SELL_SAP_01",
+            "DEMO_DPM_EUR_001",
+            "SAP",
+            "SEC_SAP_DE",
+            tx_ts(220),
+            "SELL",
+            300,
+            128,
+            38400,
+            "EUR",
+        ),
+        _tx(
+            "DEMO_DPM_CASH_IN_01",
+            "DEMO_DPM_EUR_001",
+            "CASH",
+            "CASH_EUR",
+            tx_ts(220),
+            "BUY",
+            38400,
+            1,
+            38400,
+            "EUR",
+        ),
+        _tx(
+            "DEMO_INCOME_DEP_01",
+            "DEMO_INCOME_CHF_001",
+            "CASH",
+            "CASH_CHF",
+            tx_ts(1, 9),
+            "DEPOSIT",
+            420000,
+            1,
+            420000,
+            "CHF",
+        ),
+        _tx(
+            "DEMO_INCOME_BUY_NOVN_01",
+            "DEMO_INCOME_CHF_001",
+            "NOVN",
+            "SEC_NOVN_CH",
+            tx_ts(4),
+            "BUY",
+            1000,
+            92,
+            92000,
+            "CHF",
+        ),
+        _tx(
+            "DEMO_INCOME_CASH_OUT_01",
+            "DEMO_INCOME_CHF_001",
+            "CASH",
+            "CASH_CHF",
+            tx_ts(4),
+            "SELL",
+            92000,
+            1,
+            92000,
+            "CHF",
+        ),
+        _tx(
+            "DEMO_INCOME_BUY_BOND_01",
+            "DEMO_INCOME_CHF_001",
+            "CORP_IG",
+            "SEC_CORP_IG_USD",
+            tx_ts(8),
+            "BUY",
+            90,
+            1010,
+            90900,
+            "USD",
+        ),
+        _tx(
+            "DEMO_INCOME_CASH_OUT_02",
+            "DEMO_INCOME_CHF_001",
+            "CASH",
+            "CASH_CHF",
+            tx_ts(8),
+            "SELL",
+            82000,
+            1,
+            82000,
+            "CHF",
+        ),
+        _tx(
+            "DEMO_INCOME_COUPON_01",
+            "DEMO_INCOME_CHF_001",
+            "CORP_IG",
+            "SEC_CORP_IG_USD",
+            tx_ts(190),
+            "DIVIDEND",
+            0,
+            0,
+            650,
+            "USD",
+        ),
+        _tx(
+            "DEMO_INCOME_CASH_IN_01",
+            "DEMO_INCOME_CHF_001",
+            "CASH",
+            "CASH_CHF",
+            tx_ts(190),
+            "BUY",
+            580,
+            1,
+            580,
+            "CHF",
+        ),
+        _tx(
+            "DEMO_BAL_DEP_01",
+            "DEMO_BALANCED_SGD_001",
+            "CASH",
+            "CASH_SGD",
+            tx_ts(1, 9),
+            "DEPOSIT",
+            700000,
+            1,
+            700000,
+            "SGD",
+        ),
+        _tx(
+            "DEMO_BAL_BUY_SONY_01",
+            "DEMO_BALANCED_SGD_001",
+            "SONY",
+            "SEC_SONY_JP",
+            tx_ts(3),
+            "BUY",
+            1200,
+            1750,
+            2100000,
+            "JPY",
+        ),
+        _tx(
+            "DEMO_BAL_CASH_OUT_01",
+            "DEMO_BALANCED_SGD_001",
+            "CASH",
+            "CASH_SGD",
+            tx_ts(3),
+            "SELL",
+            19800,
+            1,
+            19800,
+            "SGD",
+        ),
+        _tx(
+            "DEMO_BAL_BUY_GOLD_01",
+            "DEMO_BALANCED_SGD_001",
+            "GOLD_ETC",
+            "SEC_GOLD_ETC_USD",
+            tx_ts(30),
+            "BUY",
+            500,
+            210,
+            105000,
+            "USD",
+        ),
+        _tx(
+            "DEMO_BAL_CASH_OUT_02",
+            "DEMO_BALANCED_SGD_001",
+            "CASH",
+            "CASH_SGD",
+            tx_ts(30),
+            "SELL",
+            141000,
+            1,
+            141000,
+            "SGD",
+        ),
+        _tx(
+            "DEMO_BAL_SELL_SONY_01",
+            "DEMO_BALANCED_SGD_001",
+            "SONY",
+            "SEC_SONY_JP",
+            tx_ts(280),
+            "SELL",
+            200,
+            1820,
+            364000,
+            "JPY",
+        ),
+        _tx(
+            "DEMO_BAL_CASH_IN_01",
+            "DEMO_BALANCED_SGD_001",
+            "CASH",
+            "CASH_SGD",
+            tx_ts(280),
+            "BUY",
+            3300,
+            1,
+            3300,
+            "SGD",
+        ),
+        _tx(
+            "DEMO_REBAL_DEP_01",
+            "DEMO_REBAL_USD_001",
+            "CASH",
+            "CASH_USD",
+            tx_ts(1, 9),
+            "DEPOSIT",
+            300000,
+            1,
+            300000,
+            "USD",
+        ),
+        _tx(
+            "DEMO_REBAL_BUY_FUND_01",
+            "DEMO_REBAL_USD_001",
+            "EM_FUND",
+            "SEC_FUND_EM_EQ",
+            tx_ts(10),
+            "BUY",
+            2000,
+            55,
+            110000,
+            "USD",
+        ),
+        _tx(
+            "DEMO_REBAL_CASH_OUT_01",
+            "DEMO_REBAL_USD_001",
+            "CASH",
+            "CASH_USD",
+            tx_ts(10),
+            "SELL",
+            110000,
+            1,
+            110000,
+            "USD",
+        ),
+        _tx(
+            "DEMO_REBAL_BUY_BOND_01",
+            "DEMO_REBAL_USD_001",
+            "CORP_IG",
+            "SEC_CORP_IG_USD",
+            tx_ts(20),
+            "BUY",
+            60,
+            1012,
+            60720,
+            "USD",
+        ),
+        _tx(
+            "DEMO_REBAL_CASH_OUT_02",
+            "DEMO_REBAL_USD_001",
+            "CASH",
+            "CASH_USD",
+            tx_ts(20),
+            "SELL",
+            60720,
+            1,
+            60720,
+            "USD",
+        ),
+        _tx(
+            "DEMO_REBAL_TRANSFER_OUT_01",
+            "DEMO_REBAL_USD_001",
+            "EM_FUND",
+            "SEC_FUND_EM_EQ",
+            tx_ts(240),
+            "TRANSFER_OUT",
+            200,
+            56,
+            11200,
+            "USD",
+        ),
+        _tx(
+            "DEMO_REBAL_CASH_IN_01",
+            "DEMO_REBAL_USD_001",
+            "CASH",
+            "CASH_USD",
+            tx_ts(240),
+            "BUY",
+            11200,
+            1,
+            11200,
+            "USD",
+        ),
+        _tx(
+            "DEMO_REBAL_WITHDRAW_01",
+            "DEMO_REBAL_USD_001",
+            "CASH",
+            "CASH_USD",
+            tx_ts(340),
+            "WITHDRAWAL",
+            15000,
+            1,
+            15000,
+            "USD",
+        ),
     ]
     price_paths = {
         "SEC_AAPL_US": (184, 194, "USD"),
@@ -540,7 +1049,9 @@ def build_demo_bundle() -> dict[str, Any]:
     for security_id, (start_px, end_px, ccy) in price_paths.items():
         for idx, d in enumerate(dates):
             px = round(start_px + ((end_px - start_px) * idx / (len(dates) - 1)), 2)
-            market_prices.append({"security_id": security_id, "price_date": d, "price": px, "currency": ccy})
+            market_prices.append(
+                {"security_id": security_id, "price_date": d, "price": px, "currency": ccy}
+            )
     fx_paths = {
         ("USD", "EUR"): (0.92, 0.90),
         ("EUR", "USD"): (1.09, 1.11),
@@ -557,7 +1068,9 @@ def build_demo_bundle() -> dict[str, Any]:
     for (from_ccy, to_ccy), (start_rate, end_rate) in fx_paths.items():
         for idx, d in enumerate(dates):
             rate = round(start_rate + ((end_rate - start_rate) * idx / (len(dates) - 1)), 6)
-            fx_rates.append({"from_currency": from_ccy, "to_currency": to_ccy, "rate_date": d, "rate": rate})
+            fx_rates.append(
+                {"from_currency": from_ccy, "to_currency": to_ccy, "rate_date": d, "rate": rate}
+            )
     benchmark_reference = _build_benchmark_reference_data(dates=dates, start_date=start_date)
     risk_free_reference = build_risk_free_reference_data(
         start_date=start_date,
@@ -600,10 +1113,22 @@ def _ingest_demo_reference_data(ingestion_base_url: str, bundle: dict[str, Any])
         ("/ingest/indices", {"indices": bundle["indices"]}),
         ("/ingest/index-price-series", {"index_price_series": bundle["index_price_series"]}),
         ("/ingest/index-return-series", {"index_return_series": bundle["index_return_series"]}),
-        ("/ingest/benchmark-definitions", {"benchmark_definitions": bundle["benchmark_definitions"]}),
-        ("/ingest/benchmark-compositions", {"benchmark_compositions": bundle["benchmark_compositions"]}),
-        ("/ingest/benchmark-return-series", {"benchmark_return_series": bundle["benchmark_return_series"]}),
-        ("/ingest/benchmark-assignments", {"benchmark_assignments": bundle["benchmark_assignments"]}),
+        (
+            "/ingest/benchmark-definitions",
+            {"benchmark_definitions": bundle["benchmark_definitions"]},
+        ),
+        (
+            "/ingest/benchmark-compositions",
+            {"benchmark_compositions": bundle["benchmark_compositions"]},
+        ),
+        (
+            "/ingest/benchmark-return-series",
+            {"benchmark_return_series": bundle["benchmark_return_series"]},
+        ),
+        (
+            "/ingest/benchmark-assignments",
+            {"benchmark_assignments": bundle["benchmark_assignments"]},
+        ),
         ("/ingest/risk-free-series", {"risk_free_series": bundle["risk_free_series"]}),
     )
     for endpoint, payload in reference_payloads:
@@ -660,15 +1185,21 @@ def _verify_portfolio(
     deadline = time.time() + wait_seconds
     while time.time() < deadline:
         try:
-            _, pos_payload = _request_json("GET", f"{query_base_url}/portfolios/{expected.portfolio_id}/positions")
-            _, tx_payload = _request_json("GET", f"{query_base_url}/portfolios/{expected.portfolio_id}/transactions?limit=200")
+            _, pos_payload = _request_json(
+                "GET", f"{query_base_url}/portfolios/{expected.portfolio_id}/positions"
+            )
+            _, tx_payload = _request_json(
+                "GET", f"{query_base_url}/portfolios/{expected.portfolio_id}/transactions?limit=200"
+            )
         except RuntimeError:
             time.sleep(poll_interval_seconds)
             continue
         positions = pos_payload.get("positions") or []
         valued = [
-            p for p in positions
-            if isinstance(p.get("valuation"), dict) and p["valuation"].get("market_value") is not None
+            p
+            for p in positions
+            if isinstance(p.get("valuation"), dict)
+            and p["valuation"].get("market_value") is not None
         ]
         total_transactions = int(tx_payload.get("total", 0))
         all_quantities_match = True
@@ -737,9 +1268,7 @@ def _verify_benchmark_reference(
 
         records = catalog_payload.get("records") if isinstance(catalog_payload, dict) else None
         segments = (
-            composition_payload.get("segments")
-            if isinstance(composition_payload, dict)
-            else None
+            composition_payload.get("segments") if isinstance(composition_payload, dict) else None
         )
         if (
             isinstance(records, list)
@@ -795,7 +1324,10 @@ def main() -> int:
         if args.force_ingest or not _all_demo_portfolios_exist(query_base_url):
             payload = _build_portfolio_bundle_payload(demo_bundle)
             LOGGER.info(
-                "Ingesting demo pack: portfolios=%d instruments=%d transactions=%d market_prices=%d fx_rates=%d",
+                (
+                    "Ingesting demo pack: portfolios=%d instruments=%d "
+                    "transactions=%d market_prices=%d fx_rates=%d"
+                ),
                 len(payload["portfolios"]),
                 len(payload["instruments"]),
                 len(payload["transactions"]),
@@ -822,7 +1354,10 @@ def main() -> int:
             )
             verification_results.append(result)
             LOGGER.info(
-                "Verified portfolio %s (positions=%d valued_positions=%d transactions=%d holdings_validated=%d)",
+                (
+                    "Verified portfolio %s (positions=%d valued_positions=%d "
+                    "transactions=%d holdings_validated=%d)"
+                ),
                 result["portfolio_id"],
                 result["positions"],
                 result["valued_positions"],

--- a/tools/front_office_portfolio_seed.py
+++ b/tools/front_office_portfolio_seed.py
@@ -208,6 +208,7 @@ def build_front_office_portfolio_bundle(
             "issuer_name": "Custody Cash Ledger",
             "ultimate_parent_issuer_id": "CASH_LEDGER",
             "ultimate_parent_issuer_name": "Custody Cash Ledger",
+            "liquidity_tier": "L1",
         },
         {
             "security_id": "CASH_EUR_BOOK_OPERATING",
@@ -220,6 +221,7 @@ def build_front_office_portfolio_bundle(
             "issuer_name": "Custody Cash Ledger",
             "ultimate_parent_issuer_id": "CASH_LEDGER",
             "ultimate_parent_issuer_name": "Custody Cash Ledger",
+            "liquidity_tier": "L1",
         },
         {
             "security_id": "FO_EQ_AAPL_US",
@@ -234,6 +236,7 @@ def build_front_office_portfolio_bundle(
             "issuer_name": "Apple Inc.",
             "ultimate_parent_issuer_id": "ISSUER_AAPL",
             "ultimate_parent_issuer_name": "Apple Inc.",
+            "liquidity_tier": "L1",
         },
         {
             "security_id": "FO_EQ_MSFT_US",
@@ -248,6 +251,7 @@ def build_front_office_portfolio_bundle(
             "issuer_name": "Microsoft Corporation",
             "ultimate_parent_issuer_id": "ISSUER_MSFT",
             "ultimate_parent_issuer_name": "Microsoft Corporation",
+            "liquidity_tier": "L1",
         },
         {
             "security_id": "FO_EQ_SAP_DE",
@@ -262,6 +266,7 @@ def build_front_office_portfolio_bundle(
             "issuer_name": "SAP SE",
             "ultimate_parent_issuer_id": "ISSUER_SAP",
             "ultimate_parent_issuer_name": "SAP SE",
+            "liquidity_tier": "L1",
         },
         {
             "security_id": "FO_ETF_MSCI_WORLD",
@@ -276,6 +281,7 @@ def build_front_office_portfolio_bundle(
             "issuer_name": "BlackRock Asset Management Ireland Limited",
             "ultimate_parent_issuer_id": "ULTIMATE_BLACKROCK",
             "ultimate_parent_issuer_name": "BlackRock, Inc.",
+            "liquidity_tier": "L1",
         },
         {
             "security_id": "FO_FUND_BLK_ALLOC",
@@ -290,6 +296,7 @@ def build_front_office_portfolio_bundle(
             "issuer_name": "BlackRock Global Funds",
             "ultimate_parent_issuer_id": "ULTIMATE_BLACKROCK",
             "ultimate_parent_issuer_name": "BlackRock, Inc.",
+            "liquidity_tier": "L2",
         },
         {
             "security_id": "FO_FUND_PIMCO_INC",
@@ -304,6 +311,7 @@ def build_front_office_portfolio_bundle(
             "issuer_name": "PIMCO Global Advisors (Ireland) Limited",
             "ultimate_parent_issuer_id": "ULTIMATE_PIMCO",
             "ultimate_parent_issuer_name": "Pacific Investment Management Company LLC",
+            "liquidity_tier": "L3",
         },
         {
             "security_id": "FO_BOND_UST_2030",
@@ -320,6 +328,7 @@ def build_front_office_portfolio_bundle(
             "issuer_name": "United States Treasury",
             "ultimate_parent_issuer_id": "ISSUER_UST",
             "ultimate_parent_issuer_name": "United States Treasury",
+            "liquidity_tier": "L1",
         },
         {
             "security_id": "FO_BOND_SIEMENS_2031",
@@ -336,6 +345,7 @@ def build_front_office_portfolio_bundle(
             "issuer_name": "Siemens Financieringsmaatschappij NV",
             "ultimate_parent_issuer_id": "ULTIMATE_SIEMENS",
             "ultimate_parent_issuer_name": "Siemens AG",
+            "liquidity_tier": "L2",
         },
         {
             "security_id": "FO_PRIV_PRIVATE_CREDIT_A",
@@ -350,6 +360,7 @@ def build_front_office_portfolio_bundle(
             "issuer_name": "Private Credit Opportunities Platform",
             "ultimate_parent_issuer_id": "ULTIMATE_PRIVCREDIT",
             "ultimate_parent_issuer_name": "Private Credit Opportunities Platform",
+            "liquidity_tier": "L5",
         },
     ]
 

--- a/tools/front_office_portfolio_seed.py
+++ b/tools/front_office_portfolio_seed.py
@@ -19,6 +19,7 @@ from tools.demo_data_pack import (  # noqa: E402
     _build_benchmark_reference_data,
     _request_json,
     _wait_ready,
+    build_risk_free_reference_data,
 )
 
 LOGGER = logging.getLogger("front_office_portfolio_seed")
@@ -885,6 +886,13 @@ def build_front_office_portfolio_bundle(
         }
         for assignment in benchmark_reference["benchmark_assignments"]
     ]
+    risk_free_reference = build_risk_free_reference_data(
+        start_date=start_date,
+        end_date=end_date + timedelta(days=30),
+        currency="USD",
+        source_vendor="LOTUS_FRONT_OFFICE_SEED",
+        source_prefix="front_office_risk_free",
+    )
 
     market_price_specs = {
         "FO_EQ_AAPL_US": (Decimal("184.00"), Decimal("212.00")),
@@ -979,6 +987,7 @@ def build_front_office_portfolio_bundle(
         "fx_rates": fx_rates,
         "as_of_date": as_of_date,
         **benchmark_reference,
+        **risk_free_reference,
     }
 
 
@@ -1023,6 +1032,7 @@ def _ingest_reference_data(ingestion_base_url: str, bundle: dict[str, Any]) -> N
             "/ingest/benchmark-assignments",
             {"benchmark_assignments": bundle["benchmark_assignments"]},
         ),
+        ("/ingest/risk-free-series", {"risk_free_series": bundle["risk_free_series"]}),
     )
     for endpoint, payload in reference_payloads:
         _request_json("POST", f"{ingestion_base_url}{endpoint}", payload=payload)


### PR DESCRIPTION
## Summary
- close RFC-0020 core-side allocation and data-readiness implementation
- finalize advisory allocation parity tests and demo-pack formatting/gate readiness
- keep canonical allocation calculator, liquidity tier support, and risk-free seed coverage merge-ready

## Evidence
1. `python -m pytest tests\unit\services\query_service\advisory_simulation\test_valuation.py tests\unit\services\query_service\services\test_advisory_simulation_service.py tests\unit\services\query_service\services\test_allocation_calculator.py tests\unit\services\query_service\advisory_simulation\test_allocation_contract.py tests\unit\services\query_service\repositories\test_reference_data_repository.py tests\unit\tools\test_front_office_portfolio_seed.py tests\integration\tools\test_demo_data_pack.py -q`
2. `python -m ruff check src\services\query_service\app\services\allocation_calculator.py src\services\query_service\app\advisory_simulation\valuation.py src\services\query_service\app\advisory_simulation\models.py src\services\query_service\app\advisory_simulation\allocation_contract.py src\services\query_service\app\repositories\reference_data_repository.py src\services\query_service\app\services\reporting_service.py src\services\query_service\app\services\core_snapshot_service.py src\services\query_service\app\services\position_service.py tools\demo_data_pack.py tools\front_office_portfolio_seed.py tests\unit\services\query_service\advisory_simulation\test_allocation_contract.py tests\unit\services\query_service\services\test_allocation_calculator.py tests\unit\services\query_service\services\test_advisory_simulation_service.py tests\unit\services\query_service\advisory_simulation\test_valuation.py tests\unit\services\query_service\repositories\test_reference_data_repository.py tests\unit\tools\test_front_office_portfolio_seed.py tests\integration\tools\test_demo_data_pack.py`
3. `python -m mypy src\services\query_service\app\services\allocation_calculator.py src\services\query_service\app\advisory_simulation\valuation.py src\services\query_service\app\repositories\reference_data_repository.py src\services\query_service\app\services\reporting_service.py src\services\query_service\app\services\core_snapshot_service.py src\services\query_service\app\services\position_service.py`
