### PR TITLE
docs: link RFC-0074 onboarding context

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -4,9 +4,9 @@ This file provides repository-local engineering context for `lotus-core`.
 
 For platform-wide truth, read:
 
-1. `C:\Users\Sandeep\projects\lotus-platform\context\LOTUS-QUICKSTART-CONTEXT.md`
-2. `C:\Users\Sandeep\projects\lotus-platform\context\LOTUS-ENGINEERING-CONTEXT.md`
-3. `C:\Users\Sandeep\projects\lotus-platform\context\CONTEXT-REFERENCE-MAP.md`
+1. `../lotus-platform/context/LOTUS-QUICKSTART-CONTEXT.md`
+2. `../lotus-platform/context/LOTUS-ENGINEERING-CONTEXT.md`
+3. `../lotus-platform/context/CONTEXT-REFERENCE-MAP.md`
 
 ## Repository Role
 
@@ -105,12 +105,12 @@ Important validation expectations:
 
 Most relevant current governance:
 
-1. `C:\Users\Sandeep\projects\lotus-platform\rfcs\RFC-0041-platform-integration-architecture-bible-governance.md`
-2. `C:\Users\Sandeep\projects\lotus-platform\rfcs\RFC-0067-centralized-api-vocabulary-inventory-and-openapi-documentation-governance.md`
-3. `C:\Users\Sandeep\projects\lotus-platform\rfcs\RFC-0068-centralized-shared-infrastructure-ownership-and-migration.md`
-4. `C:\Users\Sandeep\projects\lotus-platform\rfcs\RFC-0071-centralized-environment-scoped-service-addressing-and-ingress-governance.md`
-5. `C:\Users\Sandeep\projects\lotus-platform\rfcs\RFC-0072-platform-wide-multi-lane-ci-validation-and-release-governance.md`
-6. `C:\Users\Sandeep\projects\lotus-platform\rfcs\RFC-0073-lotus-ecosystem-engineering-context-and-agent-guidance-system.md`
+1. `../lotus-platform/rfcs/RFC-0041-platform-integration-architecture-bible-governance.md`
+2. `../lotus-platform/rfcs/RFC-0067-centralized-api-vocabulary-inventory-and-openapi-documentation-governance.md`
+3. `../lotus-platform/rfcs/RFC-0068-centralized-shared-infrastructure-ownership-and-migration.md`
+4. `../lotus-platform/rfcs/RFC-0071-centralized-environment-scoped-service-addressing-and-ingress-governance.md`
+5. `../lotus-platform/rfcs/RFC-0072-platform-wide-multi-lane-ci-validation-and-release-governance.md`
+6. `../lotus-platform/rfcs/RFC-0073-lotus-ecosystem-engineering-context-and-agent-guidance-system.md`
 7. `docs/architecture/lotus-core-target-architecture.md`
 8. `docs/standards/layering-boundaries.md`
 
@@ -133,7 +133,9 @@ Update this document when:
 
 ## Cross-Links
 
-1. `C:\Users\Sandeep\projects\lotus-platform\context\LOTUS-QUICKSTART-CONTEXT.md`
-2. `C:\Users\Sandeep\projects\lotus-platform\context\LOTUS-ENGINEERING-CONTEXT.md`
-3. `C:\Users\Sandeep\projects\lotus-platform\context\CONTEXT-REFERENCE-MAP.md`
-4. `C:\Users\Sandeep\projects\lotus-platform\context\Repository-Engineering-Context-Contract.md`
+1. `../lotus-platform/context/LOTUS-QUICKSTART-CONTEXT.md`
+2. `../lotus-platform/context/LOTUS-ENGINEERING-CONTEXT.md`
+3. `../lotus-platform/context/CONTEXT-REFERENCE-MAP.md`
+4. `../lotus-platform/context/Repository-Engineering-Context-Contract.md`
+5. [Lotus Developer Onboarding](../lotus-platform/docs/onboarding/LOTUS-DEVELOPER-ONBOARDING.md)
+6. [Lotus Agent Ramp-Up](../lotus-platform/docs/onboarding/LOTUS-AGENT-RAMP-UP.md)


### PR DESCRIPTION
## Summary
- Link repository-local engineering context to the central RFC-0074 developer onboarding and agent ramp-up guides.
- Replace machine-specific lotus-platform references with sibling-relative platform links.

## Validation
- Local cross-repo audit confirmed onboarding/ramp-up links exist and central onboarding content is not duplicated.
- `git diff --check` passed for all touched repository context documents.