### PR TITLE
Fix dual-currency E2E valuation readiness polling

### DIFF
--- a/tests/e2e/state_assertions.py
+++ b/tests/e2e/state_assertions.py
@@ -1,9 +1,28 @@
 from __future__ import annotations
 
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
+from typing import Any
 
 from .api_client import E2EApiClient
 from .assertions import as_decimal
+
+
+def _matches_decimal(value: Any, expected: Decimal) -> bool:
+    try:
+        return as_decimal(value) == expected
+    except (InvalidOperation, TypeError, ValueError):
+        return False
+
+
+def _position_matches_expected(row: dict[str, Any], expected: dict[str, Decimal]) -> bool:
+    valuation = row.get("valuation")
+    if not isinstance(valuation, dict):
+        return False
+    return (
+        _matches_decimal(row.get("quantity"), expected["quantity"])
+        and _matches_decimal(row.get("cost_basis"), expected["cost_basis"])
+        and _matches_decimal(valuation.get("market_value"), expected["market_value"])
+    )
 
 
 def assert_positions_state(
@@ -21,12 +40,7 @@ def assert_positions_state(
         if set(by_security) != set(expected_positions):
             return False
         for security_id, expected in expected_positions.items():
-            row = by_security[security_id]
-            if as_decimal(row["quantity"]) != expected["quantity"]:
-                return False
-            if as_decimal(row["cost_basis"]) != expected["cost_basis"]:
-                return False
-            if as_decimal(row["valuation"]["market_value"]) != expected["market_value"]:
+            if not _position_matches_expected(by_security[security_id], expected):
                 return False
         return True
 

--- a/tests/unit/test_e2e_state_assertions.py
+++ b/tests/unit/test_e2e_state_assertions.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any, Callable, cast
+
+from tests.e2e.api_client import E2EApiClient
+from tests.e2e.state_assertions import assert_positions_state
+
+
+class StubE2EApiClient:
+    def __init__(self, *, pending_payload: dict[str, Any], ready_payload: dict[str, Any]) -> None:
+        self.pending_payload = pending_payload
+        self.ready_payload = ready_payload
+        self.requested_endpoint: str | None = None
+
+    def poll_for_data(
+        self,
+        endpoint: str,
+        validation_func: Callable[[Any], bool],
+        timeout: int = 60,
+        interval: int = 2,
+        fail_message: str = "Polling timed out",
+    ) -> dict[str, Any]:
+        self.requested_endpoint = endpoint
+        assert timeout == 180
+        assert fail_message
+        assert not validation_func(self.pending_payload)
+        assert validation_func(self.ready_payload)
+        return self.ready_payload
+
+
+def test_assert_positions_state_treats_incomplete_valuations_as_pending() -> None:
+    pending_payload = {
+        "positions": [
+            {
+                "security_id": "SEC_DAIMLER",
+                "quantity": "60",
+                "cost_basis": "9900",
+                "valuation": {"market_value": None},
+            }
+        ]
+    }
+    ready_payload = {
+        "positions": [
+            {
+                "security_id": "SEC_DAIMLER",
+                "quantity": "60",
+                "cost_basis": "9900",
+                "valuation": {"market_value": "12960"},
+            }
+        ]
+    }
+    client = StubE2EApiClient(pending_payload=pending_payload, ready_payload=ready_payload)
+
+    assert_positions_state(
+        cast(E2EApiClient, client),
+        portfolio_id="E2E_DUAL_CURRENCY",
+        as_of_date="2025-08-15",
+        expected_positions={
+            "SEC_DAIMLER": {
+                "quantity": Decimal("60"),
+                "cost_basis": Decimal("9900"),
+                "market_value": Decimal("12960"),
+            }
+        },
+    )
+
+    assert (
+        client.requested_endpoint == "/portfolios/E2E_DUAL_CURRENCY/positions?as_of_date=2025-08-15"
+    )


### PR DESCRIPTION
## Summary
- Treat incomplete position valuation fields as pending during E2E polling instead of raising Decimal conversion errors.
- Keep final position assertions strict once the payload is returned as converged.
- Add a targeted unit regression covering pending `market_value: null` followed by a ready payload.

## Validation
- `python -m ruff check tests\e2e\state_assertions.py tests\unit\test_e2e_state_assertions.py`
- `python -m ruff format --check tests\e2e\state_assertions.py tests\unit\test_e2e_state_assertions.py`
- `python -m pytest tests\unit\test_e2e_state_assertions.py -q`
- `python -m pytest tests\e2e\test_dual_currency_workflow.py --collect-only -q`

Full E2E/Main Releasability validation intentionally delegated to GitHub Actions to avoid long local runs.