### PR TITLE
docs(mesh): document mesh wiki posture

### DIFF
--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -1,0 +1,20 @@
+# Mesh Data Products
+
+## Mesh role
+
+`lotus-core` is a maturity-wave producer in the Lotus enterprise data mesh.
+
+## Governed product
+
+- Product ID: `lotus-core:PortfolioStateSnapshot:v1`
+- Product role: authoritative portfolio state snapshot for downstream performance, risk, advisory, reporting, management, gateway, and Workbench discovery flows
+- Source declaration: `contracts/domain-data-products/`
+- Trust telemetry: `contracts/trust-telemetry/`
+
+## Platform relationship
+
+`lotus-platform` aggregates the repo-native declaration, validates trust telemetry, applies mesh SLO/access/evidence policies, and includes this product in generated catalog, dependency graph, live certification, maturity matrix, evidence packs, and RFC-0092 operating reports.
+
+## Operating rule
+
+Do not duplicate product authority in gateway, Workbench, or platform. Changes to portfolio-state product identity, lifecycle, telemetry, or evidence must start in `lotus-core` and then pass platform mesh certification.

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -44,3 +44,5 @@
 ## Direction
 
 - [Roadmap](Roadmap)
+
+- [Mesh Data Products](Mesh-Data-Products)


### PR DESCRIPTION
Updates the authored repo wiki with an explicit Mesh Data Products page and sidebar link so the repo's published wiki can reflect the implemented Lotus mesh RFC posture. This is documentation-only; no runtime or API behavior changes.