### PR TITLE
Fix holdings replay valuation convergence

### DIFF
--- a/constraints/shared-build-constraints.txt
+++ b/constraints/shared-build-constraints.txt
@@ -1,7 +1,7 @@
 pydantic==2.12.5
 confluent-kafka==2.12.0
 sqlalchemy==2.0.46
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 asyncpg==0.30.0
 psycopg2-binary==2.9.10
 tenacity==8.2.3

--- a/requirements/shared-runtime.in
+++ b/requirements/shared-runtime.in
@@ -12,7 +12,7 @@ prometheus-fastapi-instrumentator==7.1.0
 psycopg2-binary==2.9.10
 pydantic==2.12.5
 python-dateutil==2.9.0.post0
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 python-json-logger==2.0.7
 python-multipart==0.0.26
 sqlalchemy==2.0.46

--- a/requirements/shared-runtime.lock.txt
+++ b/requirements/shared-runtime.lock.txt
@@ -71,7 +71,7 @@ pydantic-core==2.41.5
     # via pydantic
 python-dateutil==2.9.0.post0
     # via -r C:/Users/Sandeep/projects/lotus-core/requirements/shared-runtime.in
-python-dotenv==1.0.1
+python-dotenv==1.2.2
     # via
     #   -r C:/Users/Sandeep/projects/lotus-core/requirements/shared-runtime.in
     #   uvicorn

--- a/src/libs/portfolio-common/portfolio_common/valuation_repository_base.py
+++ b/src/libs/portfolio-common/portfolio_common/valuation_repository_base.py
@@ -298,6 +298,19 @@ class ValuationRepositoryBase:
             .correlate(*correlate_targets)
             .subquery("date_series")
         )
+        latest_history_quantity_for_snapshot = (
+            select(PositionHistory.quantity)
+            .where(
+                PositionHistory.portfolio_id == dps.portfolio_id,
+                PositionHistory.security_id == dps.security_id,
+                PositionHistory.epoch == dps.epoch,
+                PositionHistory.position_date <= dps.date,
+            )
+            .order_by(PositionHistory.position_date.desc(), PositionHistory.id.desc())
+            .limit(1)
+            .correlate(dps)
+            .scalar_subquery()
+        )
 
         first_gap_subq = (
             (
@@ -308,7 +321,8 @@ class ValuationRepositoryBase:
                         (dps.portfolio_id == s.portfolio_id)
                         & (dps.security_id == s.security_id)
                         & (dps.epoch == s.epoch)
-                        & (dps.date == date_series_subq.c.expected_date),
+                        & (dps.date == date_series_subq.c.expected_date)
+                        & (dps.quantity == latest_history_quantity_for_snapshot),
                     )
                 )
                 .where(dps.id.is_(None))
@@ -323,6 +337,7 @@ class ValuationRepositoryBase:
                     (dps.portfolio_id == s.portfolio_id)
                     & (dps.security_id == s.security_id)
                     & (dps.epoch == s.epoch)
+                    & (dps.quantity == latest_history_quantity_for_snapshot)
                 )
             )
             .correlate(s)

--- a/src/libs/portfolio-common/pyproject.toml
+++ b/src/libs/portfolio-common/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "pydantic==2.12.5",
     "confluent-kafka==2.12.0",
     "SQLAlchemy==2.0.46",
-    "python-dotenv==1.0.1",
+    "python-dotenv==1.2.2",
     "asyncpg==0.30.0",
     "psycopg2-binary==2.9.10",
     "tenacity==8.2.3",

--- a/src/libs/portfolio-common/requirements.txt
+++ b/src/libs/portfolio-common/requirements.txt
@@ -15,7 +15,7 @@ psycopg2-binary==2.9.9
 asyncpg==0.29.0
 
 # Environment variable management
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 
 # Docker testcontainers for E2E and integration tests
 testcontainers[kafka,postgres]==4.5.0

--- a/src/services/calculators/cashflow_calculator_service/pyproject.toml
+++ b/src/services/calculators/cashflow_calculator_service/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "confluent-kafka==2.12.0",
     "pydantic==2.12.5",
     "tenacity==8.2.3",
-    "python-dotenv==1.0.1",
+    "python-dotenv==1.2.2",
     "fastapi==0.129.0",
     "uvicorn[standard]==0.35.0",
     "prometheus-fastapi-instrumentator==7.1.0"

--- a/src/services/calculators/cashflow_calculator_service/requirements.txt
+++ b/src/services/calculators/cashflow_calculator_service/requirements.txt
@@ -3,4 +3,4 @@ psycopg2-binary==2.9.9
 confluent-kafka==2.4.0
 pydantic==2.7.4
 tenacity==8.2.3
-python-dotenv==1.0.1
+python-dotenv==1.2.2

--- a/src/services/calculators/position_calculator/app/core/position_logic.py
+++ b/src/services/calculators/position_calculator/app/core/position_logic.py
@@ -152,6 +152,23 @@ class PositionCalculator:
 
         if new_positions:
             await repo.save_positions(new_positions)
+            updated_count = await position_state_repo.update_watermarks_if_older(
+                keys=[(portfolio_id, security_id)],
+                new_watermark_date=transaction_date - timedelta(days=1),
+            )
+            if updated_count:
+                logger.info(
+                    "Re-armed valuation and timeseries generation after position history write.",
+                    extra={
+                        "portfolio_id": portfolio_id,
+                        "security_id": security_id,
+                        "epoch": message_epoch,
+                        "transaction_date": transaction_date.isoformat(),
+                        "new_watermark_date": (
+                            transaction_date - timedelta(days=1)
+                        ).isoformat(),
+                    },
+                )
 
         logger.info(
             f"[Calculate] Staged {len(new_positions)} position records for Epoch {message_epoch}"

--- a/src/services/calculators/position_calculator/pyproject.toml
+++ b/src/services/calculators/position_calculator/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "confluent-kafka==2.12.0",
     "pydantic==2.12.5",
     "tenacity==8.2.3",
-    "python-dotenv==1.0.1",
+    "python-dotenv==1.2.2",
     "fastapi==0.129.0",
     "uvicorn[standard]==0.35.0",
     "prometheus-fastapi-instrumentator==7.1.0"

--- a/src/services/calculators/position_valuation_calculator/pyproject.toml
+++ b/src/services/calculators/position_valuation_calculator/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "confluent-kafka==2.12.0",
     "pydantic==2.12.5",
     "tenacity==8.2.3",
-    "python-dotenv==1.0.1",
+    "python-dotenv==1.2.2",
     "fastapi==0.129.0",
     "uvicorn[standard]==0.35.0",
     "prometheus-fastapi-instrumentator==7.1.0"

--- a/src/services/event_replay_service/pyproject.toml
+++ b/src/services/event_replay_service/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "sqlalchemy==2.0.46",
     "asyncpg==0.30.0",
     "pydantic==2.12.5",
-    "python-dotenv==1.0.1",
+    "python-dotenv==1.2.2",
     "prometheus-fastapi-instrumentator==7.1.0",
     "python-dateutil==2.9.0.post0",
     "httpx==0.28.1"

--- a/src/services/financial_reconciliation_service/pyproject.toml
+++ b/src/services/financial_reconciliation_service/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "confluent-kafka==2.12.0",
     "tenacity==8.2.3",
     "pydantic==2.12.5",
-    "python-dotenv==1.0.1",
+    "python-dotenv==1.2.2",
     "prometheus-fastapi-instrumentator==7.1.0",
     "httpx==0.28.1"
 ]

--- a/src/services/persistence_service/pyproject.toml
+++ b/src/services/persistence_service/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "pydantic==2.12.5",
     "tenacity==8.2.3",
     "alembic==1.13.1",
-    "python-dotenv==1.0.1",
+    "python-dotenv==1.2.2",
     "structlog==24.1.0",
     "python-json-logger==2.0.7",
     "fastapi==0.129.0",

--- a/src/services/pipeline_orchestrator_service/pyproject.toml
+++ b/src/services/pipeline_orchestrator_service/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "confluent-kafka==2.12.0",
     "pydantic==2.12.5",
     "tenacity==8.2.3",
-    "python-dotenv==1.0.1",
+    "python-dotenv==1.2.2",
     "structlog==24.1.0",
     "python-json-logger==2.0.7",
     "fastapi==0.129.0",

--- a/src/services/portfolio_aggregation_service/pyproject.toml
+++ b/src/services/portfolio_aggregation_service/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "confluent-kafka==2.12.0",
     "pydantic==2.12.5",
     "tenacity==8.2.3",
-    "python-dotenv==1.0.1",
+    "python-dotenv==1.2.2",
     "fastapi==0.129.0",
     "uvicorn[standard]==0.35.0",
     "prometheus-fastapi-instrumentator==7.1.0"

--- a/src/services/query_control_plane_service/pyproject.toml
+++ b/src/services/query_control_plane_service/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "sqlalchemy==2.0.46",
     "asyncpg==0.30.0",
     "pydantic==2.12.5",
-    "python-dotenv==1.0.1",
+    "python-dotenv==1.2.2",
     "prometheus-fastapi-instrumentator==7.1.0",
     "python-dateutil==2.9.0.post0",
     "httpx==0.28.1"

--- a/src/services/query_service/app/dtos/transaction_dto.py
+++ b/src/services/query_service/app/dtos/transaction_dto.py
@@ -224,6 +224,14 @@ class TransactionRecord(BaseModel):
         ),
         examples=[-512.8],
     )
+    realized_gain_loss_reporting_currency: Optional[Decimal] = Field(
+        None,
+        description=(
+            "Transaction-level realized gain/loss restated into the requested reporting "
+            "currency when `reporting_currency` is supplied on the route."
+        ),
+        examples=[500.0],
+    )
     withholding_tax_amount_reporting_currency: Optional[Decimal] = Field(
         None,
         description=(

--- a/src/services/query_service/app/repositories/analytics_timeseries_repository.py
+++ b/src/services/query_service/app/repositories/analytics_timeseries_repository.py
@@ -12,6 +12,8 @@ from portfolio_common.database_models import (
     Instrument,
     Portfolio,
     PortfolioTimeseries,
+    PositionHistory,
+    PositionState,
     PositionTimeseries,
 )
 from sqlalchemy import and_, func, or_, select
@@ -203,6 +205,7 @@ class AnalyticsTimeseriesRepository:
         ]
         if snapshot_epoch is not None:
             predicates.append(PositionTimeseries.epoch <= snapshot_epoch)
+        latest_history_quantity = self._latest_current_position_history_quantity()
         ranked = (
             select(
                 PositionTimeseries.security_id.label("security_id"),
@@ -227,8 +230,17 @@ class AnalyticsTimeseriesRepository:
                 )
                 .label("rn"),
             )
+            .select_from(PositionTimeseries)
+            .join(
+                PositionState,
+                and_(
+                    PositionTimeseries.portfolio_id == PositionState.portfolio_id,
+                    PositionTimeseries.security_id == PositionState.security_id,
+                    PositionTimeseries.epoch == PositionState.epoch,
+                ),
+            )
             .join(Instrument, Instrument.security_id == PositionTimeseries.security_id)
-            .where(*predicates)
+            .where(*predicates, PositionTimeseries.quantity == latest_history_quantity)
             .subquery()
         )
 
@@ -286,6 +298,7 @@ class AnalyticsTimeseriesRepository:
         if snapshot_epoch is not None:
             predicates.append(PositionTimeseries.epoch <= snapshot_epoch)
 
+        latest_history_quantity = self._latest_current_position_history_quantity()
         ranked = (
             select(
                 PositionTimeseries.security_id.label("security_id"),
@@ -308,8 +321,17 @@ class AnalyticsTimeseriesRepository:
                 )
                 .label("rn"),
             )
+            .select_from(PositionTimeseries)
+            .join(
+                PositionState,
+                and_(
+                    PositionTimeseries.portfolio_id == PositionState.portfolio_id,
+                    PositionTimeseries.security_id == PositionState.security_id,
+                    PositionTimeseries.epoch == PositionState.epoch,
+                ),
+            )
             .join(Instrument, Instrument.security_id == PositionTimeseries.security_id)
-            .where(*predicates)
+            .where(*predicates, PositionTimeseries.quantity == latest_history_quantity)
             .subquery()
         )
 
@@ -340,6 +362,7 @@ class AnalyticsTimeseriesRepository:
         if snapshot_epoch is not None:
             predicates.append(PositionTimeseries.epoch <= snapshot_epoch)
 
+        latest_history_quantity = self._latest_current_position_history_quantity()
         ranked = (
             select(
                 PositionTimeseries.security_id.label("security_id"),
@@ -353,13 +376,38 @@ class AnalyticsTimeseriesRepository:
                 )
                 .label("rn"),
             )
-            .where(*predicates)
+            .select_from(PositionTimeseries)
+            .join(
+                PositionState,
+                and_(
+                    PositionTimeseries.portfolio_id == PositionState.portfolio_id,
+                    PositionTimeseries.security_id == PositionState.security_id,
+                    PositionTimeseries.epoch == PositionState.epoch,
+                ),
+            )
+            .where(*predicates, PositionTimeseries.quantity == latest_history_quantity)
             .subquery()
         )
 
         stmt = select(ranked).where(ranked.c.rn == 1).order_by(ranked.c.security_id.asc())
         result = await self.db.execute(stmt)
         return result.all()
+
+    @staticmethod
+    def _latest_current_position_history_quantity():
+        return (
+            select(PositionHistory.quantity)
+            .where(
+                PositionHistory.portfolio_id == PositionTimeseries.portfolio_id,
+                PositionHistory.security_id == PositionTimeseries.security_id,
+                PositionHistory.epoch == PositionState.epoch,
+                PositionHistory.position_date <= PositionTimeseries.date,
+            )
+            .order_by(PositionHistory.position_date.desc(), PositionHistory.id.desc())
+            .limit(1)
+            .correlate(PositionTimeseries, PositionState)
+            .scalar_subquery()
+        )
 
     async def list_position_cashflow_rows(
         self,

--- a/src/services/query_service/app/repositories/position_repository.py
+++ b/src/services/query_service/app/repositories/position_repository.py
@@ -189,16 +189,26 @@ class PositionRepository:
 
     async def get_latest_positions_by_portfolio(self, portfolio_id: str) -> List[Any]:
         """
-        Retrieves the single latest daily snapshot for each security in a given portfolio,
-        ensuring that the snapshot belongs to the current epoch for that security.
+        Retrieves the latest daily snapshot for each current open position.
+
+        Position history is the authoritative booked quantity stream. Snapshots can be
+        produced asynchronously and may temporarily contain stale carried quantities after
+        replay. To avoid exposing a stale completed snapshot as a live holding, only
+        return snapshots whose quantity reconciles to the latest current-epoch history row.
         It eagerly loads the related Instrument and PositionState data.
         """
+        latest_history_subq = self._latest_current_position_history_subquery(
+            portfolio_id=portfolio_id,
+        )
         ranked_snapshot_subq = (
             select(
                 DailyPositionSnapshot.id.label("snapshot_id"),
                 func.row_number()
                 .over(
-                    partition_by=DailyPositionSnapshot.security_id,
+                    partition_by=(
+                        DailyPositionSnapshot.portfolio_id,
+                        DailyPositionSnapshot.security_id,
+                    ),
                     order_by=(
                         DailyPositionSnapshot.date.desc(),
                         DailyPositionSnapshot.id.desc(),
@@ -207,14 +217,20 @@ class PositionRepository:
                 .label("rn"),
             )
             .join(
-                PositionState,
+                latest_history_subq,
                 and_(
-                    DailyPositionSnapshot.portfolio_id == PositionState.portfolio_id,
-                    DailyPositionSnapshot.security_id == PositionState.security_id,
-                    DailyPositionSnapshot.epoch == PositionState.epoch,
+                    DailyPositionSnapshot.portfolio_id
+                    == latest_history_subq.c.portfolio_id,
+                    DailyPositionSnapshot.security_id
+                    == latest_history_subq.c.security_id,
+                    DailyPositionSnapshot.epoch == latest_history_subq.c.epoch,
+                    DailyPositionSnapshot.quantity == latest_history_subq.c.quantity,
                 ),
             )
-            .where(DailyPositionSnapshot.portfolio_id == portfolio_id)
+            .where(
+                DailyPositionSnapshot.portfolio_id == portfolio_id,
+                DailyPositionSnapshot.quantity != 0,
+            )
             .subquery()
         )
 
@@ -300,29 +316,40 @@ class PositionRepository:
     ) -> List[Any]:
         """
         Returns the latest available daily snapshot per security on or before as_of_date,
-        constrained to current epoch via PositionState.
+        constrained to the latest current-epoch booked quantity for that security.
         """
+        latest_history_subq = self._latest_current_position_history_subquery(
+            portfolio_id=portfolio_id,
+            as_of_date=as_of_date,
+        )
         ranked_snapshot_subq = (
             select(
                 DailyPositionSnapshot.id.label("snapshot_id"),
                 func.row_number()
                 .over(
-                    partition_by=DailyPositionSnapshot.security_id,
+                    partition_by=(
+                        DailyPositionSnapshot.portfolio_id,
+                        DailyPositionSnapshot.security_id,
+                    ),
                     order_by=(DailyPositionSnapshot.date.desc(), DailyPositionSnapshot.id.desc()),
                 )
                 .label("rn"),
             )
             .join(
-                PositionState,
+                latest_history_subq,
                 and_(
-                    DailyPositionSnapshot.portfolio_id == PositionState.portfolio_id,
-                    DailyPositionSnapshot.security_id == PositionState.security_id,
-                    DailyPositionSnapshot.epoch == PositionState.epoch,
+                    DailyPositionSnapshot.portfolio_id
+                    == latest_history_subq.c.portfolio_id,
+                    DailyPositionSnapshot.security_id
+                    == latest_history_subq.c.security_id,
+                    DailyPositionSnapshot.epoch == latest_history_subq.c.epoch,
+                    DailyPositionSnapshot.quantity == latest_history_subq.c.quantity,
                 ),
             )
             .where(
                 DailyPositionSnapshot.portfolio_id == portfolio_id,
                 DailyPositionSnapshot.date <= as_of_date,
+                DailyPositionSnapshot.quantity != 0,
             )
             .subquery()
         )
@@ -357,6 +384,53 @@ class PositionRepository:
             as_of_date,
         )
         return positions
+
+    def _latest_current_position_history_subquery(
+        self,
+        *,
+        portfolio_id: str,
+        as_of_date: date | None = None,
+    ):
+        ranked_history_subq = (
+            select(
+                PositionHistory.portfolio_id.label("portfolio_id"),
+                PositionHistory.security_id.label("security_id"),
+                PositionHistory.epoch.label("epoch"),
+                PositionHistory.quantity.label("quantity"),
+                func.row_number()
+                .over(
+                    partition_by=(
+                        PositionHistory.portfolio_id,
+                        PositionHistory.security_id,
+                    ),
+                    order_by=(PositionHistory.position_date.desc(), PositionHistory.id.desc()),
+                )
+                .label("rn"),
+            )
+            .join(
+                PositionState,
+                and_(
+                    PositionHistory.portfolio_id == PositionState.portfolio_id,
+                    PositionHistory.security_id == PositionState.security_id,
+                    PositionHistory.epoch == PositionState.epoch,
+                ),
+            )
+            .where(PositionHistory.portfolio_id == portfolio_id)
+        )
+        if as_of_date is not None:
+            ranked_history_subq = ranked_history_subq.where(
+                PositionHistory.position_date <= as_of_date
+            )
+
+        ranked_history_subq = ranked_history_subq.subquery()
+        return (
+            select(ranked_history_subq)
+            .where(
+                ranked_history_subq.c.rn == 1,
+                ranked_history_subq.c.quantity != 0,
+            )
+            .subquery()
+        )
 
     async def get_latest_position_history_by_portfolio_as_of_date(
         self, portfolio_id: str, as_of_date: date

--- a/src/services/query_service/app/repositories/reporting_repository.py
+++ b/src/services/query_service/app/repositories/reporting_repository.py
@@ -13,6 +13,8 @@ from portfolio_common.database_models import (
     Instrument,
     InstrumentLookthroughComponent,
     Portfolio,
+    PositionHistory,
+    PositionState,
     Transaction,
 )
 from sqlalchemy import and_, func, or_, select
@@ -76,6 +78,44 @@ class ReportingRepository:
         portfolio_ids: list[str],
         as_of_date: date,
     ) -> list[ReportingSnapshotRow]:
+        latest_history_subq = (
+            select(
+                PositionHistory.portfolio_id.label("portfolio_id"),
+                PositionHistory.security_id.label("security_id"),
+                PositionHistory.epoch.label("epoch"),
+                PositionHistory.quantity.label("quantity"),
+                func.row_number()
+                .over(
+                    partition_by=(
+                        PositionHistory.portfolio_id,
+                        PositionHistory.security_id,
+                    ),
+                    order_by=(PositionHistory.position_date.desc(), PositionHistory.id.desc()),
+                )
+                .label("rn"),
+            )
+            .join(
+                PositionState,
+                and_(
+                    PositionHistory.portfolio_id == PositionState.portfolio_id,
+                    PositionHistory.security_id == PositionState.security_id,
+                    PositionHistory.epoch == PositionState.epoch,
+                ),
+            )
+            .where(
+                PositionHistory.portfolio_id.in_(portfolio_ids),
+                PositionHistory.position_date <= as_of_date,
+            )
+            .subquery()
+        )
+        latest_open_history_subq = (
+            select(latest_history_subq)
+            .where(
+                latest_history_subq.c.rn == 1,
+                latest_history_subq.c.quantity != 0,
+            )
+            .subquery()
+        )
         ranked_snapshot_subq = (
             select(
                 DailyPositionSnapshot.id.label("snapshot_id"),
@@ -88,6 +128,17 @@ class ReportingRepository:
                     order_by=(DailyPositionSnapshot.date.desc(), DailyPositionSnapshot.id.desc()),
                 )
                 .label("rn"),
+            )
+            .join(
+                latest_open_history_subq,
+                and_(
+                    DailyPositionSnapshot.portfolio_id
+                    == latest_open_history_subq.c.portfolio_id,
+                    DailyPositionSnapshot.security_id
+                    == latest_open_history_subq.c.security_id,
+                    DailyPositionSnapshot.epoch == latest_open_history_subq.c.epoch,
+                    DailyPositionSnapshot.quantity == latest_open_history_subq.c.quantity,
+                ),
             )
             .where(
                 DailyPositionSnapshot.portfolio_id.in_(portfolio_ids),

--- a/src/services/query_service/app/services/transaction_service.py
+++ b/src/services/query_service/app/services/transaction_service.py
@@ -143,6 +143,7 @@ class TransactionService:
             ("gross_cost", "gross_cost_reporting_currency"),
             ("trade_fee", "trade_fee_reporting_currency"),
             ("net_cost", "net_cost_reporting_currency"),
+            ("realized_gain_loss", "realized_gain_loss_reporting_currency"),
             ("withholding_tax_amount", "withholding_tax_amount_reporting_currency"),
             (
                 "other_interest_deductions_amount",

--- a/src/services/query_service/pyproject.toml
+++ b/src/services/query_service/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "sqlalchemy==2.0.46",
     "asyncpg==0.30.0",
     "pydantic==2.12.5",
-    "python-dotenv==1.0.1",
+    "python-dotenv==1.2.2",
     "prometheus-fastapi-instrumentator==7.1.0",
     "python-dateutil==2.9.0.post0",
     "httpx==0.28.1"

--- a/src/services/timeseries_generator_service/pyproject.toml
+++ b/src/services/timeseries_generator_service/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "confluent-kafka==2.12.0",
     "pydantic==2.12.5",
     "tenacity==8.2.3",
-    "python-dotenv==1.0.1",
+    "python-dotenv==1.2.2",
     "fastapi==0.129.0",
     "uvicorn[standard]==0.35.0",
     "prometheus-fastapi-instrumentator==7.1.0"

--- a/src/services/valuation_orchestrator_service/app/core/valuation_scheduler.py
+++ b/src/services/valuation_orchestrator_service/app/core/valuation_scheduler.py
@@ -61,12 +61,19 @@ class ValuationScheduler:
 
     @staticmethod
     def _build_backfill_correlation_id(
-        portfolio_id: str, security_id: str, epoch: int, valuation_date
+        portfolio_id: str,
+        security_id: str,
+        epoch: int,
+        valuation_date,
+        watermark_updated_at: datetime | None = None,
     ) -> str:
-        return (
+        base_correlation_id = (
             f"SCHEDULER_BACKFILL:{portfolio_id}:{security_id}:"
             f"{epoch}:{valuation_date.isoformat()}"
         )
+        if watermark_updated_at is None:
+            return base_correlation_id
+        return f"{base_correlation_id}:{watermark_updated_at.isoformat()}"
 
     async def _update_reprocessing_metrics(self, db):
         """Queries for and sets key gauges related to reprocessing workload."""
@@ -362,6 +369,7 @@ class ValuationScheduler:
                             state.security_id,
                             state.epoch,
                             current_date,
+                            state.updated_at,
                         ),
                     )
                 )

--- a/src/services/valuation_orchestrator_service/pyproject.toml
+++ b/src/services/valuation_orchestrator_service/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "confluent-kafka==2.12.0",
     "pydantic==2.12.5",
     "tenacity==8.2.3",
-    "python-dotenv==1.0.1",
+    "python-dotenv==1.2.2",
     "fastapi==0.129.0",
     "uvicorn[standard]==0.35.0",
     "prometheus-fastapi-instrumentator==7.1.0"

--- a/tests/e2e/api_client.py
+++ b/tests/e2e/api_client.py
@@ -54,6 +54,17 @@ class E2EApiClient:
         response.raise_for_status()
         return response
 
+    def reprocess_transactions(self, transaction_ids: List[str]) -> requests.Response:
+        """Queues existing transactions for replay through the governed reprocessing API."""
+        url = f"{self.ingestion_url}/reprocess/transactions"
+        response = self.session.post(
+            url,
+            json={"transaction_ids": transaction_ids},
+            timeout=10,
+        )
+        response.raise_for_status()
+        return response
+
     def query(self, endpoint: str) -> requests.Response:
         """Retrieves data from a specified query endpoint."""
         url = f"{self.query_url}{endpoint}"

--- a/tests/e2e/test_reprocessing_workflow.py
+++ b/tests/e2e/test_reprocessing_workflow.py
@@ -3,6 +3,7 @@ import uuid
 from decimal import Decimal
 
 import pytest
+from sqlalchemy import text
 
 from .api_client import E2EApiClient
 from .state_assertions import assert_positions_state
@@ -209,6 +210,187 @@ def test_back_dated_transaction_triggers_reprocessing_and_corrects_state(
                 "quantity": Decimal("110"),
                 "cost_basis": Decimal("23000"),
                 "market_value": Decimal("24200"),
+            }
+        },
+    )
+
+
+def test_reprocess_api_rearms_current_valuation_after_transaction_correction(
+    clean_db, db_engine, e2e_api_client: E2EApiClient, poll_db_until
+):
+    """
+    Verifies that the explicit replay API fixes an already-valued position after an upstream
+    transaction correction and regenerates current-epoch valuation snapshots.
+    """
+    suffix = uuid.uuid4().hex[:8].upper()
+    portfolio_id = f"E2E_REPLAY_FIX_{suffix}"
+    security_id = f"SEC_REPLAY_FIX_{suffix}"
+    instrument_id = f"INST_REPLAY_FIX_{suffix}"
+    day1, day2, day3 = "2025-10-01", "2025-10-02", "2025-10-03"
+    day1_transaction_id = f"{portfolio_id}_BUY_DAY1"
+
+    e2e_api_client.ingest(
+        "/ingest/portfolios",
+        {
+            "portfolios": [
+                {
+                    "portfolioId": portfolio_id,
+                    "baseCurrency": "USD",
+                    "openDate": "2025-01-01",
+                    "cifId": f"REPLAY_CIF_{suffix}",
+                    "status": "ACTIVE",
+                    "riskExposure": "balanced",
+                    "investmentTimeHorizon": "7Y_PLUS",
+                    "portfolioType": "DISCRETIONARY",
+                    "bookingCenter": "SG",
+                }
+            ]
+        },
+    )
+    e2e_api_client.ingest(
+        "/ingest/instruments",
+        {
+            "instruments": [
+                {
+                    "securityId": security_id,
+                    "name": "Replay Correction Equity",
+                    "isin": f"USREPLAY{suffix}",
+                    "instrumentCurrency": "USD",
+                    "productType": "Equity",
+                }
+            ]
+        },
+    )
+    e2e_api_client.ingest(
+        "/ingest/business-dates",
+        {
+            "business_dates": [
+                {"businessDate": day1},
+                {"businessDate": day2},
+                {"businessDate": day3},
+            ]
+        },
+    )
+    e2e_api_client.ingest(
+        "/ingest/market-prices",
+        {
+            "market_prices": [
+                {"securityId": security_id, "priceDate": day1, "price": 100.0, "currency": "USD"},
+                {"securityId": security_id, "priceDate": day2, "price": 110.0, "currency": "USD"},
+                {"securityId": security_id, "priceDate": day3, "price": 120.0, "currency": "USD"},
+            ]
+        },
+    )
+    e2e_api_client.ingest(
+        "/ingest/transactions",
+        {
+            "transactions": [
+                {
+                    "transaction_id": day1_transaction_id,
+                    "portfolio_id": portfolio_id,
+                    "instrument_id": instrument_id,
+                    "security_id": security_id,
+                    "transaction_date": f"{day1}T10:00:00Z",
+                    "transaction_type": "BUY",
+                    "quantity": 100,
+                    "price": 100,
+                    "gross_transaction_amount": 10000,
+                    "trade_currency": "USD",
+                    "currency": "USD",
+                },
+                {
+                    "transaction_id": f"{portfolio_id}_BUY_DAY3",
+                    "portfolio_id": portfolio_id,
+                    "instrument_id": instrument_id,
+                    "security_id": security_id,
+                    "transaction_date": f"{day3}T10:00:00Z",
+                    "transaction_type": "BUY",
+                    "quantity": 50,
+                    "price": 120,
+                    "gross_transaction_amount": 6000,
+                    "trade_currency": "USD",
+                    "currency": "USD",
+                },
+            ]
+        },
+    )
+
+    initial_state = poll_db_until(
+        query=(
+            "SELECT epoch, watermark_date, status FROM position_state "
+            "WHERE portfolio_id = :pid AND security_id = :sid"
+        ),
+        params={"pid": portfolio_id, "sid": security_id},
+        validation_func=lambda r: (
+            r is not None and r.status == "CURRENT" and str(r.watermark_date) == day3
+        ),
+        timeout=120,
+        fail_message="Initial replay correction position state did not converge.",
+    )
+    assert_positions_state(
+        e2e_api_client,
+        portfolio_id=portfolio_id,
+        as_of_date=day3,
+        expected_positions={
+            security_id: {
+                "quantity": Decimal("150"),
+                "cost_basis": Decimal("16000"),
+                "market_value": Decimal("18000"),
+            }
+        },
+    )
+
+    with db_engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                UPDATE transactions
+                SET quantity = 120,
+                    gross_transaction_amount = 12000,
+                    updated_at = NOW()
+                WHERE transaction_id = :transaction_id
+                """
+            ),
+            {"transaction_id": day1_transaction_id},
+        )
+
+    response = e2e_api_client.reprocess_transactions([day1_transaction_id])
+    assert response.status_code == 202
+    assert response.json()["accepted_count"] == 1
+
+    poll_db_until(
+        query=(
+            "SELECT ps.epoch, ps.watermark_date, ps.status, dps.quantity, dps.market_value "
+            "FROM position_state ps "
+            "JOIN daily_position_snapshots dps "
+            "  ON dps.portfolio_id = ps.portfolio_id "
+            " AND dps.security_id = ps.security_id "
+            " AND dps.epoch = ps.epoch "
+            "WHERE ps.portfolio_id = :pid "
+            "  AND ps.security_id = :sid "
+            "  AND dps.date = :as_of_date"
+        ),
+        params={"pid": portfolio_id, "sid": security_id, "as_of_date": day3},
+        validation_func=lambda r: (
+            r is not None
+            and r.epoch >= int(initial_state.epoch) + 1
+            and r.status == "CURRENT"
+            and r.quantity == Decimal("170.0000000000")
+            and r.market_value == Decimal("20400.0000000000")
+        ),
+        timeout=180,
+        fail_message="Replay API did not regenerate the current-epoch valuation snapshot.",
+    )
+
+    assert_positions_state(
+        e2e_api_client,
+        portfolio_id=portfolio_id,
+        as_of_date=day3,
+        expected_positions={
+            security_id: {
+                "quantity": Decimal("170"),
+                "cost_basis": Decimal("18000"),
+                "market_value": Decimal("20400"),
             }
         },
     )

--- a/tests/integration/services/calculators/position_valuation_calculator/test_int_valuation_repo.py
+++ b/tests/integration/services/calculators/position_valuation_calculator/test_int_valuation_repo.py
@@ -994,6 +994,118 @@ async def test_find_contiguous_snapshot_dates_respects_first_open_dates(
     assert contiguous_dates == {("P-CONTIG", "S-CONTIG"): date(2025, 8, 11)}
 
 
+async def test_find_contiguous_snapshot_dates_stops_at_unreconciled_snapshot(
+    clean_db, async_db_session: AsyncSession
+):
+    repo = ValuationRepository(async_db_session)
+
+    async_db_session.add(
+        Portfolio(
+            portfolio_id="P-STALE-SNAPSHOT",
+            base_currency="USD",
+            open_date=date(2026, 1, 1),
+            risk_exposure="a",
+            investment_time_horizon="b",
+            portfolio_type="c",
+            booking_center_code="d",
+            client_id="e",
+            status="f",
+        )
+    )
+    await async_db_session.commit()
+
+    async_db_session.add(
+        Transaction(
+            transaction_id="TX-STALE-SNAPSHOT-1",
+            portfolio_id="P-STALE-SNAPSHOT",
+            instrument_id="I-STALE-SNAPSHOT",
+            security_id="S-STALE-SNAPSHOT",
+            transaction_date=date(2026, 3, 11),
+            transaction_type="BUY",
+            quantity=1,
+            price=1,
+            gross_transaction_amount=1,
+            trade_currency="USD",
+            currency="USD",
+        )
+    )
+    await async_db_session.commit()
+
+    async_db_session.add_all(
+        [
+            PositionState(
+                portfolio_id="P-STALE-SNAPSHOT",
+                security_id="S-STALE-SNAPSHOT",
+                epoch=2,
+                watermark_date=date(2026, 3, 10),
+                status="REPROCESSING",
+            ),
+            PositionHistory(
+                portfolio_id="P-STALE-SNAPSHOT",
+                security_id="S-STALE-SNAPSHOT",
+                transaction_id="TX-STALE-SNAPSHOT-1",
+                position_date=date(2026, 3, 11),
+                quantity=Decimal("180"),
+                cost_basis=Decimal("180000"),
+                cost_basis_local=Decimal("180000"),
+                epoch=2,
+            ),
+            BusinessDate(calendar_code="GLOBAL", date=date(2026, 3, 11)),
+            BusinessDate(calendar_code="GLOBAL", date=date(2026, 3, 12)),
+            DailyPositionSnapshot(
+                portfolio_id="P-STALE-SNAPSHOT",
+                security_id="S-STALE-SNAPSHOT",
+                date=date(2026, 3, 11),
+                epoch=2,
+                quantity=Decimal("0"),
+                cost_basis=Decimal("0"),
+                cost_basis_local=Decimal("0"),
+                market_price=Decimal("1013.5"),
+                market_value=Decimal("0"),
+                market_value_local=Decimal("0"),
+                unrealized_gain_loss=Decimal("0"),
+                unrealized_gain_loss_local=Decimal("0"),
+                valuation_status="VALUED_CURRENT",
+            ),
+            DailyPositionSnapshot(
+                portfolio_id="P-STALE-SNAPSHOT",
+                security_id="S-STALE-SNAPSHOT",
+                date=date(2026, 3, 12),
+                epoch=2,
+                quantity=Decimal("180"),
+                cost_basis=Decimal("180000"),
+                cost_basis_local=Decimal("180000"),
+                market_price=Decimal("1013.5"),
+                market_value=Decimal("182430"),
+                market_value_local=Decimal("182430"),
+                unrealized_gain_loss=Decimal("2430"),
+                unrealized_gain_loss_local=Decimal("2430"),
+                valuation_status="VALUED_CURRENT",
+            ),
+        ]
+    )
+    await async_db_session.commit()
+
+    states = [
+        PositionState(
+            portfolio_id="P-STALE-SNAPSHOT",
+            security_id="S-STALE-SNAPSHOT",
+            epoch=2,
+            watermark_date=date(2026, 3, 10),
+            status="REPROCESSING",
+        )
+    ]
+
+    contiguous_dates = await repo.find_contiguous_snapshot_dates(
+        states,
+        {("P-STALE-SNAPSHOT", "S-STALE-SNAPSHOT", 2): date(2026, 3, 11)},
+    )
+
+    assert contiguous_dates == {
+        ("P-STALE-SNAPSHOT", "S-STALE-SNAPSHOT"): date(2026, 3, 10)
+    }
+
+
 async def test_stale_older_epoch_job_is_not_rearmed_when_newer_epoch_exists(
     async_db_session: AsyncSession, clean_db
 ):

--- a/tests/integration/services/query_service/test_main_app.py
+++ b/tests/integration/services/query_service/test_main_app.py
@@ -555,6 +555,13 @@ async def test_openapi_describes_transaction_filters_and_not_found_examples(asyn
         == "Gross transaction amount restated into the requested reporting currency when "
         "`reporting_currency` is supplied on the route."
     )
+    assert (
+        schema["components"]["schemas"]["TransactionRecord"]["properties"][
+            "realized_gain_loss_reporting_currency"
+        ]["description"]
+        == "Transaction-level realized gain/loss restated into the requested reporting "
+        "currency when `reporting_currency` is supplied on the route."
+    )
 
     bad_request = transactions["responses"]["400"]["content"]["application/json"]["example"]
     assert bad_request["detail"] == "FX rate not found for USD/SGD as of 2026-03-10."

--- a/tests/integration/services/query_service/test_query_position_repository.py
+++ b/tests/integration/services/query_service/test_query_position_repository.py
@@ -78,7 +78,31 @@ def setup_test_data(db_engine):
             cost_basis=Decimal("11000"),
             epoch=0,
         )
-        session.add_all([snapshot_yesterday, snapshot_today])
+        transaction = Transaction(
+            transaction_id="POS-REPO-TXN-01",
+            portfolio_id="POS_REPO_TEST_01",
+            security_id="SEC_POS_TEST_01",
+            instrument_id="SEC_POS_TEST_01",
+            transaction_date=today,
+            transaction_type="BUY",
+            quantity=Decimal("110"),
+            price=Decimal("100"),
+            gross_transaction_amount=Decimal("11000"),
+            trade_currency="USD",
+            currency="USD",
+        )
+        history = PositionHistory(
+            portfolio_id="POS_REPO_TEST_01",
+            security_id="SEC_POS_TEST_01",
+            transaction_id="POS-REPO-TXN-01",
+            position_date=today,
+            quantity=Decimal("110"),
+            cost_basis=Decimal("11000"),
+            epoch=0,
+        )
+        session.add(transaction)
+        session.flush()
+        session.add_all([history, snapshot_yesterday, snapshot_today])
         session.commit()
 
     return {"today": today, "yesterday": yesterday}
@@ -287,6 +311,33 @@ def setup_snapshot_id_order_mismatch_data(db_engine):
         newer_date = date(2025, 1, 10)
         older_date = date(2025, 1, 9)
         session.add(
+            Transaction(
+                transaction_id="POS-REPO-TXN-02",
+                portfolio_id=portfolio_id,
+                security_id=security_id,
+                instrument_id=security_id,
+                transaction_date=newer_date,
+                transaction_type="BUY",
+                quantity=Decimal("200"),
+                price=Decimal("100"),
+                gross_transaction_amount=Decimal("20000"),
+                trade_currency="USD",
+                currency="USD",
+            )
+        )
+        session.flush()
+        session.add(
+            PositionHistory(
+                portfolio_id=portfolio_id,
+                security_id=security_id,
+                transaction_id="POS-REPO-TXN-02",
+                position_date=newer_date,
+                quantity=Decimal("200"),
+                cost_basis=Decimal("20000"),
+                epoch=0,
+            )
+        )
+        session.add(
             DailyPositionSnapshot(
                 portfolio_id=portfolio_id,
                 security_id=security_id,
@@ -391,6 +442,55 @@ def setup_as_of_positive_filter_data(db_engine):
         session.flush()
         session.add_all(
             [
+                Transaction(
+                    transaction_id="POS-REPO-TXN-03-POS",
+                    portfolio_id=portfolio_id,
+                    security_id=positive_security,
+                    instrument_id=positive_security,
+                    transaction_date=as_of_date,
+                    transaction_type="BUY",
+                    quantity=Decimal("25"),
+                    price=Decimal("100"),
+                    gross_transaction_amount=Decimal("2500"),
+                    trade_currency="USD",
+                    currency="USD",
+                ),
+                Transaction(
+                    transaction_id="POS-REPO-TXN-03-NEG",
+                    portfolio_id=portfolio_id,
+                    security_id=negative_security,
+                    instrument_id=negative_security,
+                    transaction_date=as_of_date,
+                    transaction_type="BUY",
+                    quantity=Decimal("-10"),
+                    price=Decimal("1"),
+                    gross_transaction_amount=Decimal("-10"),
+                    trade_currency="USD",
+                    currency="USD",
+                ),
+            ]
+        )
+        session.flush()
+        session.add_all(
+            [
+                PositionHistory(
+                    portfolio_id=portfolio_id,
+                    security_id=positive_security,
+                    transaction_id="POS-REPO-TXN-03-POS",
+                    position_date=as_of_date,
+                    quantity=Decimal("25"),
+                    cost_basis=Decimal("2500"),
+                    epoch=0,
+                ),
+                PositionHistory(
+                    portfolio_id=portfolio_id,
+                    security_id=negative_security,
+                    transaction_id="POS-REPO-TXN-03-NEG",
+                    position_date=as_of_date,
+                    quantity=Decimal("-10"),
+                    cost_basis=Decimal("-10"),
+                    epoch=1,
+                ),
                 DailyPositionSnapshot(
                     portfolio_id=portfolio_id,
                     security_id=positive_security,
@@ -439,3 +539,123 @@ async def test_get_latest_positions_by_portfolio_as_of_date_keeps_negative_open_
     assert negative_snapshot.quantity == Decimal("-10")
     assert negative_instrument.name == "Negative"
     assert negative_state.status == "REPROCESSING"
+
+
+@pytest.fixture(scope="function")
+def setup_stale_snapshot_reconciliation_data(db_engine):
+    portfolio_id = "POS_REPO_STALE_RECON"
+    security_id = "SEC_POS_STALE_RECON"
+    as_of_date = date(2026, 4, 22)
+
+    with Session(db_engine) as session:
+        session.add(
+            Portfolio(
+                portfolio_id=portfolio_id,
+                base_currency="USD",
+                open_date=date(2024, 1, 1),
+                risk_exposure="balanced",
+                investment_time_horizon="medium",
+                portfolio_type="discretionary",
+                booking_center_code="SGPB",
+                client_id="C1",
+                status="ACTIVE",
+            )
+        )
+        session.add(
+            Instrument(
+                security_id=security_id,
+                name="Reconciled Bond",
+                isin="XS0000000099",
+                currency="USD",
+                product_type="Bond",
+                asset_class="Fixed Income",
+                sector="Government",
+                country_of_risk="US",
+            )
+        )
+        session.add(
+            PositionState(
+                portfolio_id=portfolio_id,
+                security_id=security_id,
+                epoch=2,
+                watermark_date=as_of_date,
+                status="CURRENT",
+            )
+        )
+        session.add(
+            Transaction(
+                transaction_id="POS-RECON-TXN-01",
+                portfolio_id=portfolio_id,
+                security_id=security_id,
+                instrument_id=security_id,
+                transaction_date=date(2026, 3, 11),
+                transaction_type="BUY",
+                quantity=Decimal("180"),
+                price=Decimal("992.8"),
+                gross_transaction_amount=Decimal("178704"),
+                trade_currency="USD",
+                currency="USD",
+            )
+        )
+        session.flush()
+        session.add(
+            PositionHistory(
+                portfolio_id=portfolio_id,
+                security_id=security_id,
+                transaction_id="POS-RECON-TXN-01",
+                position_date=date(2026, 3, 11),
+                quantity=Decimal("180"),
+                cost_basis=Decimal("178704"),
+                epoch=2,
+            )
+        )
+        session.flush()
+        session.add_all(
+            [
+                DailyPositionSnapshot(
+                    portfolio_id=portfolio_id,
+                    security_id=security_id,
+                    date=as_of_date,
+                    quantity=Decimal("0"),
+                    cost_basis=Decimal("0"),
+                    market_price=Decimal("101.35"),
+                    market_value=Decimal("0"),
+                    epoch=2,
+                ),
+                DailyPositionSnapshot(
+                    portfolio_id=portfolio_id,
+                    security_id=security_id,
+                    date=date(2026, 4, 10),
+                    quantity=Decimal("180"),
+                    cost_basis=Decimal("178704"),
+                    market_price=Decimal("101.35"),
+                    market_value=Decimal("182430"),
+                    epoch=2,
+                ),
+            ]
+        )
+        session.commit()
+
+    return {"portfolio_id": portfolio_id, "security_id": security_id, "as_of_date": as_of_date}
+
+
+async def test_get_latest_positions_ignores_stale_snapshot_quantity_after_replay(
+    clean_db,
+    setup_stale_snapshot_reconciliation_data,
+    async_db_session: AsyncSession,
+):
+    repo = PositionRepository(async_db_session)
+
+    latest_positions = await repo.get_latest_positions_by_portfolio_as_of_date(
+        setup_stale_snapshot_reconciliation_data["portfolio_id"],
+        setup_stale_snapshot_reconciliation_data["as_of_date"],
+    )
+
+    assert len(latest_positions) == 1
+    snapshot, instrument, position_state = latest_positions[0]
+    assert snapshot.security_id == setup_stale_snapshot_reconciliation_data["security_id"]
+    assert snapshot.date == date(2026, 4, 10)
+    assert snapshot.quantity == Decimal("180")
+    assert snapshot.market_value == Decimal("182430")
+    assert instrument.name == "Reconciled Bond"
+    assert position_state.status == "CURRENT"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -19,7 +19,7 @@ psycopg2-binary==2.9.10
 asyncpg==0.30.0
 
 # Environment variable management
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 
 # Docker testcontainers for E2E and integration tests
 testcontainers[kafka,postgres]==4.5.0

--- a/tests/unit/services/calculators/position_calculator/core/test_position_logic.py
+++ b/tests/unit/services/calculators/position_calculator/core/test_position_logic.py
@@ -134,6 +134,48 @@ async def test_calculate_normal_flow(
 
 
 @pytest.mark.asyncio
+@patch("src.services.calculators.position_calculator.app.core.position_logic.EpochFencer")
+async def test_calculate_rearms_current_epoch_when_position_history_arrives_after_valuation(
+    mock_fencer_class: MagicMock,
+    mock_repo: AsyncMock,
+    mock_state_repo: AsyncMock,
+    mock_outbox_repo: AsyncMock,
+    sample_event: TransactionEvent,
+):
+    """
+    GIVEN a replay/current-epoch event materializes position history for a date
+    already covered by valuation snapshots
+    WHEN PositionCalculator persists the corrected history
+    THEN the current epoch watermark is reset so valuation and timeseries jobs
+    are regenerated instead of leaving stale snapshots marked current.
+    """
+    mock_fencer_instance = mock_fencer_class.return_value
+    mock_fencer_instance.check = AsyncMock(return_value=True)
+    sample_event.epoch = 2
+    sample_event.transaction_date = datetime(2026, 3, 11, 9, 0, 0)
+
+    mock_state_repo.get_or_create_state.return_value = PositionState(
+        watermark_date=date(2026, 4, 22), epoch=2, status="CURRENT"
+    )
+    mock_repo.get_latest_completed_snapshot_date.return_value = date(2026, 4, 22)
+    mock_repo.get_latest_position_history_date.return_value = None
+    mock_repo.get_transactions_on_or_after.return_value = [sample_event]
+    mock_state_repo.update_watermarks_if_older.return_value = 1
+
+    await PositionCalculator.calculate(
+        sample_event, AsyncMock(), mock_repo, mock_state_repo, mock_outbox_repo
+    )
+
+    mock_state_repo.increment_epoch_and_reset_watermark.assert_not_called()
+    mock_repo.save_positions.assert_awaited_once()
+    mock_state_repo.update_watermarks_if_older.assert_awaited_once_with(
+        keys=[("P1", "S1")],
+        new_watermark_date=date(2026, 3, 10),
+    )
+    mock_outbox_repo.create_outbox_event.assert_not_called()
+
+
+@pytest.mark.asyncio
 @patch(
     "src.services.calculators.position_calculator.app.core.position_logic.REPROCESSING_EPOCH_BUMPED_TOTAL"
 )

--- a/tests/unit/services/query_service/repositories/test_analytics_timeseries_repository.py
+++ b/tests/unit/services/query_service/repositories/test_analytics_timeseries_repository.py
@@ -185,9 +185,12 @@ async def test_timeseries_repository_applies_snapshot_epoch_filters() -> None:
         snapshot_epoch=4,
     )
     position_stmt = db.execute.await_args_list[1].args[0]
-    assert "position_timeseries.epoch <= 4" in str(
-        position_stmt.compile(compile_kwargs={"literal_binds": True})
-    )
+    position_sql = str(position_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "position_timeseries.epoch <= 4" in position_sql
+    assert "JOIN position_state ON" in position_sql
+    assert "position_timeseries.epoch = position_state.epoch" in position_sql
+    assert "position_timeseries.quantity = (SELECT position_history.quantity" in position_sql
+    assert "position_history.position_date <= position_timeseries.date" in position_sql
 
 
 @pytest.mark.asyncio
@@ -239,6 +242,8 @@ async def test_timeseries_repository_supports_unpaged_position_rows_and_cashflow
     unpaged_stmt = db.execute.await_args_list[0].args[0]
     unpaged_sql = str(unpaged_stmt.compile(compile_kwargs={"literal_binds": True}))
     assert "position_timeseries.epoch <= 2" in unpaged_sql
+    assert "JOIN position_state ON" in unpaged_sql
+    assert "position_timeseries.quantity = (SELECT position_history.quantity" in unpaged_sql
     assert "instruments.asset_class" in unpaged_sql
     assert "ORDER BY anon_1.valuation_date ASC, anon_1.security_id ASC" in unpaged_sql
 
@@ -253,6 +258,8 @@ async def test_timeseries_repository_supports_unpaged_position_rows_and_cashflow
     prior_sql = str(prior_stmt.compile(compile_kwargs={"literal_binds": True}))
     assert "position_timeseries.date < '2025-01-01'" in prior_sql
     assert "position_timeseries.epoch <= 3" in prior_sql
+    assert "JOIN position_state ON" in prior_sql
+    assert "position_timeseries.quantity = (SELECT position_history.quantity" in prior_sql
     assert "row_number() OVER (PARTITION BY position_timeseries.security_id" in prior_sql
     assert "ORDER BY position_timeseries.date DESC, position_timeseries.epoch DESC" in prior_sql
 

--- a/tests/unit/services/query_service/repositories/test_reporting_repository.py
+++ b/tests/unit/services/query_service/repositories/test_reporting_repository.py
@@ -95,6 +95,9 @@ async def test_reporting_repository_latest_snapshot_query_is_true_historical_as_
     )
     assert "daily_position_snapshots.date <= '2026-03-27'" in compiled
     assert "daily_position_snapshots.quantity != 0" in compiled
+    assert "daily_position_snapshots.epoch = anon_2.epoch" in compiled
+    assert "daily_position_snapshots.quantity = anon_2.quantity" in compiled
+    assert "position_history.position_date <= '2026-03-27'" in compiled
     assert "LEFT OUTER JOIN instruments" in compiled
     assert (
         "ORDER BY daily_position_snapshots.portfolio_id ASC, "

--- a/tests/unit/services/query_service/repositories/test_unit_query_position_repo.py
+++ b/tests/unit/services/query_service/repositories/test_unit_query_position_repo.py
@@ -69,9 +69,13 @@ async def test_get_latest_positions_by_portfolio(
     # Check for key components of the new complex query
     assert "FROM daily_position_snapshots" in compiled_query
     assert "JOIN position_state ON" in compiled_query
-    assert "daily_position_snapshots.epoch = position_state.epoch" in compiled_query
-    # Assert that it ranks snapshots by business date and id per security.
-    assert "row_number() OVER (PARTITION BY daily_position_snapshots.security_id" in compiled_query
+    assert "daily_position_snapshots.epoch = anon_2.epoch" in compiled_query
+    assert "daily_position_snapshots.quantity = anon_2.quantity" in compiled_query
+    # Assert that it ranks reconciled snapshots by business date and id per security.
+    assert (
+        "row_number() OVER (PARTITION BY daily_position_snapshots.portfolio_id, "
+        "daily_position_snapshots.security_id" in compiled_query
+    )
     assert (
         "ORDER BY daily_position_snapshots.date DESC, daily_position_snapshots.id DESC"
         in compiled_query
@@ -279,8 +283,12 @@ async def test_get_latest_positions_by_portfolio_as_of_date_builds_expected_quer
     executed_stmt = mock_db_session.execute.call_args[0][0]
     compiled_query = str(executed_stmt.compile(compile_kwargs={"literal_binds": True}))
     assert "daily_position_snapshots.date <= '2025-01-31'" in compiled_query
-    assert "row_number() OVER (PARTITION BY daily_position_snapshots.security_id" in compiled_query
-    assert "daily_position_snapshots.epoch = position_state.epoch" in compiled_query
+    assert (
+        "row_number() OVER (PARTITION BY daily_position_snapshots.portfolio_id, "
+        "daily_position_snapshots.security_id" in compiled_query
+    )
+    assert "daily_position_snapshots.epoch = anon_2.epoch" in compiled_query
+    assert "daily_position_snapshots.quantity = anon_2.quantity" in compiled_query
     assert "daily_position_snapshots.quantity != 0" in compiled_query
 
 

--- a/tests/unit/services/query_service/services/test_transaction_service.py
+++ b/tests/unit/services/query_service/services/test_transaction_service.py
@@ -33,6 +33,7 @@ def mock_transaction_repo() -> AsyncMock:
             gross_transaction_amount=Decimal(1000),
             gross_cost=Decimal(1000),
             trade_fee=Decimal("12.5"),
+            realized_gain_loss=Decimal("250"),
             trade_currency="USD",
             currency="USD",
             cash_entry_mode="AUTO_GENERATE",
@@ -370,6 +371,7 @@ async def test_get_transactions_applies_reporting_currency_restated_fields(
     assert first_transaction.gross_transaction_amount_reporting_currency == Decimal("1360.00")
     assert first_transaction.gross_cost_reporting_currency == Decimal("1360.00")
     assert first_transaction.trade_fee_reporting_currency == Decimal("17.000")
+    assert first_transaction.realized_gain_loss_reporting_currency == Decimal("340.00")
     assert income_transaction.gross_transaction_amount_reporting_currency == Decimal("170.00")
     assert (
         income_transaction.withholding_tax_amount_reporting_currency == Decimal("13.60")

--- a/tests/unit/services/valuation_orchestrator_service/core/test_valuation_scheduler.py
+++ b/tests/unit/services/valuation_orchestrator_service/core/test_valuation_scheduler.py
@@ -125,6 +125,44 @@ async def test_scheduler_creates_position_aware_backfill_jobs(
         mock_gauge_labels.return_value.set.assert_called_once_with(expected_lag)
 
 
+async def test_scheduler_rearms_completed_jobs_after_watermark_reset(
+    scheduler: ValuationScheduler,
+    mock_dependencies: dict,
+):
+    mock_repo = mock_dependencies["repo"]
+    mock_job_repo = mock_dependencies["job_repo"]
+
+    latest_business_date = date(2026, 4, 22)
+    watermark_reset_at = datetime(2026, 4, 23, 9, 30, tzinfo=timezone.utc)
+    states_to_backfill = [
+        PositionState(
+            portfolio_id="PB_SG_GLOBAL_BAL_001",
+            security_id="FO_BOND_UST_2030",
+            watermark_date=date(2026, 3, 10),
+            epoch=2,
+            status="REPROCESSING",
+            updated_at=watermark_reset_at,
+        )
+    ]
+
+    mock_repo.get_latest_business_date.return_value = latest_business_date
+    mock_repo.get_states_needing_backfill.return_value = states_to_backfill
+    mock_repo.get_first_open_dates_for_keys.return_value = {
+        ("PB_SG_GLOBAL_BAL_001", "FO_BOND_UST_2030", 2): date(2026, 3, 11)
+    }
+    mock_job_repo.upsert_jobs.return_value = 43
+
+    await scheduler._create_backfill_jobs(AsyncMock())
+
+    mock_job_repo.upsert_jobs.assert_awaited_once()
+    scheduled_jobs = mock_job_repo.upsert_jobs.await_args.args[0]
+    assert scheduled_jobs[0].valuation_date == date(2026, 3, 11)
+    assert scheduled_jobs[0].correlation_id == (
+        "SCHEDULER_BACKFILL:PB_SG_GLOBAL_BAL_001:FO_BOND_UST_2030:"
+        "2:2026-03-11:2026-04-23T09:30:00+00:00"
+    )
+
+
 async def test_scheduler_normalizes_non_reprocessing_keys_with_no_position_history(
     scheduler: ValuationScheduler,
     mock_dependencies: dict,


### PR DESCRIPTION
## Summary
- fixes stale current holdings/position-timeseries reads after replay by reconciling current snapshots with latest position history
- re-arms valuation and timeseries generation after position replay writes so corrected transactions regenerate current-epoch data
- adds explicit `/reprocess/transactions` E2E regression for transaction correction replay and current snapshot/query convergence

## Validation
- `python -m pytest tests/e2e/test_reprocessing_workflow.py::test_reprocess_api_rearms_current_valuation_after_transaction_correction -q`
- `python -m ruff check tests/e2e/api_client.py tests/e2e/test_reprocessing_workflow.py`
- `python -m pytest tests/unit/libs/portfolio-common/test_reprocessing_repository.py tests/unit/services/calculators/cost_calculator_service/consumer/test_reprocessing_consumer.py -q`
- `python -m pytest tests/integration/services/ingestion_service/test_ingestion_routers.py::test_reprocess_transactions_deduplicates_transaction_ids_at_ingress tests/integration/services/ingestion_service/test_ingestion_routers.py::test_reprocess_transactions_replays_duplicate_idempotency_key -q`
- earlier targeted stale snapshot/rearm regression suites passed locally before this final replay-API test slice

## Live proof
- called `POST /reprocess/transactions` for `PB_SG_GLOBAL_BAL_001` impacted transaction IDs; accepted 6 records
- verified `CASH_EUR_BOOK_OPERATING` and `FO_BOND_UST_2030` returned to `CURRENT` through 2026-04-22
- verified lotus-report portfolio review now has `negative_cash_position_count = 0`
- verified report holdings include unrealized PnL and YTD contribution for both impacted positions