### PR TITLE
ci: harden protected auto-merge governance

### DIFF
--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -2,7 +2,7 @@ name: PR Auto Merge
 
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
 
 permissions:
   contents: write
@@ -15,12 +15,28 @@ jobs:
       github.event.pull_request.state == 'open' &&
       github.event.pull_request.draft == false &&
       github.event.pull_request.base.ref == 'main' &&
-      github.event.pull_request.head.repo.fork == false
+      github.event.pull_request.head.repo.fork == false &&
+      contains(github.event.pull_request.labels.*.name, 'automerge')
     concurrency:
       group: pr-auto-merge-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
+      - name: Verify branch protection exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/branches/main/protection" > /tmp/branch-protection.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          payload = json.loads(Path("/tmp/branch-protection.json").read_text())
+          checks = payload.get("required_status_checks") or {}
+          contexts = checks.get("contexts") or []
+          if not contexts:
+              raise SystemExit("main branch must have required status checks before auto-merge can be queued")
+          print("Protected branch contexts:", ", ".join(contexts))
+          PY
       - name: Enable auto-merge queue (squash)
         env:
           GH_TOKEN: ${{ github.token }}
@@ -35,11 +51,6 @@ jobs:
             exit 0
           fi
           if echo "$output" | grep -qi "already"; then
-            echo "$output"
-            exit 0
-          fi
-          if echo "$output" | grep -qi "Auto merge is not allowed for this repository"; then
-            echo "Auto-merge is disabled at repository level; skipping queue step."
             echo "$output"
             exit 0
           fi

--- a/docs/operations/development-workflow-and-ci-strategy.md
+++ b/docs/operations/development-workflow-and-ci-strategy.md
@@ -19,7 +19,7 @@ Define a repeatable, single-developer-friendly workflow that preserves instituti
 ## PR Model (Single Developer)
 1. PR is mandatory, even without reviewer approval requirements.
 2. Treat PR checks as the quality approval layer.
-3. Enable auto-merge only after all required checks are green.
+3. Enable auto-merge only on protected branches and only for PRs explicitly labeled `automerge`.
 
 ## CI Gate Tiers
 


### PR DESCRIPTION
## Summary
- require the utomerge label before queueing PR auto-merge
- refuse to queue auto-merge unless main is protected with required checks
- update repo docs to reflect explicit opt-in auto-merge on protected branches

## External changes already applied
- tightened branch protection on main
- expanded the required check set
- enabled equired_conversation_resolution
- created the utomerge label