### PR TITLE
fix(simulation): preserve trusted snapshot parity for no-op proposals

### DIFF
--- a/src/services/query_service/app/advisory_simulation/advisory_engine.py
+++ b/src/services/query_service/app/advisory_simulation/advisory_engine.py
@@ -195,14 +195,17 @@ def run_proposal_simulation(
         cash_flow_intents + sell_intents + fx_intents + executable_buy_intents
     )
 
-    after = build_simulated_state(
-        after_portfolio,
-        market_data,
-        shelf,
-        diagnostics.data_quality,
-        diagnostics.warnings,
-        options.model_copy(update={"valuation_mode": ValuationMode.CALCULATED}),
-    )
+    if intents:
+        after = build_simulated_state(
+            after_portfolio,
+            market_data,
+            shelf,
+            diagnostics.data_quality,
+            diagnostics.warnings,
+            options.model_copy(update={"valuation_mode": ValuationMode.CALCULATED}),
+        )
+    else:
+        after = before.model_copy(deep=True)
     rule_results = RuleEngine.evaluate(after, options, diagnostics)
 
     if hard_failures:

--- a/src/services/query_service/app/advisory_simulation/valuation.py
+++ b/src/services/query_service/app/advisory_simulation/valuation.py
@@ -81,16 +81,32 @@ class ValuationService:
 
         is_trust = options.valuation_mode == ValuationMode.TRUST_SNAPSHOT
         if is_trust and position.market_value:
-            mv_instr_ccy = position.market_value.amount
-            currency = position.market_value.currency
+            trusted_value = position.market_value
+            price_currency = price_ent.currency if price_ent is not None else trusted_value.currency
+            trust_is_base_authority = (
+                trusted_value.currency == base_ccy and price_currency != base_ccy
+            )
+            if trust_is_base_authority:
+                currency = price_currency
+                mv_instr_ccy = (
+                    position.quantity * price_val if price_ent is not None else Decimal("0")
+                )
+                mv_base = trusted_value.amount
+            else:
+                mv_instr_ccy = trusted_value.amount
+                currency = trusted_value.currency
+                rate = get_fx_rate(market_data, currency, base_ccy)
+                if rate is None:
+                    mv_base = Decimal("0")
+                else:
+                    mv_base = mv_instr_ccy * rate
         else:
             mv_instr_ccy = position.quantity * price_val
-
-        rate = get_fx_rate(market_data, currency, base_ccy)
-        if rate is None:
-            mv_base = Decimal("0")
-        else:
-            mv_base = mv_instr_ccy * rate
+            rate = get_fx_rate(market_data, currency, base_ccy)
+            if rate is None:
+                mv_base = Decimal("0")
+            else:
+                mv_base = mv_instr_ccy * rate
 
         return PositionSummary(
             instrument_id=position.instrument_id,

--- a/tests/shared/advisory_simulation_parity.py
+++ b/tests/shared/advisory_simulation_parity.py
@@ -107,7 +107,7 @@ PARITY_SCENARIOS: tuple[dict[str, Any], ...] = (
             "status": "BLOCKED",
             "intents": [],
             "after_total": "10000",
-            "after_cash": [("SGD", "10000"), ("USD", "0")],
+            "after_cash": [("SGD", "10000")],
             "after_positions": [],
             "rule_results": [
                 ("CASH_BAND", "PASS", "OK"),
@@ -303,7 +303,7 @@ PARITY_SCENARIOS: tuple[dict[str, Any], ...] = (
             "status": "BLOCKED",
             "intents": [],
             "after_total": "100.0",
-            "after_cash": [("USD", "0")],
+            "after_cash": [],
             "after_positions": [("EQ_A", "10")],
             "rule_results": [
                 ("CASH_BAND", "PASS", "OK"),

--- a/tests/unit/services/query_service/advisory_simulation/test_valuation.py
+++ b/tests/unit/services/query_service/advisory_simulation/test_valuation.py
@@ -60,6 +60,32 @@ def test_value_position_uses_trust_snapshot_market_value_when_configured() -> No
     assert summary.value_in_base_ccy.amount == Decimal("333")
 
 
+def test_value_position_preserves_price_currency_when_trusted_value_is_in_base_currency() -> None:
+    market_data = market_data_snapshot(
+        prices=[price("EQ_EUR", "10", "EUR")],
+        fx_rates=[fx("EUR/USD", "1.2")],
+    )
+    portfolio = portfolio_snapshot(
+        positions=[
+            position("EQ_EUR", "10").model_copy(
+                update={"market_value": Money(amount=Decimal("120"), currency="USD")}
+            )
+        ]
+    )
+
+    summary = ValuationService.value_position(
+        portfolio.positions[0],
+        market_data,
+        "USD",
+        EngineOptions(valuation_mode=ValuationMode.TRUST_SNAPSHOT),
+        {"price_missing": [], "fx_missing": []},
+    )
+
+    assert summary.instrument_currency == "EUR"
+    assert summary.value_in_instrument_ccy.amount == Decimal("100")
+    assert summary.value_in_base_ccy.amount == Decimal("120")
+
+
 def test_value_position_uses_calculated_market_value_by_default() -> None:
     market_data = market_data_snapshot(prices=[price("EQ_1", "100", "USD")])
     portfolio = portfolio_snapshot(positions=[position("EQ_1", "2")])

--- a/tests/unit/services/query_service/services/test_advisory_simulation_service.py
+++ b/tests/unit/services/query_service/services/test_advisory_simulation_service.py
@@ -158,6 +158,59 @@ def test_advisory_simulation_exposes_allocation_lens_metadata_and_views():
 
     assert result.allocation_lens.contract_version == "advisory-simulation.v1"
     assert result.allocation_lens.source == "LOTUS_CORE"
+
+
+def test_noop_advisory_after_reuses_trusted_before_state_for_snapshot_inputs():
+    request = ProposalSimulateRequest.model_validate(
+        {
+            "portfolio_snapshot": {
+                "portfolio_id": "pf_core_trust_noop",
+                "base_currency": "USD",
+                "positions": [
+                    {
+                        "instrument_id": "EQ_EUR",
+                        "quantity": "10",
+                        "market_value": {"amount": "120", "currency": "USD"},
+                    }
+                ],
+                "cash_balances": [],
+            },
+            "market_data_snapshot": {
+                "prices": [{"instrument_id": "EQ_EUR", "price": "10", "currency": "EUR"}],
+                "fx_rates": [{"pair": "EUR/USD", "rate": "1.5"}],
+            },
+            "shelf_entries": [
+                {
+                    "instrument_id": "EQ_EUR",
+                    "status": "APPROVED",
+                    "asset_class": "EQUITY",
+                    "attributes": {
+                        "country": "Germany",
+                        "product_type": "Equity",
+                        "sector": "Technology",
+                    },
+                }
+            ],
+            "options": {
+                "enable_proposal_simulation": True,
+                "valuation_mode": "TRUST_SNAPSHOT",
+            },
+            "proposed_cash_flows": [],
+            "proposed_trades": [],
+        }
+    )
+
+    result = execute_advisory_simulation(
+        request=request,
+        request_hash="sha256:trust-noop",
+        idempotency_key=None,
+        correlation_id="corr-core-trust-noop",
+        simulation_contract_version="advisory-simulation.v1",
+    )
+
+    assert result.before.total_value.amount == Decimal("120")
+    assert result.after_simulated.total_value.amount == Decimal("120")
+    assert result.before.model_dump(mode="json") == result.after_simulated.model_dump(mode="json")
     assert tuple(result.allocation_lens.dimensions) == ADVISORY_PROPOSAL_ALLOCATION_DIMENSIONS
     assert [view.dimension for view in result.before.allocation_views] == list(
         ADVISORY_PROPOSAL_ALLOCATION_DIMENSIONS


### PR DESCRIPTION
## Summary
- preserve trusted snapshot parity for no-op proposals
- keep canonical before/after state aligned in the advisory simulation seam
- add focused regression coverage for trusted valuation parity

## Validation
- `python -m pytest tests/unit/services/query_service/advisory_simulation/test_valuation.py tests/unit/services/query_service/services/test_advisory_simulation_service.py -q`
- `python -m ruff check src/services/query_service/app/advisory_simulation/valuation.py tests/unit/services/query_service/advisory_simulation/test_valuation.py tests/unit/services/query_service/services/test_advisory_simulation_service.py`
- `python -m mypy src/services/query_service/app/advisory_simulation/valuation.py`
