### PR TITLE
Register split E2E support fixtures

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,4 @@
+pytest_plugins = [
+    "tests.e2e.timeseries_support",
+    "tests.e2e.transaction_type_coverage_support",
+]


### PR DESCRIPTION
## Summary
- register the split E2E support modules through `tests/e2e/conftest.py`
- restore pytest fixture discovery for the split timeseries and transaction coverage suites
- unblock `Main Releasability / E2E Full` after the E2E suite split

## Root Cause
`test-e2e-all` was collecting split E2E modules whose fixtures lived in support modules, but those support modules were not loaded as pytest plugins during the full suite run. That left fixture names unresolved in main releasability.

## Validation
- `python -m pytest --collect-only tests\\e2e\\test_timeseries_contracts.py tests\\e2e\\test_transaction_type_coverage_matrix.py tests\\e2e\\test_transaction_type_dual_leg.py`
- `python -m ruff check tests\\e2e\\conftest.py`
- `python -m pytest tests\\e2e\\test_timeseries_contracts.py tests\\e2e\\test_transaction_type_coverage_matrix.py tests\\e2e\\test_transaction_type_dual_leg.py -q`