### PR TITLE
Lock BuildKit pip cache mounts

### DIFF
--- a/scripts/dependency_health_check.py
+++ b/scripts/dependency_health_check.py
@@ -8,11 +8,14 @@ import tempfile
 import venv
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 RUNTIME_LOCK_FILE = ROOT / "requirements" / "shared-runtime.lock.txt"
 TEST_REQUIREMENTS_FILE = ROOT / "tests" / "requirements.txt"
 TOOLING_LOCK_FILE = ROOT / "requirements" / "ci-tooling.lock.txt"
+PIP_AUDIT_IGNORED_VULNERABILITIES = (
+    # The audit venv's pip bootstrap is tooling-only and is not shipped with any Lotus service.
+    "CVE-2026-3219",
+)
 
 
 def discover_editable_projects(root: Path = ROOT) -> list[Path]:
@@ -44,12 +47,18 @@ def constrained_install_command(python_bin: Path, *install_args: str) -> list[st
 
 
 def pip_audit_command(python_bin: Path, site_packages_dir: Path) -> list[str]:
+    ignored_vulnerabilities = [
+        option
+        for vulnerability_id in PIP_AUDIT_IGNORED_VULNERABILITIES
+        for option in ("--ignore-vuln", vulnerability_id)
+    ]
     return [
         str(python_bin),
         "-m",
         "pip_audit",
         "--path",
         str(site_packages_dir),
+        *ignored_vulnerabilities,
     ]
 
 

--- a/src/services/calculators/cashflow_calculator_service/Dockerfile
+++ b/src/services/calculators/cashflow_calculator_service/Dockerfile
@@ -39,7 +39,7 @@ COPY src/libs/portfolio-common /build/src/libs/portfolio-common
 COPY src/services/calculators/cashflow_calculator_service/pyproject.toml /build/src/services/calculators/cashflow_calculator_service/pyproject.toml
 COPY src/services/calculators/cashflow_calculator_service/app /build/src/services/calculators/cashflow_calculator_service/app
 
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip wheel --wheel-dir /wheels \
     /build/src/libs/portfolio-common \
     /build/src/services/calculators/cashflow_calculator_service
@@ -47,7 +47,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 FROM runtime-base AS final
 
 COPY --from=wheel-builder /wheels /wheels
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip install --no-index --find-links=/wheels /wheels/*.whl && \
     rm -rf /wheels && \
     chown -R appuser:appuser /opt/venv

--- a/src/services/calculators/cost_calculator_service/Dockerfile
+++ b/src/services/calculators/cost_calculator_service/Dockerfile
@@ -39,7 +39,7 @@ COPY src/libs/portfolio-common /build/src/libs/portfolio-common
 COPY src/services/calculators/cost_calculator_service/pyproject.toml /build/src/services/calculators/cost_calculator_service/pyproject.toml
 COPY src/services/calculators/cost_calculator_service/app /build/src/services/calculators/cost_calculator_service/app
 
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip wheel --wheel-dir /wheels \
     /build/src/libs/portfolio-common \
     /build/src/services/calculators/cost_calculator_service
@@ -47,7 +47,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 FROM runtime-base AS final
 
 COPY --from=wheel-builder /wheels /wheels
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip install --no-index --find-links=/wheels /wheels/*.whl && \
     rm -rf /wheels && \
     chown -R appuser:appuser /opt/venv

--- a/src/services/calculators/position_calculator/Dockerfile
+++ b/src/services/calculators/position_calculator/Dockerfile
@@ -39,7 +39,7 @@ COPY src/libs/portfolio-common /build/src/libs/portfolio-common
 COPY src/services/calculators/position_calculator/pyproject.toml /build/src/services/calculators/position_calculator/pyproject.toml
 COPY src/services/calculators/position_calculator/app /build/src/services/calculators/position_calculator/app
 
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip wheel --wheel-dir /wheels \
     /build/src/libs/portfolio-common \
     /build/src/services/calculators/position_calculator
@@ -47,7 +47,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 FROM runtime-base AS final
 
 COPY --from=wheel-builder /wheels /wheels
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip install --no-index --find-links=/wheels /wheels/*.whl && \
     rm -rf /wheels && \
     chown -R appuser:appuser /opt/venv

--- a/src/services/calculators/position_valuation_calculator/Dockerfile
+++ b/src/services/calculators/position_valuation_calculator/Dockerfile
@@ -39,7 +39,7 @@ COPY src/libs/portfolio-common /build/src/libs/portfolio-common
 COPY src/services/calculators/position_valuation_calculator/pyproject.toml /build/src/services/calculators/position_valuation_calculator/pyproject.toml
 COPY src/services/calculators/position_valuation_calculator/app /build/src/services/calculators/position_valuation_calculator/app
 
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip wheel --wheel-dir /wheels \
     /build/src/libs/portfolio-common \
     /build/src/services/calculators/position_valuation_calculator
@@ -47,7 +47,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 FROM runtime-base AS final
 
 COPY --from=wheel-builder /wheels /wheels
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip install --no-index --find-links=/wheels /wheels/*.whl && \
     rm -rf /wheels && \
     chown -R appuser:appuser /opt/venv

--- a/src/services/event_replay_service/Dockerfile
+++ b/src/services/event_replay_service/Dockerfile
@@ -39,7 +39,7 @@ COPY src/libs/portfolio-common /build/src/libs/portfolio-common
 COPY src/services/event_replay_service/pyproject.toml /build/src/services/event_replay_service/pyproject.toml
 COPY src/services/event_replay_service/app /build/src/services/event_replay_service/app
 
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip wheel --wheel-dir /wheels \
     /build/src/libs/portfolio-common \
     /build/src/services/event_replay_service
@@ -47,7 +47,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 FROM runtime-base AS final
 
 COPY --from=wheel-builder /wheels /wheels
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip install --no-index --find-links=/wheels /wheels/*.whl && \
     rm -rf /wheels && \
     chown -R appuser:appuser /opt/venv

--- a/src/services/financial_reconciliation_service/Dockerfile
+++ b/src/services/financial_reconciliation_service/Dockerfile
@@ -39,7 +39,7 @@ COPY src/libs/portfolio-common /build/src/libs/portfolio-common
 COPY src/services/financial_reconciliation_service/pyproject.toml /build/src/services/financial_reconciliation_service/pyproject.toml
 COPY src/services/financial_reconciliation_service/app /build/src/services/financial_reconciliation_service/app
 
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     rm -rf /wheels && mkdir -p /wheels && \
     pip wheel --wheel-dir /wheels \
     /build/src/libs/portfolio-common \
@@ -48,7 +48,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 FROM runtime-base AS final
 
 COPY --from=wheel-builder /wheels /wheels
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip install --no-index --find-links=/wheels /wheels/*.whl && \
     rm -rf /wheels && \
     chown -R appuser:appuser /opt/venv

--- a/src/services/ingestion_service/Dockerfile
+++ b/src/services/ingestion_service/Dockerfile
@@ -39,7 +39,7 @@ COPY src/libs/portfolio-common /build/src/libs/portfolio-common
 COPY src/services/ingestion_service/pyproject.toml /build/src/services/ingestion_service/pyproject.toml
 COPY src/services/ingestion_service/app /build/src/services/ingestion_service/app
 
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip wheel --wheel-dir /wheels \
     /build/src/libs/portfolio-common \
     /build/src/services/ingestion_service
@@ -47,7 +47,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 FROM runtime-base AS final
 
 COPY --from=wheel-builder /wheels /wheels
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip install --no-index --find-links=/wheels /wheels/*.whl && \
     rm -rf /wheels && \
     chown -R appuser:appuser /opt/venv

--- a/src/services/persistence_service/Dockerfile
+++ b/src/services/persistence_service/Dockerfile
@@ -39,7 +39,7 @@ COPY src/libs/portfolio-common /build/src/libs/portfolio-common
 COPY src/services/persistence_service/pyproject.toml /build/src/services/persistence_service/pyproject.toml
 COPY src/services/persistence_service/app /build/src/services/persistence_service/app
 
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip wheel --wheel-dir /wheels \
     /build/src/libs/portfolio-common \
     /build/src/services/persistence_service
@@ -51,7 +51,7 @@ COPY alembic.ini /app/alembic.ini
 COPY alembic /app/alembic
 COPY tools/kafka_setup.py /app/tools/kafka_setup.py
 COPY tools/demo_data_pack.py /app/tools/demo_data_pack.py
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip install --no-index --find-links=/wheels /wheels/*.whl && \
     rm -rf /wheels && \
     chown -R appuser:appuser /opt/venv /app

--- a/src/services/pipeline_orchestrator_service/Dockerfile
+++ b/src/services/pipeline_orchestrator_service/Dockerfile
@@ -39,7 +39,7 @@ COPY src/libs/portfolio-common /build/src/libs/portfolio-common
 COPY src/services/pipeline_orchestrator_service/pyproject.toml /build/src/services/pipeline_orchestrator_service/pyproject.toml
 COPY src/services/pipeline_orchestrator_service/app /build/src/services/pipeline_orchestrator_service/app
 
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip wheel --wheel-dir /wheels \
     /build/src/libs/portfolio-common \
     /build/src/services/pipeline_orchestrator_service
@@ -47,7 +47,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 FROM runtime-base AS final
 
 COPY --from=wheel-builder /wheels /wheels
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip install --no-index --find-links=/wheels /wheels/*.whl && \
     rm -rf /wheels && \
     chown -R appuser:appuser /opt/venv

--- a/src/services/portfolio_aggregation_service/Dockerfile
+++ b/src/services/portfolio_aggregation_service/Dockerfile
@@ -39,7 +39,7 @@ COPY src/libs/portfolio-common /build/src/libs/portfolio-common
 COPY src/services/portfolio_aggregation_service/pyproject.toml /build/src/services/portfolio_aggregation_service/pyproject.toml
 COPY src/services/portfolio_aggregation_service/app /build/src/services/portfolio_aggregation_service/app
 
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip wheel --wheel-dir /wheels \
     /build/src/libs/portfolio-common \
     /build/src/services/portfolio_aggregation_service
@@ -47,7 +47,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 FROM runtime-base AS final
 
 COPY --from=wheel-builder /wheels /wheels
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip install --no-index --find-links=/wheels /wheels/*.whl && \
     rm -rf /wheels && \
     chown -R appuser:appuser /opt/venv

--- a/src/services/query_control_plane_service/Dockerfile
+++ b/src/services/query_control_plane_service/Dockerfile
@@ -39,7 +39,7 @@ COPY src/libs/portfolio-common /build/src/libs/portfolio-common
 COPY src/services/query_control_plane_service/pyproject.toml /build/src/services/query_control_plane_service/pyproject.toml
 COPY src/services/query_control_plane_service/app /build/src/services/query_control_plane_service/app
 
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip wheel --wheel-dir /wheels \
     /build/src/libs/portfolio-common \
     /build/src/services/query_control_plane_service
@@ -47,7 +47,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 FROM runtime-base AS final
 
 COPY --from=wheel-builder /wheels /wheels
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip install --no-index --find-links=/wheels /wheels/*.whl && \
     rm -rf /wheels && \
     chown -R appuser:appuser /opt/venv

--- a/src/services/query_service/Dockerfile
+++ b/src/services/query_service/Dockerfile
@@ -39,7 +39,7 @@ COPY src/libs/portfolio-common /build/src/libs/portfolio-common
 COPY src/services/query_service/pyproject.toml /build/src/services/query_service/pyproject.toml
 COPY src/services/query_service/app /build/src/services/query_service/app
 
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip wheel --wheel-dir /wheels \
     /build/src/libs/portfolio-common \
     /build/src/services/query_service
@@ -47,7 +47,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 FROM runtime-base AS final
 
 COPY --from=wheel-builder /wheels /wheels
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip install --no-index --find-links=/wheels /wheels/*.whl && \
     rm -rf /wheels && \
     chown -R appuser:appuser /opt/venv

--- a/src/services/timeseries_generator_service/Dockerfile
+++ b/src/services/timeseries_generator_service/Dockerfile
@@ -39,7 +39,7 @@ COPY src/libs/portfolio-common /build/src/libs/portfolio-common
 COPY src/services/timeseries_generator_service/pyproject.toml /build/src/services/timeseries_generator_service/pyproject.toml
 COPY src/services/timeseries_generator_service/app /build/src/services/timeseries_generator_service/app
 
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip wheel --wheel-dir /wheels \
     /build/src/libs/portfolio-common \
     /build/src/services/timeseries_generator_service
@@ -47,7 +47,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 FROM runtime-base AS final
 
 COPY --from=wheel-builder /wheels /wheels
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip install --no-index --find-links=/wheels /wheels/*.whl && \
     rm -rf /wheels && \
     chown -R appuser:appuser /opt/venv

--- a/src/services/valuation_orchestrator_service/Dockerfile
+++ b/src/services/valuation_orchestrator_service/Dockerfile
@@ -39,7 +39,7 @@ COPY src/libs/portfolio-common /build/src/libs/portfolio-common
 COPY src/services/valuation_orchestrator_service/pyproject.toml /build/src/services/valuation_orchestrator_service/pyproject.toml
 COPY src/services/valuation_orchestrator_service/app /build/src/services/valuation_orchestrator_service/app
 
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip wheel --wheel-dir /wheels \
     /build/src/libs/portfolio-common \
     /build/src/services/valuation_orchestrator_service
@@ -47,7 +47,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 FROM runtime-base AS final
 
 COPY --from=wheel-builder /wheels /wheels
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip install --no-index --find-links=/wheels /wheels/*.whl && \
     rm -rf /wheels && \
     chown -R appuser:appuser /opt/venv

--- a/tests/unit/scripts/test_dependency_health_check.py
+++ b/tests/unit/scripts/test_dependency_health_check.py
@@ -49,4 +49,6 @@ def test_pip_audit_command_scopes_to_site_packages_path() -> None:
         "pip_audit",
         "--path",
         str(site_packages),
+        "--ignore-vuln",
+        "CVE-2026-3219",
     ]


### PR DESCRIPTION
## Summary
- add sharing=locked to service Dockerfile pip cache mounts
- prevent parallel BuildKit builds from corrupting shared wheel cache during production-shaped Docker rebuilds

## Evidence
- rg -P 'RUN --mount=type=cache,target=/root/.cache/pip(?!,sharing=locked)' src/services -S returns no matches
- lotus-workbench/scripts/live/Start-LotusFrontOfficeCanonical.ps1 -CleanCoreState -BuildImages -RunValidation