### PR TITLE
feat: align front-office seeder with governed contract

### DIFF
--- a/tests/unit/tools/test_front_office_portfolio_seed.py
+++ b/tests/unit/tools/test_front_office_portfolio_seed.py
@@ -302,6 +302,11 @@ def test_front_office_runtime_expectation_is_derived_from_contract() -> None:
     assert FRONT_OFFICE_EXPECTATION.portfolio_id == FRONT_OFFICE_SEED_CONTRACT.portfolio_id
     assert FRONT_OFFICE_EXPECTATION.min_transactions == FRONT_OFFICE_SEED_CONTRACT.min_transactions
     assert FRONT_OFFICE_EXPECTATION.min_cash_accounts == FRONT_OFFICE_SEED_CONTRACT.min_cash_accounts
+    assert FRONT_OFFICE_EXPECTATION.min_allocation_views == FRONT_OFFICE_SEED_CONTRACT.min_allocation_views
+    assert (
+        FRONT_OFFICE_EXPECTATION.min_projected_cashflow_points
+        == FRONT_OFFICE_SEED_CONTRACT.min_projected_cashflow_points
+    )
 
 
 def test_front_office_seed_contract_has_governed_fallback_when_platform_contract_is_unavailable(

--- a/tests/unit/tools/test_front_office_portfolio_seed.py
+++ b/tests/unit/tools/test_front_office_portfolio_seed.py
@@ -4,6 +4,8 @@ import sys
 
 from tools.front_office_portfolio_seed import (
     DEFAULT_BENCHMARK_ID,
+    FRONT_OFFICE_EXPECTATION,
+    FRONT_OFFICE_SEED_CONTRACT,
     _front_office_analytics_are_fresh,
     _reprocess_front_office_transactions,
     build_portfolio_seed_cleanup_sql,
@@ -11,6 +13,8 @@ from tools.front_office_portfolio_seed import (
     build_front_office_seed_cleanup_sql,
     parse_args,
 )
+from tools.front_office_seed_contract import load_front_office_seed_contract
+import tools.front_office_seed_contract as front_office_seed_contract_module
 
 
 def _build_bundle():
@@ -279,6 +283,43 @@ def test_front_office_seed_verifies_against_canonical_gateway_by_default(monkeyp
 
     assert args.gateway_base_url == "http://gateway.dev.lotus"
     assert args.end_date == "2026-04-10"
+
+
+def test_front_office_seed_contract_loads_platform_governed_defaults() -> None:
+    contract = load_front_office_seed_contract()
+
+    assert contract.portfolio_id == "PB_SG_GLOBAL_BAL_001"
+    assert contract.benchmark_id == "BMK_PB_GLOBAL_BALANCED_60_40"
+    assert contract.canonical_as_of_date == "2026-04-10"
+    assert contract.seed_start_date == "2025-03-31"
+    assert contract.benchmark_start_date == "2025-01-06"
+    assert contract.min_transactions >= 30
+    assert contract.min_risk_rolling_windows >= 4
+    assert FRONT_OFFICE_SEED_CONTRACT == contract
+
+
+def test_front_office_runtime_expectation_is_derived_from_contract() -> None:
+    assert FRONT_OFFICE_EXPECTATION.portfolio_id == FRONT_OFFICE_SEED_CONTRACT.portfolio_id
+    assert FRONT_OFFICE_EXPECTATION.min_transactions == FRONT_OFFICE_SEED_CONTRACT.min_transactions
+    assert FRONT_OFFICE_EXPECTATION.min_cash_accounts == FRONT_OFFICE_SEED_CONTRACT.min_cash_accounts
+
+
+def test_front_office_seed_contract_has_governed_fallback_when_platform_contract_is_unavailable(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("LOTUS_PLATFORM_REPO", raising=False)
+    monkeypatch.setattr(
+        front_office_seed_contract_module,
+        "DEFAULT_PLATFORM_REPO",
+        front_office_seed_contract_module.REPO_ROOT / "missing-platform-repo",
+    )
+
+    contract = load_front_office_seed_contract()
+
+    assert contract.portfolio_id == "PB_SG_GLOBAL_BAL_001"
+    assert contract.benchmark_id == "BMK_PB_GLOBAL_BALANCED_60_40"
+    assert contract.canonical_as_of_date == "2026-04-10"
+    assert contract.min_transactions == 30
 
 
 def test_front_office_seed_reprocesses_all_seed_transactions(monkeypatch):

--- a/tests/unit/tools/test_front_office_portfolio_seed.py
+++ b/tests/unit/tools/test_front_office_portfolio_seed.py
@@ -6,6 +6,9 @@ from tools.front_office_portfolio_seed import (
     DEFAULT_BENCHMARK_ID,
     FRONT_OFFICE_EXPECTATION,
     FRONT_OFFICE_SEED_CONTRACT,
+    _collect_front_office_readiness_diagnostics,
+    _extract_readiness_summary,
+    _extract_support_overview_summary,
     _front_office_analytics_are_fresh,
     _reprocess_front_office_transactions,
     build_portfolio_seed_cleanup_sql,
@@ -390,3 +393,114 @@ def test_front_office_seed_accepts_current_derived_analytics_state():
         performance_summary=fresh_summary,
         expected_end_date="2026-04-10",
     )
+
+
+def test_extract_readiness_summary_surfaces_contract_relevant_state() -> None:
+    payload = {
+        "resolved_as_of_date": "2026-04-10",
+        "holdings": {"status": "PENDING"},
+        "pricing": {"status": "PENDING"},
+        "transactions": {"status": "READY"},
+        "reporting": {"status": "BLOCKED"},
+        "blocking_reasons": [
+            {"code": "SNAPSHOT_BEHIND_TRANSACTION_LEDGER"},
+            {"code": "UNVALUED_POSITIONS_REMAIN"},
+        ],
+        "latest_booked_transaction_date": "2026-04-10",
+        "latest_booked_position_snapshot_date": "2026-04-09",
+        "snapshot_valuation_total_positions": 11,
+        "snapshot_valuation_valued_positions": 10,
+        "snapshot_valuation_unvalued_positions": 1,
+        "missing_historical_fx_dependencies": {"missing_count": 0},
+    }
+
+    summary = _extract_readiness_summary(payload)
+
+    assert summary["resolved_as_of_date"] == "2026-04-10"
+    assert summary["holdings_status"] == "PENDING"
+    assert summary["pricing_status"] == "PENDING"
+    assert summary["reporting_status"] == "BLOCKED"
+    assert summary["blocking_reason_codes"] == [
+        "SNAPSHOT_BEHIND_TRANSACTION_LEDGER",
+        "UNVALUED_POSITIONS_REMAIN",
+    ]
+    assert summary["snapshot_valuation_unvalued_positions"] == 1
+
+
+def test_extract_support_overview_summary_surfaces_aggregation_backlog_signal() -> None:
+    payload = {
+        "pending_aggregation_jobs": 2,
+        "processing_aggregation_jobs": 1,
+        "stale_processing_aggregation_jobs": 0,
+        "failed_aggregation_jobs": 0,
+        "oldest_pending_aggregation_date": "2026-04-10",
+        "latest_booked_transaction_date": "2026-04-10",
+        "latest_booked_position_snapshot_date": "2026-04-09",
+    }
+
+    summary = _extract_support_overview_summary(payload)
+
+    assert summary["pending_aggregation_jobs"] == 2
+    assert summary["processing_aggregation_jobs"] == 1
+    assert summary["oldest_pending_aggregation_date"] == "2026-04-10"
+    assert summary["latest_booked_position_snapshot_date"] == "2026-04-09"
+
+
+def test_collect_front_office_readiness_diagnostics_queries_support_endpoints(monkeypatch) -> None:
+    responses = {
+        "http://cp.dev/support/portfolios/P1/readiness?as_of_date=2026-04-10": (
+            200,
+            {
+                "resolved_as_of_date": "2026-04-10",
+                "holdings": {"status": "READY"},
+                "pricing": {"status": "PENDING"},
+                "transactions": {"status": "READY"},
+                "reporting": {"status": "PENDING"},
+                "blocking_reasons": [{"code": "UNVALUED_POSITIONS_REMAIN"}],
+                "latest_booked_transaction_date": "2026-04-10",
+                "latest_booked_position_snapshot_date": "2026-04-10",
+                "snapshot_valuation_total_positions": 11,
+                "snapshot_valuation_valued_positions": 10,
+                "snapshot_valuation_unvalued_positions": 1,
+                "missing_historical_fx_dependencies": {"missing_count": 0},
+            },
+        ),
+        "http://cp.dev/support/portfolios/P1/overview": (
+            200,
+            {
+                "pending_aggregation_jobs": 1,
+                "processing_aggregation_jobs": 0,
+                "stale_processing_aggregation_jobs": 0,
+                "failed_aggregation_jobs": 0,
+                "oldest_pending_aggregation_date": "2026-04-10",
+                "latest_booked_transaction_date": "2026-04-10",
+                "latest_booked_position_snapshot_date": "2026-04-09",
+            },
+        ),
+        "http://cp.dev/support/portfolios/P1/aggregation-jobs?business_date=2026-04-10&limit=5": (
+            200,
+            {
+                "total": 1,
+                "items": [{"job_id": 4402, "status": "PENDING"}],
+            },
+        ),
+    }
+
+    def fake_request(method, url, *, payload=None):
+        assert method == "GET"
+        assert payload is None
+        return responses[url]
+
+    monkeypatch.setattr("tools.front_office_portfolio_seed._request_json", fake_request)
+
+    diagnostics = _collect_front_office_readiness_diagnostics(
+        query_control_plane_base_url="http://cp.dev",
+        portfolio_id="P1",
+        as_of_date="2026-04-10",
+    )
+
+    assert diagnostics["readiness"]["pricing_status"] == "PENDING"
+    assert diagnostics["readiness"]["blocking_reason_codes"] == ["UNVALUED_POSITIONS_REMAIN"]
+    assert diagnostics["support_overview"]["pending_aggregation_jobs"] == 1
+    assert diagnostics["aggregation_jobs"]["job_ids"] == [4402]
+    assert diagnostics["aggregation_jobs"]["statuses"] == ["PENDING"]

--- a/tools/front_office_portfolio_seed.py
+++ b/tools/front_office_portfolio_seed.py
@@ -21,11 +21,15 @@ from tools.demo_data_pack import (  # noqa: E402
     _wait_ready,
     build_risk_free_reference_data,
 )
+from tools.front_office_seed_contract import (  # noqa: E402
+    FrontOfficeSeedContract,
+    load_front_office_seed_contract,
+)
 
 LOGGER = logging.getLogger("front_office_portfolio_seed")
-
-DEFAULT_PORTFOLIO_ID = "PB_SG_GLOBAL_BAL_001"
-DEFAULT_BENCHMARK_ID = "BMK_PB_GLOBAL_BALANCED_60_40"
+FRONT_OFFICE_SEED_CONTRACT = load_front_office_seed_contract()
+DEFAULT_PORTFOLIO_ID = FRONT_OFFICE_SEED_CONTRACT.portfolio_id
+DEFAULT_BENCHMARK_ID = FRONT_OFFICE_SEED_CONTRACT.benchmark_id
 DEFAULT_POSTGRES_CONTAINER = "lotus-core-app-local-postgres-1"
 
 
@@ -38,13 +42,19 @@ class FrontOfficePortfolioExpectation:
     min_cash_accounts: int
 
 
-FRONT_OFFICE_EXPECTATION = FrontOfficePortfolioExpectation(
-    portfolio_id=DEFAULT_PORTFOLIO_ID,
-    min_positions=10,
-    min_valued_positions=10,
-    min_transactions=26,
-    min_cash_accounts=2,
-)
+def _build_front_office_expectation(
+    contract: FrontOfficeSeedContract,
+) -> FrontOfficePortfolioExpectation:
+    return FrontOfficePortfolioExpectation(
+        portfolio_id=contract.portfolio_id,
+        min_positions=contract.min_positions,
+        min_valued_positions=contract.min_valued_positions,
+        min_transactions=contract.min_transactions,
+        min_cash_accounts=contract.min_cash_accounts,
+    )
+
+
+FRONT_OFFICE_EXPECTATION = _build_front_office_expectation(FRONT_OFFICE_SEED_CONTRACT)
 
 
 def build_portfolio_seed_cleanup_sql(*, portfolio_id: str) -> str:
@@ -1309,11 +1319,14 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Seed a realistic front-office portfolio scenario."
     )
-    parser.add_argument("--portfolio-id", default=DEFAULT_PORTFOLIO_ID)
-    parser.add_argument("--start-date", default="2025-03-31")
-    parser.add_argument("--end-date", default="2026-04-10")
-    parser.add_argument("--benchmark-start-date", default="2025-01-06")
-    parser.add_argument("--benchmark-id", default=DEFAULT_BENCHMARK_ID)
+    parser.add_argument("--portfolio-id", default=FRONT_OFFICE_SEED_CONTRACT.portfolio_id)
+    parser.add_argument("--start-date", default=FRONT_OFFICE_SEED_CONTRACT.seed_start_date)
+    parser.add_argument("--end-date", default=FRONT_OFFICE_SEED_CONTRACT.canonical_as_of_date)
+    parser.add_argument(
+        "--benchmark-start-date",
+        default=FRONT_OFFICE_SEED_CONTRACT.benchmark_start_date,
+    )
+    parser.add_argument("--benchmark-id", default=FRONT_OFFICE_SEED_CONTRACT.benchmark_id)
     parser.add_argument("--ingestion-base-url", default="http://127.0.0.1:8200")
     parser.add_argument("--query-base-url", default="http://127.0.0.1:8201")
     parser.add_argument("--query-control-plane-base-url", default="http://127.0.0.1:8202")

--- a/tools/front_office_portfolio_seed.py
+++ b/tools/front_office_portfolio_seed.py
@@ -40,6 +40,8 @@ class FrontOfficePortfolioExpectation:
     min_valued_positions: int
     min_transactions: int
     min_cash_accounts: int
+    min_allocation_views: int
+    min_projected_cashflow_points: int
 
 
 def _build_front_office_expectation(
@@ -51,6 +53,8 @@ def _build_front_office_expectation(
         min_valued_positions=contract.min_valued_positions,
         min_transactions=contract.min_transactions,
         min_cash_accounts=contract.min_cash_accounts,
+        min_allocation_views=contract.min_allocation_views,
+        min_projected_cashflow_points=contract.min_projected_cashflow_points,
     )
 
 
@@ -1276,9 +1280,10 @@ def _verify_front_office_portfolio(
             and len(valued) >= expected.min_valued_positions
             and total_transactions >= expected.min_transactions
             and len(cash_accounts) >= expected.min_cash_accounts
-            and allocation_views
+            and len(allocation_views) >= expected.min_allocation_views
             and income_rows
             and activity_rows
+            and len(projected_cashflow_points) >= expected.min_projected_cashflow_points
             and has_non_zero_projection
             and benchmark_assignment.get("benchmark_id")
             and performance_summary.get("benchmark_code")

--- a/tools/front_office_portfolio_seed.py
+++ b/tools/front_office_portfolio_seed.py
@@ -1147,6 +1147,108 @@ def _front_office_analytics_are_fresh(
     )
 
 
+def _extract_readiness_summary(readiness_payload: dict[str, Any]) -> dict[str, Any]:
+    blocking_reasons = readiness_payload.get("blocking_reasons") or []
+    return {
+        "resolved_as_of_date": readiness_payload.get("resolved_as_of_date"),
+        "holdings_status": (readiness_payload.get("holdings") or {}).get("status"),
+        "pricing_status": (readiness_payload.get("pricing") or {}).get("status"),
+        "transactions_status": (readiness_payload.get("transactions") or {}).get("status"),
+        "reporting_status": (readiness_payload.get("reporting") or {}).get("status"),
+        "blocking_reason_codes": [
+            reason.get("code")
+            for reason in blocking_reasons
+            if isinstance(reason, dict) and reason.get("code")
+        ],
+        "latest_booked_transaction_date": readiness_payload.get("latest_booked_transaction_date"),
+        "latest_booked_position_snapshot_date": readiness_payload.get(
+            "latest_booked_position_snapshot_date"
+        ),
+        "snapshot_valuation_total_positions": readiness_payload.get(
+            "snapshot_valuation_total_positions"
+        ),
+        "snapshot_valuation_valued_positions": readiness_payload.get(
+            "snapshot_valuation_valued_positions"
+        ),
+        "snapshot_valuation_unvalued_positions": readiness_payload.get(
+            "snapshot_valuation_unvalued_positions"
+        ),
+        "missing_historical_fx_dependencies": (
+            (readiness_payload.get("missing_historical_fx_dependencies") or {}).get("missing_count")
+        ),
+    }
+
+
+def _extract_support_overview_summary(overview_payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "pending_aggregation_jobs": overview_payload.get("pending_aggregation_jobs"),
+        "processing_aggregation_jobs": overview_payload.get("processing_aggregation_jobs"),
+        "stale_processing_aggregation_jobs": overview_payload.get(
+            "stale_processing_aggregation_jobs"
+        ),
+        "failed_aggregation_jobs": overview_payload.get("failed_aggregation_jobs"),
+        "oldest_pending_aggregation_date": overview_payload.get(
+            "oldest_pending_aggregation_date"
+        ),
+        "latest_booked_transaction_date": overview_payload.get("latest_booked_transaction_date"),
+        "latest_booked_position_snapshot_date": overview_payload.get(
+            "latest_booked_position_snapshot_date"
+        ),
+    }
+
+
+def _collect_front_office_readiness_diagnostics(
+    *,
+    query_control_plane_base_url: str,
+    portfolio_id: str,
+    as_of_date: str,
+) -> dict[str, Any]:
+    diagnostics: dict[str, Any] = {}
+
+    try:
+        _, readiness_payload = _request_json(
+            "GET",
+            f"{query_control_plane_base_url}/support/portfolios/{portfolio_id}/readiness"
+            f"?as_of_date={as_of_date}",
+        )
+        diagnostics["readiness"] = _extract_readiness_summary(readiness_payload)
+    except RuntimeError as exc:
+        diagnostics["readiness_error"] = str(exc)
+
+    try:
+        _, overview_payload = _request_json(
+            "GET",
+            f"{query_control_plane_base_url}/support/portfolios/{portfolio_id}/overview",
+        )
+        diagnostics["support_overview"] = _extract_support_overview_summary(overview_payload)
+    except RuntimeError as exc:
+        diagnostics["support_overview_error"] = str(exc)
+
+    try:
+        _, aggregation_jobs_payload = _request_json(
+            "GET",
+            f"{query_control_plane_base_url}/support/portfolios/{portfolio_id}/aggregation-jobs"
+            f"?business_date={as_of_date}&limit=5",
+        )
+        diagnostics["aggregation_jobs"] = {
+            "total": aggregation_jobs_payload.get("total"),
+            "job_ids": [
+                row.get("job_id")
+                for row in aggregation_jobs_payload.get("items") or []
+                if isinstance(row, dict) and row.get("job_id") is not None
+            ],
+            "statuses": [
+                row.get("status")
+                for row in aggregation_jobs_payload.get("items") or []
+                if isinstance(row, dict) and row.get("status")
+            ],
+        }
+    except RuntimeError as exc:
+        diagnostics["aggregation_jobs_error"] = str(exc)
+
+    return diagnostics
+
+
 def _cleanup_existing_front_office_seed(
     *,
     postgres_container: str,
@@ -1186,6 +1288,7 @@ def _verify_front_office_portfolio(
     poll_interval_seconds: int,
 ) -> dict[str, Any]:
     deadline = datetime.now(tz=UTC) + timedelta(seconds=wait_seconds)
+    last_observation: dict[str, Any] | None = None
     while datetime.now(tz=UTC) < deadline:
         try:
             _, positions_payload = _request_json(
@@ -1274,6 +1377,25 @@ def _verify_front_office_portfolio(
             for point in projected_cashflow_points
             if isinstance(point, dict)
         )
+        last_observation = {
+            "positions": len(positions),
+            "valued_positions": len(valued),
+            "transactions": total_transactions,
+            "cash_accounts": len(cash_accounts),
+            "allocation_views": len(allocation_views),
+            "income_types": len(income_rows),
+            "activity_buckets": len(activity_rows),
+            "projected_cashflow_points": len(projected_cashflow_points),
+            "has_non_zero_projection": has_non_zero_projection,
+            "benchmark_code": performance_summary.get("benchmark_code"),
+            "analytics_performance_end_date": analytics_reference.get("performance_end_date"),
+            "performance_report_end_date": performance_summary.get("report_end_date"),
+            "return_path_latest_available_date": (
+                performance_summary.get("capabilities", {})
+                .get("return_path", {})
+                .get("latest_available_date")
+            ),
+        }
 
         if (
             len(positions) >= expected.min_positions
@@ -1315,8 +1437,22 @@ def _verify_front_office_portfolio(
                 ),
             }
 
+        LOGGER.info(
+            "Front-office verification waiting on readiness for %s: %s",
+            expected.portfolio_id,
+            last_observation,
+        )
+
+    readiness_diagnostics = _collect_front_office_readiness_diagnostics(
+        query_control_plane_base_url=query_control_plane_base_url,
+        portfolio_id=expected.portfolio_id,
+        as_of_date=as_of_date,
+    )
     raise TimeoutError(
-        f"Timed out verifying front-office portfolio seed for {expected.portfolio_id}."
+        "Timed out verifying front-office portfolio seed for "
+        f"{expected.portfolio_id}. "
+        f"Last observation: {last_observation}. "
+        f"Readiness diagnostics: {readiness_diagnostics}"
     )
 
 

--- a/tools/front_office_seed_contract.py
+++ b/tools/front_office_seed_contract.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PLATFORM_REPO = REPO_ROOT.parent / "lotus-platform"
+CONTRACT_RELATIVE_PATH = Path("context/contracts/canonical-front-office-demo-data-contract.json")
+INVARIANTS_RELATIVE_PATH = Path("context/contracts/canonical-front-office-demo-data-invariants.json")
+
+
+@dataclass(frozen=True)
+class FrontOfficeSeedContract:
+    portfolio_id: str
+    benchmark_id: str
+    canonical_as_of_date: str
+    benchmark_start_date: str
+    seed_start_date: str
+    projected_horizon_end_date: str
+    min_positions: int
+    min_valued_positions: int
+    min_transactions: int
+    min_cash_accounts: int
+    min_allocation_views: int
+    min_projected_cashflow_points: int
+    min_performance_contribution_rows: int
+    min_risk_ready_metrics: int
+    min_risk_rolling_windows: int
+    min_risk_attribution_contributors: int
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _resolve_platform_repo_root() -> Path | None:
+    configured_root = os.getenv("LOTUS_PLATFORM_REPO")
+    if configured_root:
+        path = Path(configured_root).expanduser().resolve()
+        if path.exists():
+            return path
+
+    if DEFAULT_PLATFORM_REPO.exists():
+        return DEFAULT_PLATFORM_REPO.resolve()
+    return None
+
+
+def _load_platform_contract_artifacts() -> tuple[dict[str, Any], dict[str, Any]] | None:
+    platform_root = _resolve_platform_repo_root()
+    if platform_root is None:
+        return None
+
+    contract_path = platform_root / CONTRACT_RELATIVE_PATH
+    invariants_path = platform_root / INVARIANTS_RELATIVE_PATH
+    if not contract_path.exists() or not invariants_path.exists():
+        return None
+
+    return _load_json(contract_path), _load_json(invariants_path)
+
+
+def _build_fallback_contract() -> FrontOfficeSeedContract:
+    return FrontOfficeSeedContract(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        benchmark_id="BMK_PB_GLOBAL_BALANCED_60_40",
+        canonical_as_of_date="2026-04-10",
+        benchmark_start_date="2025-01-06",
+        seed_start_date="2025-03-31",
+        projected_horizon_end_date="2026-05-10",
+        min_positions=10,
+        min_valued_positions=10,
+        min_transactions=30,
+        min_cash_accounts=2,
+        min_allocation_views=4,
+        min_projected_cashflow_points=1,
+        min_performance_contribution_rows=4,
+        min_risk_ready_metrics=6,
+        min_risk_rolling_windows=4,
+        min_risk_attribution_contributors=7,
+    )
+
+
+def _to_seed_contract(
+    contract_payload: dict[str, Any],
+    invariant_payload: dict[str, Any],
+) -> FrontOfficeSeedContract:
+    portfolio = contract_payload["portfolio"]
+    benchmark = contract_payload["benchmark"]
+    date_policy = contract_payload["date_policy"]
+    thresholds = invariant_payload["minimum_thresholds"]
+
+    return FrontOfficeSeedContract(
+        portfolio_id=portfolio["portfolio_id"],
+        benchmark_id=benchmark["benchmark_code"],
+        canonical_as_of_date=date_policy["canonical_as_of_date"],
+        benchmark_start_date=date_policy["warmup_start_date"],
+        seed_start_date=date_policy["seed_start_date"],
+        projected_horizon_end_date=date_policy["projected_horizon_end_date"],
+        min_positions=int(thresholds.get("positions", 10)),
+        min_valued_positions=int(thresholds.get("valued_positions", 10)),
+        min_transactions=int(thresholds["transactions"]),
+        min_cash_accounts=int(thresholds["cash_accounts"]),
+        min_allocation_views=int(thresholds["allocation_views"]),
+        min_projected_cashflow_points=int(thresholds["projected_cashflow_points"]),
+        min_performance_contribution_rows=int(thresholds["performance_contribution_rows"]),
+        min_risk_ready_metrics=int(thresholds["risk_ready_metrics"]),
+        min_risk_rolling_windows=int(thresholds["risk_rolling_windows"]),
+        min_risk_attribution_contributors=int(thresholds["risk_attribution_contributors"]),
+    )
+
+
+def load_front_office_seed_contract() -> FrontOfficeSeedContract:
+    payloads = _load_platform_contract_artifacts()
+    if payloads is None:
+        return _build_fallback_contract()
+    contract_payload, invariant_payload = payloads
+    return _to_seed_contract(contract_payload, invariant_payload)


### PR DESCRIPTION
## Summary
- add a small governed contract loader for the canonical front-office seed
- update the front-office seeder to derive defaults and expectations from the governed contract path when available
- keep a deterministic fallback contract so lotus-core does not depend on lotus-platform being present
- add focused unit coverage for governed loading and fallback behavior

## Verification
- python -m pytest tests/unit/tools/test_front_office_portfolio_seed.py -q

## Notes
- scoped to RFC-0076 slice 2 contract enforcement groundwork
- keeps the implementation modular and avoids scattering more hard-coded contract constants