### PR TITLE
Fix canonical front-office seed quiescence

### DIFF
--- a/docs/operations/Front-Office-Portfolio-Seed-Runbook.md
+++ b/docs/operations/Front-Office-Portfolio-Seed-Runbook.md
@@ -64,6 +64,7 @@ python tools/front_office_portfolio_seed.py `
 The tool ingests the portfolio bundle plus benchmark reference data and then
 verifies:
 
+- required cross-currency FX windows are queryable before transaction replay
 - positions are populated
 - valued positions are populated
 - transactions are populated

--- a/docs/operations/Front-Office-Portfolio-Seed-Runbook.md
+++ b/docs/operations/Front-Office-Portfolio-Seed-Runbook.md
@@ -17,6 +17,10 @@ Use this when you need one portfolio that exercises:
 
 This runbook is local-only and does not depend on `lotus-manage`.
 
+Routine front-office seeding is intentionally limited to `PB_SG_GLOBAL_BAL_001`. The governed
+RFC-086 bank-day load scenario with `1000` portfolios is separate load/performance tooling and is
+not part of canonical Workbench runtime bring-up.
+
 ## Seeded Portfolio
 
 - portfolio id: `PB_SG_GLOBAL_BAL_001`
@@ -108,6 +112,10 @@ available, check `portfolio_aggregation_jobs` for a pending backlog and
 `portfolio_timeseries` for a stale max date. The canonical readiness path
 requires portfolio aggregation to catch up before workbench validation or demo
 screenshots are accepted.
+
+If a prior local load or performance run polluted shared `lotus-core` Docker state, reset the
+Docker-backed core runtime before reseeding instead of broadening the seed cleanup SQL. The
+governed Workbench startup script accepts `-CleanCoreState` for this purpose.
 
 ## Related Documents
 

--- a/src/libs/portfolio-common/portfolio_common/valuation_repository_base.py
+++ b/src/libs/portfolio-common/portfolio_common/valuation_repository_base.py
@@ -154,6 +154,40 @@ class ValuationRepositoryBase:
         )
         return portfolio_ids
 
+    @async_timed(
+        repository="ValuationRepository", method="find_portfolios_first_holding_security_after_date"
+    )
+    async def find_portfolios_first_holding_security_after_date(
+        self, security_id: str, a_date: date
+    ) -> List[str]:
+        stmt = (
+            select(func.distinct(PositionHistory.portfolio_id))
+            .join(
+                PositionState,
+                and_(
+                    PositionState.portfolio_id == PositionHistory.portfolio_id,
+                    PositionState.security_id == PositionHistory.security_id,
+                    PositionState.epoch == PositionHistory.epoch,
+                ),
+            )
+            .where(
+                PositionHistory.security_id == security_id,
+                PositionHistory.position_date > a_date,
+                PositionHistory.quantity > 0,
+            )
+            .order_by(PositionHistory.portfolio_id.asc())
+        )
+
+        result = await self.db.execute(stmt)
+        portfolio_ids = result.scalars().all()
+        logger.info(
+            "Found %s portfolios first holding '%s' after %s.",
+            len(portfolio_ids),
+            security_id,
+            a_date,
+        )
+        return portfolio_ids
+
     @async_timed(repository="ValuationRepository", method="get_portfolios_by_ids")
     async def get_portfolios_by_ids(self, portfolio_ids: List[str]) -> List[Portfolio]:
         if not portfolio_ids:

--- a/src/services/valuation_orchestrator_service/app/core/reprocessing_worker.py
+++ b/src/services/valuation_orchestrator_service/app/core/reprocessing_worker.py
@@ -102,6 +102,13 @@ class ReprocessingWorker:
                                     earliest_date,
                                 )
                             )
+                            if not affected_portfolios:
+                                find_later_holdings = (
+                                    valuation_repo.find_portfolios_first_holding_security_after_date
+                                )
+                                affected_portfolios = (
+                                    await find_later_holdings(security_id, earliest_date)
+                                )
 
                             should_complete_job = True
 

--- a/tests/integration/services/valuation_orchestrator_service/test_replay_trigger_repository.py
+++ b/tests/integration/services/valuation_orchestrator_service/test_replay_trigger_repository.py
@@ -437,6 +437,77 @@ async def test_find_portfolios_holding_security_on_date_uses_latest_history_on_o
     assert portfolios_after_reopen == ["P_MIXED"]
 
 
+async def test_find_portfolios_first_holding_security_after_date_returns_later_open_positions(
+    async_db_session: AsyncSession, db_engine, clean_db
+):
+    """
+    GIVEN a portfolio that first opens a security after the replay impacted date
+    WHEN the worker fallback lookup runs
+    THEN the portfolio should still be targeted for watermark reset because the
+    earlier market data affects the first future-valued holding.
+    """
+    with Session(db_engine) as session:
+        session.add(
+            Portfolio(
+                portfolio_id="P_LATE_OPEN",
+                base_currency="USD",
+                open_date=date(2024, 1, 1),
+                risk_exposure="a",
+                investment_time_horizon="b",
+                portfolio_type="c",
+                booking_center_code="d",
+                client_id="e",
+                status="f",
+            )
+        )
+        session.flush()
+        session.add(
+            PositionState(
+                portfolio_id="P_LATE_OPEN",
+                security_id="S1",
+                epoch=0,
+                watermark_date=date(2025, 8, 12),
+                status="CURRENT",
+            )
+        )
+        session.add(
+            Transaction(
+                transaction_id="TX-LATE-OPEN",
+                portfolio_id="P_LATE_OPEN",
+                instrument_id="I-S1",
+                security_id="S1",
+                transaction_type="BUY",
+                quantity=Decimal("100"),
+                price=Decimal("1"),
+                gross_transaction_amount=Decimal("100"),
+                trade_currency="USD",
+                currency="USD",
+                transaction_date=datetime(2025, 8, 11, 9, 0, 0),
+            )
+        )
+        session.flush()
+        session.add(
+            PositionHistory(
+                portfolio_id="P_LATE_OPEN",
+                security_id="S1",
+                transaction_id="TX-LATE-OPEN",
+                epoch=0,
+                position_date=date(2025, 8, 11),
+                quantity=100,
+                cost_basis=Decimal("100"),
+            )
+        )
+        session.commit()
+
+    repo = ValuationRepository(async_db_session)
+
+    portfolios = await repo.find_portfolios_first_holding_security_after_date(
+        "S1", date(2025, 8, 10)
+    )
+
+    assert portfolios == ["P_LATE_OPEN"]
+
+
 async def test_find_portfolios_holding_security_on_date_ignores_stale_epochs(
     async_db_session: AsyncSession, db_engine, clean_db
 ):

--- a/tests/unit/services/valuation_orchestrator_service/core/test_reprocessing_worker.py
+++ b/tests/unit/services/valuation_orchestrator_service/core/test_reprocessing_worker.py
@@ -289,6 +289,7 @@ async def test_worker_requeues_job_when_no_impacted_portfolios_are_visible_yet(
     mock_repro_job_repo.find_and_claim_jobs.return_value = [pending_job]
     mock_repro_job_repo.update_job_status.return_value = True
     mock_valuation_repo.find_portfolios_holding_security_on_date.return_value = []
+    mock_valuation_repo.find_portfolios_first_holding_security_after_date.return_value = []
 
     await worker._process_batch()
 
@@ -300,6 +301,49 @@ async def test_worker_requeues_job_when_no_impacted_portfolios_are_visible_yet(
     mock_observe_completed.assert_not_called()
     mock_observe_stale_skips.assert_not_called()
     mock_repro_job_repo.update_job_status.assert_awaited_once_with(19, "PENDING")
+
+
+async def test_worker_falls_back_to_later_first_holdings_before_requeueing(
+    mock_dependencies,
+):
+    worker = ReprocessingWorker(poll_interval=0.1)
+    mock_repro_job_repo = mock_dependencies["repro_job_repo"]
+    mock_valuation_repo = mock_dependencies["valuation_repo"]
+    mock_state_repo = mock_dependencies["state_repo"]
+    mock_observe_completed = mock_dependencies["observe_completed"]
+    mock_observe_noop = mock_dependencies["observe_noop"]
+
+    pending_job = ReprocessingJob(
+        id=20,
+        job_type="RESET_WATERMARKS",
+        payload={"security_id": "S1", "earliest_impacted_date": "2025-08-10"},
+        status="PENDING",
+    )
+
+    mock_repro_job_repo.find_and_reset_stale_jobs.return_value = 0
+    mock_repro_job_repo.find_and_claim_jobs.return_value = [pending_job]
+    mock_repro_job_repo.update_job_status.return_value = True
+    mock_valuation_repo.find_portfolios_holding_security_on_date.return_value = []
+    mock_valuation_repo.find_portfolios_first_holding_security_after_date.return_value = ["P_LATE"]
+    mock_state_repo.update_watermarks_if_older.return_value = 1
+
+    await worker._process_batch()
+
+    mock_valuation_repo.find_portfolios_holding_security_on_date.assert_awaited_once_with(
+        "S1",
+        date(2025, 8, 10),
+    )
+    mock_valuation_repo.find_portfolios_first_holding_security_after_date.assert_awaited_once_with(
+        "S1",
+        date(2025, 8, 10),
+    )
+    mock_state_repo.update_watermarks_if_older.assert_awaited_once_with(
+        keys=[("P_LATE", "S1")],
+        new_watermark_date=date(2025, 8, 9),
+    )
+    mock_observe_noop.assert_not_called()
+    mock_observe_completed.assert_called_once_with("RESET_WATERMARKS")
+    mock_repro_job_repo.update_job_status.assert_awaited_once_with(20, "COMPLETE")
 
 
 async def test_worker_skips_completion_metric_when_terminal_ownership_is_lost(mock_dependencies):
@@ -353,6 +397,7 @@ async def test_worker_emits_requeue_ownership_metric_when_requeue_ownership_is_l
     mock_repro_job_repo.find_and_claim_jobs.return_value = [pending_job]
     mock_repro_job_repo.update_job_status.return_value = False
     mock_valuation_repo.find_portfolios_holding_security_on_date.return_value = []
+    mock_valuation_repo.find_portfolios_first_holding_security_after_date.return_value = []
 
     await worker._process_batch()
 

--- a/tests/unit/tools/test_front_office_portfolio_seed.py
+++ b/tests/unit/tools/test_front_office_portfolio_seed.py
@@ -113,7 +113,9 @@ def test_front_office_bundle_honors_explicit_end_date_for_market_prices():
     )
 
     aapl_prices = [
-        row["price_date"] for row in bundle["market_prices"] if row["security_id"] == "FO_EQ_AAPL_US"
+        row["price_date"]
+        for row in bundle["market_prices"]
+        if row["security_id"] == "FO_EQ_AAPL_US"
     ]
     cash_prices = [
         row["price_date"]
@@ -406,14 +408,15 @@ def test_portfolio_seed_cleanup_sql_removes_portfolio_owned_state_before_reseed(
     assert "delete from cash_account_masters where portfolio_id = 'PB_SG_GLOBAL_BAL_001';" in sql
     assert "delete from portfolios where portfolio_id = 'PB_SG_GLOBAL_BAL_001';" in sql
     assert "delete from transaction_costs where transaction_id in" in sql
-    assert "service_name = 'position-calculator'" in sql
-    assert "event_id like 'transaction_processing.ready-%'" in sql
-    assert "event_id like 'transactions.cost.processed-%'" in sql
-    assert "service_name = 'cost-calculator'" in sql
-    assert "service_name = 'cashflow-calculator'" in sql
-    assert "service_name = 'pipeline-orchestrator-processed-txn'" in sql
-    assert "service_name = 'persistence-portfolios'" in sql
-    assert "event_id like 'portfolios.raw.received-%'" in sql
+    assert "delete from reprocessing_jobs;" not in sql
+    assert "service_name = 'position-calculator'" not in sql
+    assert "event_id like 'transaction_processing.ready-%'" not in sql
+    assert "event_id like 'transactions.cost.processed-%'" not in sql
+    assert "service_name = 'cost-calculator'" not in sql
+    assert "service_name = 'cashflow-calculator'" not in sql
+    assert "service_name = 'pipeline-orchestrator-processed-txn'" not in sql
+    assert "service_name = 'persistence-portfolios'" not in sql
+    assert "event_id like 'portfolios.raw.received-%'" not in sql
 
 
 def test_front_office_seed_ingests_core_data_in_parent_first_order(monkeypatch):

--- a/tests/unit/tools/test_front_office_portfolio_seed.py
+++ b/tests/unit/tools/test_front_office_portfolio_seed.py
@@ -15,10 +15,12 @@ from tools.front_office_portfolio_seed import (
     _front_office_analytics_are_fresh,
     _ingest_front_office_core_data,
     _reprocess_front_office_transactions,
+    _required_cross_currency_fx_windows,
     _validate_front_office_cash_transactions,
     _validate_front_office_internal_transaction_pairs,
     _verify_front_office_portfolio,
     _wait_for_portfolio_persistence,
+    _wait_for_required_fx_readiness,
     build_front_office_portfolio_bundle,
     build_front_office_seed_cleanup_sql,
     build_portfolio_seed_cleanup_sql,
@@ -423,6 +425,7 @@ def test_front_office_seed_ingests_core_data_in_parent_first_order(monkeypatch):
     bundle = _build_bundle()
     calls = []
     waits = []
+    fx_waits = []
 
     def capture_request(method, url, *, payload=None):
         calls.append((method, url, payload))
@@ -435,6 +438,10 @@ def test_front_office_seed_ingests_core_data_in_parent_first_order(monkeypatch):
     monkeypatch.setattr(
         "tools.front_office_portfolio_seed._wait_for_portfolio_persistence",
         capture_wait,
+    )
+    monkeypatch.setattr(
+        "tools.front_office_portfolio_seed._wait_for_required_fx_readiness",
+        lambda **kwargs: fx_waits.append(kwargs),
     )
 
     _ingest_front_office_core_data(
@@ -462,6 +469,88 @@ def test_front_office_seed_ingests_core_data_in_parent_first_order(monkeypatch):
             "poll_interval_seconds": 3,
         }
     ]
+    assert fx_waits == [
+        {
+            "query_base_url": "http://query.dev.lotus",
+            "bundle": bundle,
+            "wait_seconds": 90,
+            "poll_interval_seconds": 3,
+        }
+    ]
+
+
+def test_front_office_seed_derives_required_cross_currency_fx_windows():
+    bundle = _build_bundle()
+
+    assert _required_cross_currency_fx_windows(bundle) == [
+        ("EUR", "USD", "2025-04-02", "2025-07-27")
+    ]
+
+
+def test_front_office_seed_waits_for_required_fx_readiness(monkeypatch):
+    bundle = _build_bundle()
+    observed_urls = []
+    responses = iter(
+        [
+            (200, {"rates": [{"rate_date": "2025-04-20", "rate": "1.074352"}]}),
+            (
+                200,
+                {
+                    "rates": [
+                        {"rate_date": "2025-04-02", "rate": "1.072685"},
+                        {"rate_date": "2025-07-27", "rate": "1.081000"},
+                    ]
+                },
+            ),
+        ]
+    )
+
+    def fake_request(method, url, *, payload=None):
+        observed_urls.append((method, url, payload))
+        return next(responses)
+
+    monkeypatch.setattr("tools.front_office_portfolio_seed._request_json", fake_request)
+    monkeypatch.setattr("tools.front_office_portfolio_seed.time.sleep", lambda _: None)
+
+    _wait_for_required_fx_readiness(
+        query_base_url="http://query.dev.lotus",
+        bundle=bundle,
+        wait_seconds=1,
+        poll_interval_seconds=0,
+    )
+
+    assert observed_urls == [
+        (
+            "GET",
+            "http://query.dev.lotus/fx-rates/"
+            "?from_currency=EUR&to_currency=USD&start_date=2025-04-02&end_date=2025-07-27",
+            None,
+        ),
+        (
+            "GET",
+            "http://query.dev.lotus/fx-rates/"
+            "?from_currency=EUR&to_currency=USD&start_date=2025-04-02&end_date=2025-07-27",
+            None,
+        ),
+    ]
+
+
+def test_front_office_seed_wait_for_required_fx_readiness_times_out(monkeypatch):
+    bundle = _build_bundle()
+
+    monkeypatch.setattr(
+        "tools.front_office_portfolio_seed._request_json",
+        lambda method, url, *, payload=None: (200, {"rates": []}),
+    )
+    monkeypatch.setattr("tools.front_office_portfolio_seed.time.sleep", lambda _: None)
+
+    with pytest.raises(RuntimeError, match="Timed out waiting for FX readiness"):
+        _wait_for_required_fx_readiness(
+            query_base_url="http://query.dev.lotus",
+            bundle=bundle,
+            wait_seconds=0,
+            poll_interval_seconds=0,
+        )
 
 
 def test_front_office_seed_verifies_against_canonical_gateway_by_default(monkeypatch):

--- a/tools/front_office_portfolio_seed.py
+++ b/tools/front_office_portfolio_seed.py
@@ -1406,6 +1406,109 @@ def _ingest_reference_data(ingestion_base_url: str, bundle: dict[str, Any]) -> N
         _request_json("POST", f"{ingestion_base_url}{endpoint}", payload=payload)
 
 
+def _required_cross_currency_fx_windows(bundle: dict[str, Any]) -> list[tuple[str, str, str, str]]:
+    portfolios = {
+        row["portfolio_id"]: row["base_currency"]
+        for row in bundle.get("portfolios", [])
+        if isinstance(row, dict)
+        and isinstance(row.get("portfolio_id"), str)
+        and isinstance(row.get("base_currency"), str)
+    }
+    windows: dict[tuple[str, str], tuple[date, date]] = {}
+
+    for transaction in bundle.get("transactions", []):
+        if not isinstance(transaction, dict):
+            continue
+        portfolio_id = transaction.get("portfolio_id")
+        trade_currency = transaction.get("trade_currency")
+        transaction_date = transaction.get("transaction_date")
+        if (
+            not isinstance(portfolio_id, str)
+            or not isinstance(trade_currency, str)
+            or not isinstance(transaction_date, str)
+        ):
+            continue
+        portfolio_base_currency = portfolios.get(portfolio_id)
+        if portfolio_base_currency is None or trade_currency == portfolio_base_currency:
+            continue
+        transaction_business_date = datetime.fromisoformat(
+            transaction_date.replace("Z", "+00:00")
+        ).date()
+        pair = (trade_currency, portfolio_base_currency)
+        current_window = windows.get(pair)
+        if current_window is None:
+            windows[pair] = (transaction_business_date, transaction_business_date)
+            continue
+        windows[pair] = (
+            min(current_window[0], transaction_business_date),
+            max(current_window[1], transaction_business_date),
+        )
+
+    return [
+        (
+            from_currency,
+            to_currency,
+            window_start.isoformat(),
+            window_end.isoformat(),
+        )
+        for (from_currency, to_currency), (window_start, window_end) in sorted(windows.items())
+    ]
+
+
+def _fx_window_is_covered(
+    actual_rates: list[dict[str, Any]], expected_start: str, expected_end: str
+) -> bool:
+    if not actual_rates:
+        return False
+    expected_start_date = date.fromisoformat(expected_start)
+    expected_end_date = date.fromisoformat(expected_end)
+    actual_dates = sorted(
+        date.fromisoformat(rate["rate_date"])
+        for rate in actual_rates
+        if isinstance(rate, dict) and isinstance(rate.get("rate_date"), str)
+    )
+    if not actual_dates:
+        return False
+    return actual_dates[0] <= expected_start_date and actual_dates[-1] >= expected_end_date
+
+
+def _wait_for_required_fx_readiness(
+    *,
+    query_base_url: str,
+    bundle: dict[str, Any],
+    wait_seconds: int,
+    poll_interval_seconds: int,
+) -> None:
+    required_windows = _required_cross_currency_fx_windows(bundle)
+    if not required_windows:
+        return
+
+    deadline = datetime.now(tz=UTC) + timedelta(seconds=wait_seconds)
+    pending = required_windows
+    while datetime.now(tz=UTC) < deadline:
+        still_pending: list[tuple[str, str, str, str]] = []
+        for from_currency, to_currency, start_date, end_date in pending:
+            _, payload = _request_json(
+                "GET",
+                f"{query_base_url}/fx-rates/"
+                f"?from_currency={from_currency}&to_currency={to_currency}"
+                f"&start_date={start_date}&end_date={end_date}",
+            )
+            rates = payload.get("rates") or []
+            if not _fx_window_is_covered(rates, start_date, end_date):
+                still_pending.append((from_currency, to_currency, start_date, end_date))
+        if not still_pending:
+            return
+        time.sleep(poll_interval_seconds)
+        pending = still_pending
+
+    outstanding = ", ".join(
+        f"{from_currency}->{to_currency} {start_date}..{end_date}"
+        for from_currency, to_currency, start_date, end_date in pending
+    )
+    raise RuntimeError(f"Timed out waiting for FX readiness: {outstanding}")
+
+
 def _ingest_front_office_core_data(
     *,
     ingestion_base_url: str,
@@ -1430,6 +1533,13 @@ def _ingest_front_office_core_data(
             _wait_for_portfolio_persistence(
                 query_base_url=query_base_url,
                 portfolio_id=portfolio_id,
+                wait_seconds=wait_seconds,
+                poll_interval_seconds=poll_interval_seconds,
+            )
+        if endpoint == "/ingest/fx-rates":
+            _wait_for_required_fx_readiness(
+                query_base_url=query_base_url,
+                bundle=bundle,
                 wait_seconds=wait_seconds,
                 poll_interval_seconds=poll_interval_seconds,
             )

--- a/tools/front_office_portfolio_seed.py
+++ b/tools/front_office_portfolio_seed.py
@@ -37,20 +37,6 @@ DEFAULT_BENCHMARK_COMPONENT_INDEX_IDS = (
     "IDX_GLOBAL_BOND_TR",
 )
 
-GLOBAL_PROCESSED_EVENT_RESET_PATTERNS = (
-    ("position-calculator", "transaction_processing.ready-%"),
-    ("position-calculator", "transactions.cost.processed-%"),
-    ("cost-calculator", "transactions.persisted-%"),
-    ("cashflow-calculator", "transactions.persisted-%"),
-    ("cashflow-calculator", "transactions.cost.processed-%"),
-    ("pipeline-orchestrator-processed-txn", "transactions.cost.processed-%"),
-    ("persistence-portfolios", "portfolios.raw.received-%"),
-    ("persistence-instruments", "instruments.received-%"),
-    ("persistence-market-prices", "market_prices.raw.received-%"),
-    ("persistence-fx-rates", "fx_rates.raw.received-%"),
-    ("persistence-business-dates", "business_dates.raw.received-%"),
-)
-
 
 @dataclass(frozen=True)
 class FrontOfficePortfolioExpectation:
@@ -136,17 +122,11 @@ def build_portfolio_seed_cleanup_sql(*, portfolio_id: str) -> str:
     """
     Build the destructive local reseed cleanup SQL for the canonical front-office seed.
 
-    The global processed-event reset is intentionally broader than a single portfolio because
-    local Docker restarts can reset Kafka offsets while the persisted idempotency table survives.
-    For shared raw-topic services that key idempotency by topic/partition/offset only, a clean
-    local reseed must clear those offset-based markers or the canonical ingest will be skipped.
+    This cleanup stays scoped to portfolio-owned rows only. If a local Docker-backed runtime has
+    stale shared Kafka, idempotency, or replay state from a prior load or performance run, reset
+    the lotus-core Docker state before reseeding instead of deleting shared runtime tables from the
+    front-office seed tool.
     """
-    global_processed_event_filter = " or ".join(
-        (
-            f"(service_name = '{service_name}' and event_id like '{event_pattern}')"
-            for service_name, event_pattern in GLOBAL_PROCESSED_EVENT_RESET_PATTERNS
-        )
-    )
     return "\n".join(
         [
             (
@@ -173,7 +153,6 @@ def build_portfolio_seed_cleanup_sql(*, portfolio_id: str) -> str:
             ),
             f"delete from pipeline_stage_state where portfolio_id = '{portfolio_id}';",
             f"delete from processed_events where portfolio_id = '{portfolio_id}';",
-            (f"delete from processed_events where ({global_processed_event_filter});"),
             f"delete from cash_account_masters where portfolio_id = '{portfolio_id}';",
             f"delete from portfolio_benchmark_assignments where portfolio_id = '{portfolio_id}';",
             f"delete from transactions where portfolio_id = '{portfolio_id}';",


### PR DESCRIPTION
## Summary
- keep canonical front-office reseed cleanup scoped to portfolio-owned state instead of deleting shared runtime idempotency markers
- wait for required cross-currency FX windows before replaying canonical transactions
- target later-opened holdings during valuation reprocessing so upstream market-data repairs reset the right watermarks
- document that the 1000-portfolio scenario belongs to load/performance testing, not routine Workbench bring-up

## Validation
- `python -m pytest tests\unit\tools\test_front_office_portfolio_seed.py tests\unit\services\valuation_orchestrator_service\core\test_reprocessing_worker.py tests\integration\services\valuation_orchestrator_service\test_replay_trigger_repository.py -q`
- `python -m ruff check tools\front_office_portfolio_seed.py src\libs\portfolio-common\portfolio_common\valuation_repository_base.py src\services\valuation_orchestrator_service\app\core\reprocessing_worker.py tests\unit\tools\test_front_office_portfolio_seed.py tests\unit\services\valuation_orchestrator_service\core\test_reprocessing_worker.py tests\integration\services\valuation_orchestrator_service\test_replay_trigger_repository.py`
- `git diff --check main...feature/rfc0033-front-office-seed-quiescence`