### PR TITLE
Add RFC-0087 trust telemetry snapshot

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -47,6 +47,9 @@ Current repository posture:
 17. RFC-0086 repo-native domain-product declarations now live under
     `contracts/domain-data-products/` and are validated by `make domain-product-validate` when the
     sibling `lotus-platform` validator and vocabulary registries are available.
+18. RFC-0087 trust telemetry proof for `PortfolioStateSnapshot` now lives under
+    `contracts/trust-telemetry/` and is validated by `tests/unit/test_trust_telemetry.py` against
+    the platform trust telemetry validator when `lotus-platform` is available.
 
 ## Architecture And Module Map
 
@@ -71,9 +74,11 @@ Primary areas:
 9. `contracts/domain-data-products/`
    Repo-native RFC-0086 domain-product producer declarations for governed `lotus-core` source-data
    products.
-10. `wiki/`
+10. `contracts/trust-telemetry/`
+    Repo-native RFC-0087 trust telemetry fixtures for governed first-wave source-data products.
+11. `wiki/`
    canonical authored source for GitHub wiki publication and core-owned operator and onboarding summaries.
-11. `docs/architecture/README.md`
+12. `docs/architecture/README.md`
     the primary navigation index for the deep core architecture and RFC hardening set.
 
 ## Runtime And Integration Boundaries

--- a/contracts/trust-telemetry/README.md
+++ b/contracts/trust-telemetry/README.md
@@ -1,0 +1,19 @@
+# Lotus Core Trust Telemetry
+
+This directory contains repo-owned RFC-0087 trust telemetry snapshots for governed `lotus-core`
+domain products.
+
+The current first-wave snapshot is:
+
+1. `portfolio-state-snapshot.telemetry.v1.json`
+   Runtime trust proof for `lotus-core:PortfolioStateSnapshot:v1`.
+
+Validate locally with:
+
+```powershell
+python -m pytest tests\unit\test_trust_telemetry.py -q
+```
+
+When `../lotus-platform` is available, the test validates the snapshot with the platform
+`automation/validate_trust_telemetry.py` contract validator and checks that observed trust metadata
+matches the repo-native declaration in `contracts/domain-data-products/lotus-core-products.v1.json`.

--- a/contracts/trust-telemetry/portfolio-state-snapshot.telemetry.v1.json
+++ b/contracts/trust-telemetry/portfolio-state-snapshot.telemetry.v1.json
@@ -1,0 +1,59 @@
+{
+  "contract_id": "lotus-domain-product-trust-telemetry-snapshot",
+  "contract_version": "1.0.0",
+  "governed_by_rfcs": [
+    "RFC-0087"
+  ],
+  "emitted_at_utc": "2026-04-19T00:00:00Z",
+  "product_id": "lotus-core:PortfolioStateSnapshot:v1",
+  "producer_repository": "lotus-core",
+  "product_name": "PortfolioStateSnapshot",
+  "product_version": "v1",
+  "source_repository": "lotus-core",
+  "freshness": {
+    "freshness_class": "daily",
+    "freshness_state": "current",
+    "evaluated_at_utc": "2026-04-19T00:00:00Z",
+    "observed_at_utc": "2026-04-19T00:00:00Z",
+    "age_seconds": 0,
+    "max_allowed_age_seconds": 86400
+  },
+  "completeness_status": "complete",
+  "reconciliation_status": "reconciled",
+  "data_quality_status": "quality_passed",
+  "lineage": {
+    "lineage_materialized": true,
+    "lineage_bundle_id": "lineage:lotus-core:portfolio-state-snapshot:2026-04-19",
+    "evidence_access_class": "customer_consumable",
+    "evidence_uris": [
+      "lotus-core://evidence/portfolio-state-snapshot/PB_SG_GLOBAL_BAL_001/2026-04-19"
+    ]
+  },
+  "blocking": {
+    "blocked": false
+  },
+  "observed_trust_metadata": {
+    "product_name": "PortfolioStateSnapshot",
+    "product_version": "v1",
+    "tenant_id": "TENANT_PRIVATE_BANKING_DEMO",
+    "generated_at": "2026-04-19T00:00:00Z",
+    "as_of_date": "2026-04-19",
+    "restatement_version": "restatement:2026-04-19:0",
+    "reconciliation_status": "reconciled",
+    "data_quality_status": "quality_passed",
+    "latest_evidence_timestamp": "2026-04-19T00:00:00Z",
+    "source_batch_fingerprint": "sha256:portfolio-state-snapshot-demo-batch",
+    "snapshot_id": "PB_SG_GLOBAL_BAL_001:2026-04-19",
+    "policy_version": "portfolio-state-snapshot-policy.v1",
+    "correlation_id": "rfc-0087-lotus-core-portfolio-state-snapshot"
+  },
+  "evidence": {
+    "correlation_id": "rfc-0087-lotus-core-portfolio-state-snapshot",
+    "validation_lanes": [
+      "feature",
+      "pr-merge"
+    ],
+    "source_event_id": "source-event:lotus-core:portfolio-state-snapshot:2026-04-19",
+    "source_artifact_uri": "lotus-core://contracts/trust-telemetry/portfolio-state-snapshot.telemetry.v1.json"
+  }
+}

--- a/tests/unit/test_trust_telemetry.py
+++ b/tests/unit/test_trust_telemetry.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLATFORM_ROOT = REPO_ROOT.parent / "lotus-platform"
+TELEMETRY_DIR = REPO_ROOT / "contracts" / "trust-telemetry"
+SNAPSHOT_PATH = TELEMETRY_DIR / "portfolio-state-snapshot.telemetry.v1.json"
+DECLARATION_PATH = REPO_ROOT / "contracts" / "domain-data-products" / "lotus-core-products.v1.json"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_platform_validator():
+    validator_path = PLATFORM_ROOT / "automation" / "validate_trust_telemetry.py"
+    if not validator_path.exists():
+        pytest.skip("lotus-platform trust telemetry validator is not available")
+    automation_path = str(PLATFORM_ROOT / "automation")
+    if automation_path not in sys.path:
+        sys.path.insert(0, automation_path)
+    return importlib.import_module("validate_trust_telemetry")
+
+
+def test_portfolio_state_snapshot_trust_telemetry_validates_with_platform_contract() -> None:
+    validator = _load_platform_validator()
+
+    issues = validator.validate_trust_telemetry_path(
+        TELEMETRY_DIR,
+        catalog_path=PLATFORM_ROOT / "generated" / "domain-product-catalog.json",
+    )
+
+    assert issues == []
+
+
+def test_portfolio_state_snapshot_trust_telemetry_is_tied_to_repo_declaration() -> None:
+    snapshot = _load_json(SNAPSHOT_PATH)
+    declaration = _load_json(DECLARATION_PATH)
+    declared_product = next(
+        product
+        for product in declaration["products"]
+        if product["product_name"] == "PortfolioStateSnapshot"
+    )
+
+    assert snapshot["product_id"] == "lotus-core:PortfolioStateSnapshot:v1"
+    assert snapshot["producer_repository"] == declaration["producer_repository"]
+    assert snapshot["product_name"] == declared_product["product_name"]
+    assert snapshot["product_version"] == declared_product["product_version"]
+    assert (
+        snapshot["freshness"]["freshness_class"]
+        == (declared_product["freshness_policy"]["freshness_class"])
+    )
+    assert set(snapshot["observed_trust_metadata"]) == set(
+        declared_product["required_trust_metadata"]
+    )
+    assert snapshot["lineage"]["lineage_materialized"] is True
+    assert (
+        snapshot["lineage"]["evidence_access_class"]
+        == (declared_product["lineage_policy"]["evidence_access_class_ref"])
+    )
+    assert snapshot["blocking"]["blocked"] is False


### PR DESCRIPTION
## Summary
- adds repo-owned RFC-0087 trust telemetry snapshot for `lotus-core:PortfolioStateSnapshot:v1`
- validates the snapshot against the platform trust telemetry contract when `lotus-platform` is available
- checks observed trust metadata against the repo-native domain-product declaration
- updates repository context and adds a short contract README

## Validation
- python -m pytest tests\\unit\\test_trust_telemetry.py -q
- python -m ruff check tests\\unit\\test_trust_telemetry.py
- python -m ruff format --check tests\\unit\\test_trust_telemetry.py
- make domain-product-validate
- make test
- platform: python automation\\validate_trust_telemetry.py C:\\Users\\Sandeep\\projects\\lotus-core\\contracts\\trust-telemetry
- platform combined live trust generation: 4 snapshots certified, 0 issues