### PR TITLE
[codex] RFC-0075 canonical front-office seed readiness

### DIFF
--- a/docs/operations/Front-Office-Portfolio-Seed-Runbook.md
+++ b/docs/operations/Front-Office-Portfolio-Seed-Runbook.md
@@ -48,7 +48,7 @@ Run from the `lotus-core` repo root:
 python tools/front_office_portfolio_seed.py `
   --portfolio-id PB_SG_GLOBAL_BAL_001 `
   --start-date 2025-03-31 `
-  --end-date 2026-03-28 `
+  --end-date 2026-04-10 `
   --benchmark-start-date 2025-01-06 `
   --wait-seconds 300
 ```
@@ -71,40 +71,27 @@ verifies:
 
 ## Validation Evidence
 
-The current seeded scenario was validated directly against the local stack with
-these outcomes:
+The current seeded scenario was validated directly against the local stack after
+the RFC-0075 Slice 3 as-of-date alignment with these outcomes:
 
 - `lotus-core query_service`
-  - positions: `11`
-  - transactions: `30`, including future transaction
+  - positions: `10`
+  - valued positions: `10`
+  - transactions: `29`, including future transaction
     `TXN-WITHDRAWAL-FUTURE-001`
-  - cashflow projection: `31` points with one non-zero point on `2026-04-07`
+  - cash accounts: `2`
+  - cashflow projection: `31` points with one non-zero point on `2026-04-17`
     for `-18000`
   - allocation views: `asset_class`, `sector`, `region`, `currency`
-  - income summary:
-    - gross `2130.75 USD`
-    - net `2037.00 USD`
-  - activity summary:
-    - inflows `40000 USD`
-    - outflows `25000 USD`
-    - fees `275 USD`
-    - taxes `81.75 USD`
+  - market price coverage through `2026-04-10`
+  - EUR/USD FX, benchmark return, and USD risk-free coverage through `2026-05-10`
+  - no `PORT_SMOKE_%` portfolio rows remained after the clean seed
 - `lotus-core query_control_plane`
   - benchmark assignment resolves to `BMK_PB_GLOBAL_BALANCED_60_40`
-  - analytics reference resolves:
-    - `resolved_as_of_date = 2026-03-29`
-    - `performance_end_date = 2026-03-29`
-- `lotus-performance`
-  - `POST /performance/workspace-summary` succeeds for
-    `report_end_date = 2026-03-29`
-  - YTD net portfolio return is populated
-  - benchmark return is populated
-  - contribution and attribution blocks are returned through the workspace
-    contract
 - `lotus-gateway`
-  - performance summary, details, horizon comparison, and attribution trend all
-    resolve for `PB_SG_GLOBAL_BAL_001`
-  - projected cashflow resolves with a non-zero total net flow of `-18000`
+  - performance and risk summary endpoints return `200`
+  - derived performance window freshness remains a separate RFC-0075 Slice 4
+    readiness item and must not be treated as complete seed evidence
 
 ## Related Documents
 

--- a/docs/operations/Front-Office-Portfolio-Seed-Runbook.md
+++ b/docs/operations/Front-Office-Portfolio-Seed-Runbook.md
@@ -68,15 +68,18 @@ verifies:
 - projected cashflow contains at least one non-zero future point
 - benchmark assignment resolves
 - gateway performance summary resolves with benchmark-linked content
+- core analytics reference `performance_end_date` is at or after the seed end date
+- gateway performance `report_end_date` and return-path latest available date are
+  at or after the seed end date
 
 ## Validation Evidence
 
 The current seeded scenario was validated directly against the local stack after
-the RFC-0075 Slice 3 as-of-date alignment with these outcomes:
+the RFC-0075 Slice 4 derived-state readiness fix with these outcomes:
 
 - `lotus-core query_service`
-  - positions: `10`
-  - valued positions: `10`
+  - positions: `11`
+  - valued positions: `11`
   - transactions: `29`, including future transaction
     `TXN-WITHDRAWAL-FUTURE-001`
   - cash accounts: `2`
@@ -88,10 +91,21 @@ the RFC-0075 Slice 3 as-of-date alignment with these outcomes:
   - no `PORT_SMOKE_%` portfolio rows remained after the clean seed
 - `lotus-core query_control_plane`
   - benchmark assignment resolves to `BMK_PB_GLOBAL_BALANCED_60_40`
+  - analytics reference `performance_end_date` resolves to `2026-04-10`
+- `lotus-core portfolio_aggregation_service`
+  - portfolio aggregation backlog for `PB_SG_GLOBAL_BAL_001`: `0` pending,
+    `0` processing, `382` complete
+  - portfolio timeseries max date: `2026-04-17`
 - `lotus-gateway`
   - performance and risk summary endpoints return `200`
-  - derived performance window freshness remains a separate RFC-0075 Slice 4
-    readiness item and must not be treated as complete seed evidence
+  - performance summary `report_end_date`: `2026-04-11`
+  - return-path `latest_available_date`: `2026-04-11`
+
+If the seed verifier times out after positions and position timeseries are
+available, check `portfolio_aggregation_jobs` for a pending backlog and
+`portfolio_timeseries` for a stale max date. The canonical readiness path
+requires portfolio aggregation to catch up before workbench validation or demo
+screenshots are accepted.
 
 ## Related Documents
 

--- a/scripts/config_access_guard.py
+++ b/scripts/config_access_guard.py
@@ -14,6 +14,7 @@ ALLOWED_OS_GETENV_PATHS = {
     Path("src/services/valuation_orchestrator_service/app/settings.py"),
     Path("src/services/ingestion_service/app/settings.py"),
     Path("src/services/portfolio_aggregation_service/app/settings.py"),
+    Path("src/services/query_control_plane_service/app/settings.py"),
     Path("src/services/query_service/app/settings.py"),
 }
 

--- a/scripts/docker_endpoint_smoke.py
+++ b/scripts/docker_endpoint_smoke.py
@@ -38,6 +38,16 @@ class CheckResult:
     response: Any
 
 
+SMOKE_PORTFOLIO_ID = "PORT_SMOKE_CANONICAL"
+SMOKE_SECURITY_ID = "SEC_SMOKE_CANONICAL"
+SMOKE_INSTRUMENT_ID = "INST_SMOKE_CANONICAL"
+SMOKE_TRANSACTION_ID = "TX_SMOKE_CANONICAL"
+SMOKE_TRANSACTION_ID_2 = "TX2_SMOKE_CANONICAL"
+SMOKE_CSV_TRANSACTION_ID = "TXUP_SMOKE_CANONICAL"
+SMOKE_ISIN = "US000SMOKE01"
+DEFAULT_POSTGRES_SERVICE = "postgres"
+
+
 def _run(cmd: list[str], cwd: Path) -> None:
     completed = subprocess.run(
         cmd,
@@ -57,6 +67,26 @@ def _run(cmd: list[str], cwd: Path) -> None:
         raise RuntimeError("command failed")
 
 
+def _run_capture(cmd: list[str], cwd: Path) -> str:
+    completed = subprocess.run(
+        cmd,
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if completed.returncode != 0:
+        print(f"Command failed ({completed.returncode}): {' '.join(cmd)}", file=sys.stderr)
+        if completed.stdout:
+            print(completed.stdout, file=sys.stderr)
+        if completed.stderr:
+            print(completed.stderr, file=sys.stderr)
+        raise RuntimeError("command failed")
+    return completed.stdout.strip()
+
+
 def _compose_up_with_retry(*, compose_file: str, repo_root: Path, build: bool) -> None:
     up_cmd = ["docker", "compose", "-f", compose_file, "up", "-d"]
     if build:
@@ -74,6 +104,82 @@ def _compose_up_with_retry(*, compose_file: str, repo_root: Path, build: bool) -
             # Handle transient Kafka/ZK startup races by recycling containers once.
             _run(["docker", "compose", "-f", compose_file, "down"], cwd=repo_root)
             time.sleep(5)
+
+
+def build_smoke_cleanup_sql() -> str:
+    return "\n".join(
+        [
+            "delete from financial_reconciliation_findings where portfolio_id like 'PORT_SMOKE_%';",
+            "delete from financial_reconciliation_runs where portfolio_id like 'PORT_SMOKE_%';",
+            "delete from simulation_changes where portfolio_id like 'PORT_SMOKE_%';",
+            "delete from simulation_sessions where portfolio_id like 'PORT_SMOKE_%';",
+            "delete from analytics_export_jobs where portfolio_id like 'PORT_SMOKE_%';",
+            "delete from portfolio_aggregation_jobs where portfolio_id like 'PORT_SMOKE_%';",
+            "delete from portfolio_valuation_jobs where portfolio_id like 'PORT_SMOKE_%';",
+            "delete from daily_position_snapshots where portfolio_id like 'PORT_SMOKE_%';",
+            "delete from portfolio_timeseries where portfolio_id like 'PORT_SMOKE_%';",
+            "delete from position_timeseries where portfolio_id like 'PORT_SMOKE_%';",
+            "delete from position_history where portfolio_id like 'PORT_SMOKE_%';",
+            "delete from position_state where portfolio_id like 'PORT_SMOKE_%';",
+            "delete from position_lot_state where portfolio_id like 'PORT_SMOKE_%';",
+            "delete from accrued_income_offset_state where portfolio_id like 'PORT_SMOKE_%';",
+            "delete from cashflows where portfolio_id like 'PORT_SMOKE_%';",
+            "delete from transaction_costs where transaction_id like 'TX%_SMOKE_%';",
+            "delete from pipeline_stage_state where portfolio_id like 'PORT_SMOKE_%' or security_id like 'SEC_SMOKE_%' or transaction_id like 'TX%_SMOKE_%';",
+            "delete from processed_events where portfolio_id like 'PORT_SMOKE_%';",
+            "delete from cash_account_masters where portfolio_id like 'PORT_SMOKE_%';",
+            "delete from portfolio_benchmark_assignments where portfolio_id like 'PORT_SMOKE_%';",
+            "delete from transactions where portfolio_id like 'PORT_SMOKE_%';",
+            "delete from market_prices where security_id like 'SEC_SMOKE_%';",
+            "delete from instruments where portfolio_id like 'PORT_SMOKE_%' or security_id like 'SEC_SMOKE_%';",
+            "delete from portfolios where portfolio_id like 'PORT_SMOKE_%';",
+        ]
+    )
+
+
+def _resolve_postgres_container(
+    *,
+    repo_root: Path,
+    compose_file: str,
+    postgres_service: str,
+) -> str:
+    container_id = _run_capture(
+        ["docker", "compose", "-f", compose_file, "ps", "-q", postgres_service],
+        cwd=repo_root,
+    )
+    if not container_id:
+        raise RuntimeError(
+            f"Unable to resolve docker compose service '{postgres_service}' for smoke cleanup."
+        )
+    return container_id
+
+
+def _cleanup_existing_smoke_state(
+    *,
+    repo_root: Path,
+    compose_file: str,
+    postgres_service: str,
+) -> None:
+    postgres_container = _resolve_postgres_container(
+        repo_root=repo_root,
+        compose_file=compose_file,
+        postgres_service=postgres_service,
+    )
+    _run(
+        [
+            "docker",
+            "exec",
+            postgres_container,
+            "psql",
+            "-U",
+            "user",
+            "-d",
+            "portfolio_db",
+            "-c",
+            build_smoke_cleanup_sql(),
+        ],
+        cwd=repo_root,
+    )
 
 
 def _call(
@@ -255,6 +361,11 @@ def main() -> int:
     )
     parser.add_argument("--ready-timeout-seconds", type=int, default=180)
     parser.add_argument("--query-visible-timeout-seconds", type=int, default=120)
+    parser.add_argument(
+        "--postgres-service",
+        default=DEFAULT_POSTGRES_SERVICE,
+        help="Docker compose postgres service name used for deterministic smoke cleanup.",
+    )
     args = parser.parse_args()
 
     repo_root = Path(args.repo_root).resolve()
@@ -264,6 +375,11 @@ def main() -> int:
         if args.reset_volumes:
             _run(["docker", "compose", "-f", compose_file, "down", "-v"], cwd=repo_root)
         _compose_up_with_retry(compose_file=compose_file, repo_root=repo_root, build=args.build)
+    _cleanup_existing_smoke_state(
+        repo_root=repo_root,
+        compose_file=compose_file,
+        postgres_service=args.postgres_service,
+    )
 
     _wait_ready(args.ingestion_base_url, args.ready_timeout_seconds)
     _wait_ready(args.event_replay_base_url, args.ready_timeout_seconds)
@@ -271,13 +387,13 @@ def main() -> int:
     _wait_ready(args.query_control_plane_base_url, args.ready_timeout_seconds)
 
     run_id = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
-    portfolio_id = f"PORT_SMOKE_{run_id}"
-    security_id = f"SEC_SMOKE_{run_id}"
-    instrument_id = f"INST_SMOKE_{run_id}"
-    transaction_id = f"TX_SMOKE_{run_id}"
-    transaction_id_2 = f"TX2_SMOKE_{run_id}"
-    csv_transaction_id = f"TXUP_SMOKE_{run_id}"
-    isin = f"US{run_id.replace('-', '')[-10:]}"
+    portfolio_id = SMOKE_PORTFOLIO_ID
+    security_id = SMOKE_SECURITY_ID
+    instrument_id = SMOKE_INSTRUMENT_ID
+    transaction_id = SMOKE_TRANSACTION_ID
+    transaction_id_2 = SMOKE_TRANSACTION_ID_2
+    csv_transaction_id = SMOKE_CSV_TRANSACTION_ID
+    isin = SMOKE_ISIN
     now_utc = datetime.now(UTC).replace(microsecond=0)
     trade_timestamp = now_utc.isoformat().replace("+00:00", "Z")
     trade_date = trade_timestamp[:10]

--- a/src/libs/portfolio-common/portfolio_common/timeseries_repository_base.py
+++ b/src/libs/portfolio-common/portfolio_common/timeseries_repository_base.py
@@ -5,7 +5,6 @@ from typing import List, Optional
 from sqlalchemy import and_, exists, func, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import aliased
 
 from .database_models import (
     Cashflow,
@@ -109,33 +108,8 @@ class TimeseriesRepositoryBase:
     @async_timed(repository="TimeseriesRepository", method="find_and_claim_eligible_jobs")
     async def find_and_claim_eligible_jobs(self, batch_size: int) -> List[PortfolioAggregationJob]:
         p1 = PortfolioAggregationJob
-        p2 = aliased(PortfolioAggregationJob)
-        pts = PortfolioTimeseries
-        p1_pts = aliased(PortfolioTimeseries)
         dps = DailyPositionSnapshot
         position_ts = PositionTimeseries
-
-        prior_day_exists_subq = exists(
-            select(1).where(
-                pts.portfolio_id == p1.portfolio_id,
-                pts.date == p1.aggregation_date - timedelta(days=1),
-            )
-        ).correlate(p1)
-
-        no_prior_portfolio_history_subq = ~exists(
-            select(1).where(
-                p1_pts.portfolio_id == p1.portfolio_id,
-                p1_pts.date < p1.aggregation_date,
-            )
-        ).correlate(p1)
-        no_earlier_pending_job_subq = ~exists(
-            select(1).where(
-                p2.portfolio_id == p1.portfolio_id,
-                p2.status == "PENDING",
-                p2.aggregation_date < p1.aggregation_date,
-            )
-        ).correlate(p1)
-        is_first_job_subq = no_prior_portfolio_history_subq & no_earlier_pending_job_subq
 
         latest_snapshot_epochs = (
             select(
@@ -179,7 +153,6 @@ class TimeseriesRepositoryBase:
             select(p1.id)
             .where(
                 p1.status == "PENDING",
-                (prior_day_exists_subq | is_first_job_subq),
                 completeness_ready_subq,
             )
             .order_by(p1.portfolio_id, p1.aggregation_date)

--- a/src/services/query_control_plane_service/app/enterprise_readiness.py
+++ b/src/services/query_control_plane_service/app/enterprise_readiness.py
@@ -7,11 +7,7 @@ from fastapi import Request, Response
 from fastapi.responses import JSONResponse
 from portfolio_common.logging_utils import correlation_id_var, normalize_lineage_value
 
-from src.services.query_service.app.settings import (
-    env_bool,
-    env_int,
-    load_query_service_settings,
-)
+from .settings import env_bool, env_int, load_query_control_plane_settings
 
 logger = logging.getLogger("enterprise_readiness")
 MiddlewareNext = Callable[[Request], Awaitable[Response]]
@@ -40,19 +36,14 @@ def _env_enabled(name: str, default: str = "true") -> bool:
 
 
 def _load_json_map(name: str) -> dict[str, Any]:
-    settings = load_query_service_settings()
+    settings = load_query_control_plane_settings()
     if name == "ENTERPRISE_FEATURE_FLAGS_JSON":
         parsed = settings.enterprise_feature_flags
         return parsed if isinstance(parsed, dict) else {}
     if name == "ENTERPRISE_CAPABILITY_RULES_JSON":
         parsed = settings.enterprise_capability_rules
         return parsed if isinstance(parsed, dict) else {}
-    raw = "{}"
-    try:
-        parsed = json.loads(raw)
-    except json.JSONDecodeError:
-        return {}
-    return parsed if isinstance(parsed, dict) else {}
+    return {}
 
 
 def _env_int(name: str, default: int) -> int:
@@ -60,7 +51,7 @@ def _env_int(name: str, default: int) -> int:
 
 
 def enterprise_policy_version() -> str:
-    return load_query_service_settings().enterprise_policy_version
+    return load_query_control_plane_settings().enterprise_policy_version
 
 
 def validate_enterprise_runtime_config() -> list[str]:
@@ -74,7 +65,7 @@ def validate_enterprise_runtime_config() -> list[str]:
 
     if (
         _env_enabled("ENTERPRISE_ENFORCE_AUTHZ", "false")
-        and not load_query_service_settings().enterprise_primary_key_id.strip()
+        and not load_query_control_plane_settings().enterprise_primary_key_id.strip()
     ):
         issues.append("missing_primary_key_id")
 

--- a/src/services/query_control_plane_service/app/settings.py
+++ b/src/services/query_control_plane_service/app/settings.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Any
+
+
+def env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def env_str(name: str, default: str) -> str:
+    raw = os.getenv(name)
+    return default if raw is None else raw
+
+
+def env_json_map(name: str) -> dict[str, Any]:
+    raw = env_str(name, "{}")
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return decoded if isinstance(decoded, dict) else {}
+
+
+@dataclass(frozen=True, slots=True)
+class QueryControlPlaneSettings:
+    enterprise_policy_version: str
+    enterprise_enforce_authz: bool
+    enterprise_enforce_runtime_config: bool
+    enterprise_primary_key_id: str
+    enterprise_secret_rotation_days: int
+    enterprise_max_write_payload_bytes: int
+    enterprise_feature_flags: dict[str, Any]
+    enterprise_capability_rules: dict[str, Any]
+
+
+def load_query_control_plane_settings() -> QueryControlPlaneSettings:
+    return QueryControlPlaneSettings(
+        enterprise_policy_version=env_str("ENTERPRISE_POLICY_VERSION", "1.0.0"),
+        enterprise_enforce_authz=env_bool("ENTERPRISE_ENFORCE_AUTHZ", False),
+        enterprise_enforce_runtime_config=env_bool("ENTERPRISE_ENFORCE_RUNTIME_CONFIG", False),
+        enterprise_primary_key_id=env_str("ENTERPRISE_PRIMARY_KEY_ID", ""),
+        enterprise_secret_rotation_days=env_int("ENTERPRISE_SECRET_ROTATION_DAYS", 90),
+        enterprise_max_write_payload_bytes=env_int("ENTERPRISE_MAX_WRITE_PAYLOAD_BYTES", 1_048_576),
+        enterprise_feature_flags=env_json_map("ENTERPRISE_FEATURE_FLAGS_JSON"),
+        enterprise_capability_rules=env_json_map("ENTERPRISE_CAPABILITY_RULES_JSON"),
+    )

--- a/tests/integration/services/timeseries_generator_service/test_timeseries_repository_integration.py
+++ b/tests/integration/services/timeseries_generator_service/test_timeseries_repository_integration.py
@@ -135,8 +135,9 @@ def setup_sequential_jobs_with_snapshot_completeness(db_engine, clean_db):
                 _position_ts(portfolio_id, "SEC_A", day1),
             ]
         )
-        # Day2 inputs: provide a complete latest-per-security input set so the
-        # prior-day gate is the only remaining blocker once day1 completes.
+        # Day2 inputs: complete latest-per-security input set. Portfolio aggregation
+        # no longer depends on a previous portfolio row, so complete days can be
+        # claimed in the same batch and processed in parallel by Kafka consumers.
         session.add_all(
             [
                 _snapshot(portfolio_id, "SEC_A", day2),
@@ -160,10 +161,12 @@ async def test_find_and_claim_eligible_jobs_enforces_snapshot_completeness_gate(
     day1 = setup_sequential_jobs_with_snapshot_completeness["day1"]
     day2 = setup_sequential_jobs_with_snapshot_completeness["day2"]
 
-    # Day1 should not claim while input set is incomplete (2 expected snapshots vs 1 position-timeseries).  # noqa: E501
+    # Day1 should not claim while input set is incomplete, but complete later
+    # dates are independently eligible because portfolio aggregation does not
+    # carry prior portfolio rows forward.
     claimed_jobs_1 = await repo.find_and_claim_eligible_jobs(batch_size=5)
     await async_db_session.commit()
-    assert claimed_jobs_1 == []
+    assert [job.aggregation_date for job in claimed_jobs_1] == [day2]
 
     # Complete day1 input set.
     with Session(db_engine) as session:
@@ -173,36 +176,7 @@ async def test_find_and_claim_eligible_jobs_enforces_snapshot_completeness_gate(
 
     claimed_jobs_2 = await repo.find_and_claim_eligible_jobs(batch_size=5)
     await async_db_session.commit()
-    assert len(claimed_jobs_2) == 1
-    assert claimed_jobs_2[0].aggregation_date == day1
-
-    # Simulate day1 aggregation completion; day2 should now claim (prior-day + completeness satisfied).  # noqa: E501
-    with Session(db_engine) as session:
-        session.add(
-            PortfolioTimeseries(
-                portfolio_id=portfolio_id,
-                date=day1,
-                epoch=0,
-                bod_market_value=Decimal("0"),
-                bod_cashflow=Decimal("0"),
-                eod_cashflow=Decimal("0"),
-                eod_market_value=Decimal("0"),
-                fees=Decimal("0"),
-            )
-        )
-        job = (
-            session.query(PortfolioAggregationJob)
-            .filter_by(portfolio_id=portfolio_id, aggregation_date=day1)
-            .one()
-        )
-        job.status = "COMPLETE"
-        session.commit()
-    await async_db_session.rollback()
-
-    claimed_jobs_3 = await repo.find_and_claim_eligible_jobs(batch_size=5)
-    await async_db_session.commit()
-    assert len(claimed_jobs_3) == 1
-    assert claimed_jobs_3[0].aggregation_date == day2
+    assert [job.aggregation_date for job in claimed_jobs_2] == [day1]
 
 
 async def test_find_and_claim_eligible_jobs_claims_first_day_without_portfolio_history(
@@ -352,7 +326,7 @@ async def test_find_and_claim_eligible_jobs_accepts_mixed_latest_epochs_per_secu
     assert claimed_jobs[0].aggregation_date == a_date
 
 
-async def test_find_and_claim_eligible_jobs_bootstraps_earliest_pending_day_before_existing_history(
+async def test_find_and_claim_eligible_jobs_claims_all_complete_days_without_history_dependency(
     db_engine, clean_db, async_db_session: AsyncSession
 ):
     portfolio_id = "STRANDED_BOOTSTRAP_PORT"
@@ -429,11 +403,10 @@ async def test_find_and_claim_eligible_jobs_bootstraps_earliest_pending_day_befo
     claimed_jobs = await repo.find_and_claim_eligible_jobs(batch_size=5)
     await async_db_session.commit()
 
-    assert len(claimed_jobs) == 1
-    assert claimed_jobs[0].aggregation_date == early_day
+    assert [job.aggregation_date for job in claimed_jobs] == [early_day, later_day]
 
 
-async def test_find_and_claim_eligible_jobs_uses_prior_day_portfolio_row_even_when_current_epoch_has_advanced(  # noqa: E501
+async def test_find_and_claim_eligible_jobs_does_not_need_prior_day_when_current_epoch_has_advanced(
     db_engine, clean_db, async_db_session: AsyncSession
 ):
     portfolio_id = "PRIOR_DAY_MIXED_EPOCH"

--- a/tests/unit/scripts/test_docker_endpoint_smoke.py
+++ b/tests/unit/scripts/test_docker_endpoint_smoke.py
@@ -1,0 +1,29 @@
+from scripts.docker_endpoint_smoke import (
+    SMOKE_CSV_TRANSACTION_ID,
+    SMOKE_INSTRUMENT_ID,
+    SMOKE_ISIN,
+    SMOKE_PORTFOLIO_ID,
+    SMOKE_SECURITY_ID,
+    SMOKE_TRANSACTION_ID,
+    SMOKE_TRANSACTION_ID_2,
+    build_smoke_cleanup_sql,
+)
+
+
+def test_docker_endpoint_smoke_uses_deterministic_identifiers():
+    assert SMOKE_PORTFOLIO_ID == "PORT_SMOKE_CANONICAL"
+    assert SMOKE_SECURITY_ID == "SEC_SMOKE_CANONICAL"
+    assert SMOKE_INSTRUMENT_ID == "INST_SMOKE_CANONICAL"
+    assert SMOKE_TRANSACTION_ID == "TX_SMOKE_CANONICAL"
+    assert SMOKE_TRANSACTION_ID_2 == "TX2_SMOKE_CANONICAL"
+    assert SMOKE_CSV_TRANSACTION_ID == "TXUP_SMOKE_CANONICAL"
+    assert SMOKE_ISIN == "US000SMOKE01"
+
+
+def test_docker_endpoint_smoke_cleanup_sql_purges_legacy_smoke_rows():
+    sql = build_smoke_cleanup_sql()
+
+    assert "delete from transactions where portfolio_id like 'PORT_SMOKE_%';" in sql
+    assert "delete from portfolios where portfolio_id like 'PORT_SMOKE_%';" in sql
+    assert "delete from market_prices where security_id like 'SEC_SMOKE_%';" in sql
+    assert "delete from transaction_costs where transaction_id like 'TX%_SMOKE_%';" in sql

--- a/tests/unit/scripts/test_source_contract_guards.py
+++ b/tests/unit/scripts/test_source_contract_guards.py
@@ -11,6 +11,13 @@ def test_config_access_guard_ignores_generated_build_artifacts() -> None:
     assert config_access_guard._is_generated_artifact(source_path) is False
 
 
+def test_config_access_guard_allows_typed_service_settings_modules() -> None:
+    assert (
+        Path("src/services/query_control_plane_service/app/settings.py")
+        in config_access_guard.ALLOWED_OS_GETENV_PATHS
+    )
+
+
 def test_no_alias_contract_guard_ignores_generated_build_artifacts() -> None:
     generated_path = Path("src/services/query_service/build/lib/app/contracts.py")
     source_path = Path("src/services/query_service/app/contracts.py")

--- a/tests/unit/services/portfolio_aggregation_service/repositories/test_timeseries_repository.py
+++ b/tests/unit/services/portfolio_aggregation_service/repositories/test_timeseries_repository.py
@@ -28,7 +28,7 @@ def repository(mock_db_session: AsyncMock) -> TimeseriesRepository:
     return TimeseriesRepository(mock_db_session)
 
 
-async def test_find_and_claim_eligible_jobs_prior_day_gate_does_not_require_current_epoch_match(
+async def test_find_and_claim_eligible_jobs_does_not_require_prior_portfolio_day(
     repository: TimeseriesRepository, mock_db_session: AsyncMock
 ):
     await repository.find_and_claim_eligible_jobs(batch_size=5)
@@ -39,27 +39,10 @@ async def test_find_and_claim_eligible_jobs_prior_day_gate_does_not_require_curr
     )
 
     assert (
-        "portfolio_timeseries.date = portfolio_aggregation_jobs.aggregation_date -"
-        in compiled_query
+        "portfolio_timeseries.date = portfolio_aggregation_jobs.aggregation_date"
+        not in compiled_query
     )
-    assert "portfolio_timeseries.epoch =" not in compiled_query
-
-
-async def test_find_and_claim_eligible_jobs_first_day_gate_is_directly_correlated(
-    repository: TimeseriesRepository, mock_db_session: AsyncMock
-):
-    await repository.find_and_claim_eligible_jobs(batch_size=5)
-
-    executed_stmt = mock_db_session.execute.call_args_list[0][0][0]
-    compiled_query = str(
-        executed_stmt.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True})
-    )
-
-    assert (
-        "portfolio_aggregation_jobs_1.portfolio_id = portfolio_aggregation_jobs.portfolio_id"
-        in compiled_query
-    )
-    assert "date < portfolio_aggregation_jobs.aggregation_date" in compiled_query
+    assert "date < portfolio_aggregation_jobs.aggregation_date" not in compiled_query
     assert "FROM portfolio_timeseries, portfolio_aggregation_jobs" not in compiled_query
 
 

--- a/tests/unit/services/query_control_plane_service/test_control_plane_settings.py
+++ b/tests/unit/services/query_control_plane_service/test_control_plane_settings.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from src.services.query_control_plane_service.app.settings import (
+    env_bool,
+    env_int,
+    env_json_map,
+    load_query_control_plane_settings,
+)
+
+
+def test_control_plane_settings_parse_defaults(monkeypatch) -> None:
+    for name in (
+        "ENTERPRISE_POLICY_VERSION",
+        "ENTERPRISE_ENFORCE_AUTHZ",
+        "ENTERPRISE_ENFORCE_RUNTIME_CONFIG",
+        "ENTERPRISE_PRIMARY_KEY_ID",
+        "ENTERPRISE_SECRET_ROTATION_DAYS",
+        "ENTERPRISE_MAX_WRITE_PAYLOAD_BYTES",
+        "ENTERPRISE_FEATURE_FLAGS_JSON",
+        "ENTERPRISE_CAPABILITY_RULES_JSON",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    settings = load_query_control_plane_settings()
+
+    assert settings.enterprise_policy_version == "1.0.0"
+    assert settings.enterprise_enforce_authz is False
+    assert settings.enterprise_enforce_runtime_config is False
+    assert settings.enterprise_primary_key_id == ""
+    assert settings.enterprise_secret_rotation_days == 90
+    assert settings.enterprise_max_write_payload_bytes == 1_048_576
+    assert settings.enterprise_feature_flags == {}
+    assert settings.enterprise_capability_rules == {}
+
+
+def test_control_plane_settings_parse_governed_values(monkeypatch) -> None:
+    monkeypatch.setenv("ENTERPRISE_POLICY_VERSION", "2.3.1")
+    monkeypatch.setenv("ENTERPRISE_ENFORCE_AUTHZ", "true")
+    monkeypatch.setenv("ENTERPRISE_ENFORCE_RUNTIME_CONFIG", "yes")
+    monkeypatch.setenv("ENTERPRISE_PRIMARY_KEY_ID", "kms-key-1")
+    monkeypatch.setenv("ENTERPRISE_SECRET_ROTATION_DAYS", "45")
+    monkeypatch.setenv("ENTERPRISE_MAX_WRITE_PAYLOAD_BYTES", "2048")
+    monkeypatch.setenv(
+        "ENTERPRISE_FEATURE_FLAGS_JSON",
+        '{"risk_write":{"tenant-a":{"ops":true,"*":false}}}',
+    )
+    monkeypatch.setenv(
+        "ENTERPRISE_CAPABILITY_RULES_JSON",
+        '{"POST /integration":"risk.write"}',
+    )
+
+    settings = load_query_control_plane_settings()
+
+    assert settings.enterprise_policy_version == "2.3.1"
+    assert settings.enterprise_enforce_authz is True
+    assert settings.enterprise_enforce_runtime_config is True
+    assert settings.enterprise_primary_key_id == "kms-key-1"
+    assert settings.enterprise_secret_rotation_days == 45
+    assert settings.enterprise_max_write_payload_bytes == 2048
+    assert settings.enterprise_feature_flags == {
+        "risk_write": {"tenant-a": {"ops": True, "*": False}}
+    }
+    assert settings.enterprise_capability_rules == {"POST /integration": "risk.write"}
+
+
+def test_control_plane_settings_helpers_fail_closed_for_invalid_values(monkeypatch) -> None:
+    monkeypatch.setenv("CONTROL_BOOL", "maybe")
+    monkeypatch.setenv("CONTROL_INT", "not-an-int")
+    monkeypatch.setenv("CONTROL_JSON", "[]")
+
+    assert env_bool("CONTROL_BOOL", False) is False
+    assert env_int("CONTROL_INT", 11) == 11
+    assert env_json_map("CONTROL_JSON") == {}

--- a/tests/unit/services/timeseries_generator_service/timeseries-generator-service/repositories/test_unit_timeseries_repo.py
+++ b/tests/unit/services/timeseries_generator_service/timeseries-generator-service/repositories/test_unit_timeseries_repo.py
@@ -172,7 +172,7 @@ async def test_get_latest_snapshots_for_date_uses_latest_epoch_per_security(
     assert "daily_position_snapshots.epoch = anon_1.epoch" in compiled_query
 
 
-async def test_find_and_claim_eligible_jobs_prior_day_gate_does_not_require_current_epoch_match(
+async def test_find_and_claim_eligible_jobs_does_not_require_prior_portfolio_day(
     repository: TimeseriesRepository, mock_db_session: AsyncMock
 ):
     await repository.find_and_claim_eligible_jobs(batch_size=5)
@@ -183,10 +183,10 @@ async def test_find_and_claim_eligible_jobs_prior_day_gate_does_not_require_curr
     )
 
     assert (
-        "portfolio_timeseries.date = portfolio_aggregation_jobs.aggregation_date -"
-        in compiled_query
+        "portfolio_timeseries.date = portfolio_aggregation_jobs.aggregation_date"
+        not in compiled_query
     )
-    assert "portfolio_timeseries.epoch =" not in compiled_query
+    assert "date < portfolio_aggregation_jobs.aggregation_date" not in compiled_query
 
 
 async def test_find_and_claim_eligible_jobs_increments_attempt_count(
@@ -204,7 +204,7 @@ async def test_find_and_claim_eligible_jobs_increments_attempt_count(
     assert "attempt_count=(portfolio_aggregation_jobs.attempt_count + 1)" in compiled_query
 
 
-async def test_find_and_claim_eligible_jobs_first_day_gate_is_directly_correlated(
+async def test_find_and_claim_eligible_jobs_has_no_legacy_first_day_gate(
     repository: TimeseriesRepository, mock_db_session: AsyncMock
 ):
     await repository.find_and_claim_eligible_jobs(batch_size=5)
@@ -214,11 +214,8 @@ async def test_find_and_claim_eligible_jobs_first_day_gate_is_directly_correlate
         executed_stmt.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True})
     )
 
-    assert (
-        "portfolio_aggregation_jobs_1.portfolio_id = portfolio_aggregation_jobs.portfolio_id"
-        in compiled_query
-    )
-    assert "NOT (EXISTS" in compiled_query
+    assert "portfolio_aggregation_jobs_1.portfolio_id" not in compiled_query
+    assert "NOT (EXISTS" not in compiled_query
     assert "FROM portfolio_timeseries, portfolio_aggregation_jobs" not in compiled_query
 
 

--- a/tests/unit/tools/test_front_office_portfolio_seed.py
+++ b/tests/unit/tools/test_front_office_portfolio_seed.py
@@ -1,4 +1,5 @@
 from datetime import date
+from decimal import Decimal
 import sys
 
 from tools.front_office_portfolio_seed import (
@@ -15,7 +16,7 @@ def _build_bundle():
     return build_front_office_portfolio_bundle(
         portfolio_id="PB_SG_GLOBAL_BAL_001",
         start_date=date(2025, 3, 31),
-        end_date=date(2026, 3, 28),
+        end_date=date(2026, 4, 10),
         benchmark_start_date=date(2025, 1, 6),
         benchmark_id=DEFAULT_BENCHMARK_ID,
     )
@@ -80,8 +81,8 @@ def test_front_office_bundle_includes_income_and_paired_cash_transactions():
     assert planned_withdrawal["settlement_date"] > planned_withdrawal["transaction_date"]
     future_withdrawal = by_txn["TXN-WITHDRAWAL-FUTURE-001"]
     assert future_withdrawal["transaction_type"] == "WITHDRAWAL"
-    assert future_withdrawal["transaction_date"].startswith("2026-04-07")
-    assert future_withdrawal["settlement_date"].startswith("2026-04-10")
+    assert future_withdrawal["transaction_date"].startswith("2026-04-17")
+    assert future_withdrawal["settlement_date"].startswith("2026-04-20")
 
     assert by_txn["TXN-CASH-BUY-AAPL-001"]["transaction_type"] == "SELL"
     assert by_txn["TXN-CASH-SELL-AAPL-001"]["transaction_type"] == "BUY"
@@ -129,7 +130,8 @@ def test_front_office_bundle_includes_forward_cashflow_event_inside_projection_w
     assert {transaction["transaction_id"] for transaction in future_txns} == {
         "TXN-WITHDRAWAL-FUTURE-001"
     }
-    assert future_txns[0]["settlement_date"].startswith("2026-04-10")
+    assert future_txns[0]["transaction_date"].startswith("2026-04-17")
+    assert future_txns[0]["settlement_date"].startswith("2026-04-20")
 
 
 def test_front_office_bundle_carries_full_price_coverage_through_as_of_date():
@@ -148,6 +150,49 @@ def test_front_office_bundle_carries_full_price_coverage_through_as_of_date():
     assert benchmark_assignment["benchmark_id"] == DEFAULT_BENCHMARK_ID
     assert benchmark_assignment["assignment_source"] == "front_office_portfolio_seed"
 
+    non_cash_security_ids = {
+        instrument["security_id"]
+        for instrument in bundle["instruments"]
+        if instrument["asset_class"] != "Cash"
+    }
+    last_price_by_security = {
+        security_id: max(
+            row["price_date"]
+            for row in bundle["market_prices"]
+            if row["security_id"] == security_id
+        )
+        for security_id in non_cash_security_ids
+    }
+    assert last_price_by_security
+    assert set(last_price_by_security) == non_cash_security_ids
+    assert all(price_date == bundle["as_of_date"] for price_date in last_price_by_security.values())
+
+
+def test_front_office_bundle_cash_economics_are_plausible_by_currency():
+    bundle = _build_bundle()
+    cash_security_ids = {
+        account["security_id"]: account["account_currency"]
+        for account in bundle["cash_accounts"]
+    }
+    cash_balance_by_currency = {currency: Decimal("0") for currency in cash_security_ids.values()}
+
+    for transaction in bundle["transactions"]:
+        currency = cash_security_ids.get(transaction["security_id"])
+        if currency is None:
+            continue
+        amount = Decimal(transaction["gross_transaction_amount"])
+        if transaction["transaction_type"] in {"DEPOSIT", "BUY"}:
+            cash_balance_by_currency[currency] += amount
+        elif transaction["transaction_type"] in {"SELL", "FEE", "WITHDRAWAL"}:
+            cash_balance_by_currency[currency] -= amount
+        else:
+            raise AssertionError(f"Unexpected cash transaction type: {transaction['transaction_type']}")
+
+    assert cash_balance_by_currency["USD"] > Decimal("0")
+    assert cash_balance_by_currency["EUR"] > Decimal("0")
+    assert cash_balance_by_currency["USD"] == Decimal("101347.00")
+    assert cash_balance_by_currency["EUR"] == Decimal("19805.50")
+
 
 def test_front_office_bundle_extends_fx_coverage_through_forward_projection_window():
     bundle = _build_bundle()
@@ -158,7 +203,7 @@ def test_front_office_bundle_extends_fx_coverage_through_forward_projection_wind
         if row["from_currency"] == "EUR" and row["to_currency"] == "USD"
     ]
     assert eur_usd_rates
-    assert eur_usd_rates[-1]["rate_date"] == "2026-04-27"
+    assert eur_usd_rates[-1]["rate_date"] == "2026-05-10"
 
 
 def test_front_office_bundle_extends_usd_risk_free_coverage_through_forward_window():
@@ -169,7 +214,7 @@ def test_front_office_bundle_extends_usd_risk_free_coverage_through_forward_wind
     assert risk_free_series[0]["series_currency"] == "USD"
     assert risk_free_series[0]["risk_free_curve_id"] == "USD_SOFR_3M"
     assert risk_free_series[0]["source_vendor"] == "LOTUS_FRONT_OFFICE_SEED"
-    assert risk_free_series[-1]["series_date"] == "2026-04-27"
+    assert risk_free_series[-1]["series_date"] == "2026-05-10"
 
 
 def test_front_office_bundle_rewrites_all_benchmark_artifacts_to_dedicated_seed_identity():
@@ -199,7 +244,7 @@ def test_front_office_bundle_rewrites_all_benchmark_artifacts_to_dedicated_seed_
     assert bundle["benchmark_return_series"][0]["source_record_id"].startswith(
         DEFAULT_BENCHMARK_ID.lower()
     )
-    assert bundle["benchmark_return_series"][-1]["series_date"] == "2026-04-27"
+    assert bundle["benchmark_return_series"][-1]["series_date"] == "2026-05-10"
 
 
 def test_front_office_cleanup_sql_removes_benchmark_seed_rows_deterministically():
@@ -232,6 +277,7 @@ def test_front_office_seed_verifies_against_canonical_gateway_by_default(monkeyp
     args = parse_args()
 
     assert args.gateway_base_url == "http://gateway.dev.lotus"
+    assert args.end_date == "2026-04-10"
 
 
 def test_front_office_seed_reprocesses_all_seed_transactions(monkeypatch):

--- a/tests/unit/tools/test_front_office_portfolio_seed.py
+++ b/tests/unit/tools/test_front_office_portfolio_seed.py
@@ -4,6 +4,7 @@ import sys
 
 from tools.front_office_portfolio_seed import (
     DEFAULT_BENCHMARK_ID,
+    _front_office_analytics_are_fresh,
     _reprocess_front_office_transactions,
     build_portfolio_seed_cleanup_sql,
     build_front_office_portfolio_bundle,
@@ -307,3 +308,39 @@ def test_front_office_seed_reprocesses_all_seed_transactions(monkeypatch):
             },
         )
     ]
+
+
+def test_front_office_seed_rejects_stale_derived_analytics_state():
+    stale_reference = {"performance_end_date": "2025-08-05"}
+    fresh_summary = {
+        "report_end_date": "2026-04-11",
+        "capabilities": {
+            "return_path": {
+                "latest_available_date": "2026-04-11",
+            }
+        },
+    }
+
+    assert not _front_office_analytics_are_fresh(
+        analytics_reference=stale_reference,
+        performance_summary=fresh_summary,
+        expected_end_date="2026-04-10",
+    )
+
+
+def test_front_office_seed_accepts_current_derived_analytics_state():
+    fresh_reference = {"performance_end_date": "2026-04-10"}
+    fresh_summary = {
+        "report_end_date": "2026-04-11",
+        "capabilities": {
+            "return_path": {
+                "latest_available_date": "2026-04-11",
+            }
+        },
+    }
+
+    assert _front_office_analytics_are_fresh(
+        analytics_reference=fresh_reference,
+        performance_summary=fresh_summary,
+        expected_end_date="2026-04-10",
+    )

--- a/tests/unit/tools/test_front_office_portfolio_seed.py
+++ b/tests/unit/tools/test_front_office_portfolio_seed.py
@@ -2,6 +2,7 @@ from datetime import date
 
 from tools.front_office_portfolio_seed import (
     DEFAULT_BENCHMARK_ID,
+    build_portfolio_seed_cleanup_sql,
     build_front_office_portfolio_bundle,
     build_front_office_seed_cleanup_sql,
 )
@@ -210,3 +211,13 @@ def test_front_office_cleanup_sql_removes_benchmark_seed_rows_deterministically(
     assert "delete from benchmark_definitions" in sql
     assert "PB_SG_GLOBAL_BAL_001" in sql
     assert DEFAULT_BENCHMARK_ID in sql
+
+
+def test_portfolio_seed_cleanup_sql_removes_portfolio_owned_state_before_reseed():
+    sql = build_portfolio_seed_cleanup_sql(portfolio_id="PB_SG_GLOBAL_BAL_001")
+
+    assert "delete from transactions where portfolio_id = 'PB_SG_GLOBAL_BAL_001';" in sql
+    assert "delete from position_timeseries where portfolio_id = 'PB_SG_GLOBAL_BAL_001';" in sql
+    assert "delete from cash_account_masters where portfolio_id = 'PB_SG_GLOBAL_BAL_001';" in sql
+    assert "delete from portfolios where portfolio_id = 'PB_SG_GLOBAL_BAL_001';" in sql
+    assert "delete from transaction_costs where transaction_id in" in sql

--- a/tests/unit/tools/test_front_office_portfolio_seed.py
+++ b/tests/unit/tools/test_front_office_portfolio_seed.py
@@ -1,10 +1,12 @@
 from datetime import date
+import sys
 
 from tools.front_office_portfolio_seed import (
     DEFAULT_BENCHMARK_ID,
     build_portfolio_seed_cleanup_sql,
     build_front_office_portfolio_bundle,
     build_front_office_seed_cleanup_sql,
+    parse_args,
 )
 
 
@@ -221,3 +223,11 @@ def test_portfolio_seed_cleanup_sql_removes_portfolio_owned_state_before_reseed(
     assert "delete from cash_account_masters where portfolio_id = 'PB_SG_GLOBAL_BAL_001';" in sql
     assert "delete from portfolios where portfolio_id = 'PB_SG_GLOBAL_BAL_001';" in sql
     assert "delete from transaction_costs where transaction_id in" in sql
+
+
+def test_front_office_seed_verifies_against_canonical_gateway_by_default(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["front_office_portfolio_seed.py"])
+
+    args = parse_args()
+
+    assert args.gateway_base_url == "http://gateway.dev.lotus"

--- a/tests/unit/tools/test_front_office_portfolio_seed.py
+++ b/tests/unit/tools/test_front_office_portfolio_seed.py
@@ -3,6 +3,7 @@ import sys
 
 from tools.front_office_portfolio_seed import (
     DEFAULT_BENCHMARK_ID,
+    _reprocess_front_office_transactions,
     build_portfolio_seed_cleanup_sql,
     build_front_office_portfolio_bundle,
     build_front_office_seed_cleanup_sql,
@@ -231,3 +232,32 @@ def test_front_office_seed_verifies_against_canonical_gateway_by_default(monkeyp
     args = parse_args()
 
     assert args.gateway_base_url == "http://gateway.dev.lotus"
+
+
+def test_front_office_seed_reprocesses_all_seed_transactions(monkeypatch):
+    bundle = _build_bundle()
+    calls = []
+
+    def capture_request(method, url, *, payload=None):
+        calls.append((method, url, payload))
+        return 202, {"accepted_count": len(payload["transaction_ids"])}
+
+    monkeypatch.setattr(
+        "tools.front_office_portfolio_seed._request_json",
+        capture_request,
+    )
+
+    _reprocess_front_office_transactions("http://ingestion.dev.lotus", bundle)
+
+    assert calls == [
+        (
+            "POST",
+            "http://ingestion.dev.lotus/reprocess/transactions",
+            {
+                "transaction_ids": [
+                    transaction["transaction_id"]
+                    for transaction in bundle["transactions"]
+                ]
+            },
+        )
+    ]

--- a/tools/front_office_portfolio_seed.py
+++ b/tools/front_office_portfolio_seed.py
@@ -1085,6 +1085,21 @@ def _ingest_reference_data(ingestion_base_url: str, bundle: dict[str, Any]) -> N
         _request_json("POST", f"{ingestion_base_url}{endpoint}", payload=payload)
 
 
+def _reprocess_front_office_transactions(ingestion_base_url: str, bundle: dict[str, Any]) -> None:
+    transaction_ids = [
+        transaction["transaction_id"]
+        for transaction in bundle["transactions"]
+        if isinstance(transaction.get("transaction_id"), str)
+    ]
+    if not transaction_ids:
+        return
+    _request_json(
+        "POST",
+        f"{ingestion_base_url}/reprocess/transactions",
+        payload={"transaction_ids": transaction_ids},
+    )
+
+
 def _cleanup_existing_front_office_seed(
     *,
     postgres_container: str,
@@ -1258,6 +1273,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--verify-only", action="store_true")
     parser.add_argument("--ingest-only", action="store_true")
     parser.add_argument("--force-ingest", action="store_true")
+    parser.add_argument(
+        "--skip-reprocess",
+        action="store_true",
+        help="Do not queue transaction reprocessing after bundle ingest.",
+    )
     parser.add_argument("--log-level", default="INFO")
     return parser.parse_args()
 
@@ -1306,6 +1326,8 @@ def main() -> int:
             payload = _build_portfolio_bundle_payload(bundle)
             _request_json("POST", f"{ingestion_base_url}/ingest/portfolio-bundle", payload=payload)
         _ingest_reference_data(ingestion_base_url, bundle)
+        if should_ingest and not args.skip_reprocess:
+            _reprocess_front_office_transactions(ingestion_base_url, bundle)
 
     if not args.ingest_only:
         verification = _verify_front_office_portfolio(

--- a/tools/front_office_portfolio_seed.py
+++ b/tools/front_office_portfolio_seed.py
@@ -47,13 +47,49 @@ FRONT_OFFICE_EXPECTATION = FrontOfficePortfolioExpectation(
 )
 
 
-def build_front_office_seed_cleanup_sql(*, portfolio_id: str, benchmark_id: str) -> str:
+def build_portfolio_seed_cleanup_sql(*, portfolio_id: str) -> str:
     return "\n".join(
         [
             (
-                "delete from portfolio_benchmark_assignments "
-                f"where portfolio_id = '{portfolio_id}' and benchmark_id = '{benchmark_id}';"
+                "delete from financial_reconciliation_findings "
+                f"where portfolio_id = '{portfolio_id}';"
             ),
+            (
+                "delete from financial_reconciliation_runs "
+                f"where portfolio_id = '{portfolio_id}';"
+            ),
+            f"delete from simulation_changes where portfolio_id = '{portfolio_id}';",
+            f"delete from simulation_sessions where portfolio_id = '{portfolio_id}';",
+            f"delete from analytics_export_jobs where portfolio_id = '{portfolio_id}';",
+            f"delete from portfolio_aggregation_jobs where portfolio_id = '{portfolio_id}';",
+            f"delete from portfolio_valuation_jobs where portfolio_id = '{portfolio_id}';",
+            f"delete from daily_position_snapshots where portfolio_id = '{portfolio_id}';",
+            f"delete from portfolio_timeseries where portfolio_id = '{portfolio_id}';",
+            f"delete from position_timeseries where portfolio_id = '{portfolio_id}';",
+            f"delete from position_history where portfolio_id = '{portfolio_id}';",
+            f"delete from position_state where portfolio_id = '{portfolio_id}';",
+            f"delete from position_lot_state where portfolio_id = '{portfolio_id}';",
+            f"delete from accrued_income_offset_state where portfolio_id = '{portfolio_id}';",
+            f"delete from cashflows where portfolio_id = '{portfolio_id}';",
+            (
+                "delete from transaction_costs where transaction_id in "
+                f"(select transaction_id from transactions where portfolio_id = '{portfolio_id}');"
+            ),
+            f"delete from pipeline_stage_state where portfolio_id = '{portfolio_id}';",
+            f"delete from processed_events where portfolio_id = '{portfolio_id}';",
+            f"delete from cash_account_masters where portfolio_id = '{portfolio_id}';",
+            f"delete from portfolio_benchmark_assignments where portfolio_id = '{portfolio_id}';",
+            f"delete from transactions where portfolio_id = '{portfolio_id}';",
+            f"delete from instruments where portfolio_id = '{portfolio_id}';",
+            f"delete from portfolios where portfolio_id = '{portfolio_id}';",
+        ]
+    )
+
+
+def build_front_office_seed_cleanup_sql(*, portfolio_id: str, benchmark_id: str) -> str:
+    return "\n".join(
+        [
+            build_portfolio_seed_cleanup_sql(portfolio_id=portfolio_id),
             f"delete from benchmark_composition_series where benchmark_id = '{benchmark_id}';",
             f"delete from benchmark_return_series where benchmark_id = '{benchmark_id}';",
             f"delete from benchmark_definitions where benchmark_id = '{benchmark_id}';",
@@ -1263,7 +1299,10 @@ def main() -> int:
                 portfolio_id=args.portfolio_id,
                 benchmark_id=args.benchmark_id,
             )
-        if args.force_ingest or not _portfolio_exists(query_base_url, args.portfolio_id):
+        should_ingest = args.force_ingest or not args.skip_cleanup
+        if not should_ingest:
+            should_ingest = not _portfolio_exists(query_base_url, args.portfolio_id)
+        if should_ingest:
             payload = _build_portfolio_bundle_payload(bundle)
             _request_json("POST", f"{ingestion_base_url}/ingest/portfolio-bundle", payload=payload)
         _ingest_reference_data(ingestion_base_url, bundle)

--- a/tools/front_office_portfolio_seed.py
+++ b/tools/front_office_portfolio_seed.py
@@ -1113,6 +1113,26 @@ def _reprocess_front_office_transactions(ingestion_base_url: str, bundle: dict[s
     )
 
 
+def _date_at_or_after(actual: str | None, expected: str) -> bool:
+    if not actual:
+        return False
+    return date.fromisoformat(actual) >= date.fromisoformat(expected)
+
+
+def _front_office_analytics_are_fresh(
+    *,
+    analytics_reference: dict[str, Any],
+    performance_summary: dict[str, Any],
+    expected_end_date: str,
+) -> bool:
+    return_path = (performance_summary.get("capabilities") or {}).get("return_path") or {}
+    return (
+        _date_at_or_after(analytics_reference.get("performance_end_date"), expected_end_date)
+        and _date_at_or_after(performance_summary.get("report_end_date"), expected_end_date)
+        and _date_at_or_after(return_path.get("latest_available_date"), expected_end_date)
+    )
+
+
 def _cleanup_existing_front_office_seed(
     *,
     postgres_container: str,
@@ -1202,6 +1222,11 @@ def _verify_front_office_portfolio(
                 f"{query_control_plane_base_url}/integration/portfolios/{expected.portfolio_id}/benchmark-assignment",
                 payload={"as_of_date": as_of_date, "consumer_system": "lotus-performance"},
             )
+            _, analytics_reference = _request_json(
+                "POST",
+                f"{query_control_plane_base_url}/integration/portfolios/{expected.portfolio_id}/analytics/reference",
+                payload={"as_of_date": as_of_date, "consumer_system": "lotus-performance"},
+            )
             _, cashflow_projection = _request_json(
                 "GET",
                 f"{query_base_url}/portfolios/{expected.portfolio_id}/cashflow-projection"
@@ -1247,6 +1272,11 @@ def _verify_front_office_portfolio(
             and has_non_zero_projection
             and benchmark_assignment.get("benchmark_id")
             and performance_summary.get("benchmark_code")
+            and _front_office_analytics_are_fresh(
+                analytics_reference=analytics_reference,
+                performance_summary=performance_summary,
+                expected_end_date=end_date,
+            )
         ):
             return {
                 "portfolio_id": expected.portfolio_id,
@@ -1259,6 +1289,15 @@ def _verify_front_office_portfolio(
                 "activity_buckets": len(activity_rows),
                 "projected_cashflow_points": len(projected_cashflow_points),
                 "benchmark_code": performance_summary.get("benchmark_code"),
+                "analytics_performance_end_date": analytics_reference.get(
+                    "performance_end_date"
+                ),
+                "performance_report_end_date": performance_summary.get("report_end_date"),
+                "return_path_latest_available_date": (
+                    performance_summary.get("capabilities", {})
+                    .get("return_path", {})
+                    .get("latest_available_date")
+                ),
             }
 
     raise TimeoutError(

--- a/tools/front_office_portfolio_seed.py
+++ b/tools/front_office_portfolio_seed.py
@@ -189,9 +189,22 @@ def build_front_office_portfolio_bundle(
     calendar_dates = _calendar_dates(start_date, end_date)
     fx_calendar_dates = _calendar_dates(start_date, end_date + timedelta(days=30))
     as_of_date = end_date.isoformat()
+    forward_withdrawal_date = end_date + timedelta(days=7)
+    forward_withdrawal_settlement_date = end_date + timedelta(days=10)
 
     def tx_dt(day_offset: int, hour: int = 10) -> datetime:
         current = start_date + timedelta(days=day_offset)
+        return datetime(
+            current.year,
+            current.month,
+            current.day,
+            hour,
+            0,
+            0,
+            tzinfo=UTC,
+        )
+
+    def date_dt(current: date, hour: int = 10) -> datetime:
         return datetime(
             current.year,
             current.month,
@@ -862,8 +875,8 @@ def build_front_office_portfolio_bundle(
             portfolio_id=portfolio_id,
             instrument_id="USD-CASH",
             security_id="CASH_USD_BOOK_OPERATING",
-            when=tx_dt(372),
-            settlement_date=settle(372, 3),
+            when=date_dt(forward_withdrawal_date),
+            settlement_date=date_dt(forward_withdrawal_settlement_date, 16),
             tx_type="WITHDRAWAL",
             quantity="18000",
             price="1",
@@ -1259,7 +1272,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--portfolio-id", default=DEFAULT_PORTFOLIO_ID)
     parser.add_argument("--start-date", default="2025-03-31")
-    parser.add_argument("--end-date", default="2026-03-28")
+    parser.add_argument("--end-date", default="2026-04-10")
     parser.add_argument("--benchmark-start-date", default="2025-01-06")
     parser.add_argument("--benchmark-id", default=DEFAULT_BENCHMARK_ID)
     parser.add_argument("--ingestion-base-url", default="http://127.0.0.1:8200")

--- a/tools/front_office_portfolio_seed.py
+++ b/tools/front_office_portfolio_seed.py
@@ -1250,7 +1250,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--ingestion-base-url", default="http://127.0.0.1:8200")
     parser.add_argument("--query-base-url", default="http://127.0.0.1:8201")
     parser.add_argument("--query-control-plane-base-url", default="http://127.0.0.1:8202")
-    parser.add_argument("--gateway-base-url", default="http://127.0.0.1:8100")
+    parser.add_argument("--gateway-base-url", default="http://gateway.dev.lotus")
     parser.add_argument("--wait-seconds", type=int, default=300)
     parser.add_argument("--poll-interval-seconds", type=int, default=3)
     parser.add_argument("--postgres-container", default=DEFAULT_POSTGRES_CONTAINER)


### PR DESCRIPTION
## Summary
- Implements RFC-0075 canonical front-office seed hardening in lotus-core.
- Removes stale smoke-data patterns, aligns the canonical seed as-of date, tightens reseed cleanup and derived readiness, and accelerates aggregation readiness for demo validation.

## Validation
- python -m pytest tests/unit/tools/test_front_office_portfolio_seed.py tests/unit/services/portfolio_aggregation_service/repositories/test_timeseries_repository.py tests/unit/services/timeseries_generator_service/timeseries-generator-service/repositories/test_unit_timeseries_repo.py tests/unit/services/portfolio_aggregation_service/core/test_aggregation_scheduler.py -q
- python -m pytest tests/integration/services/timeseries_generator_service/test_timeseries_repository_integration.py -q
- python tools\front_office_portfolio_seed.py --verify-only --portfolio-id PB_SG_GLOBAL_BAL_001 --start-date 2025-03-31 --end-date 2026-04-10 --benchmark-start-date 2025-01-06 --wait-seconds 120 --poll-interval-seconds 5
