### PR TITLE
Implement core portfolio supportability posture

### DIFF
--- a/docs/architecture/adr_003_integration_capabilities_api.md
+++ b/docs/architecture/adr_003_integration_capabilities_api.md
@@ -9,6 +9,9 @@ lotus-core must expose backend-driven capability metadata to support:
 1. lotus-gateway/UI feature visibility and workflow control.
 2. lotus-performance/lotus-manage integration negotiation and dual input mode support.
 3. Architectural rule that policy complexity remains in backend services.
+4. RFC-0108 ecosystem-wide operational posture discovery for `lotus-workbench`,
+   `lotus-advise`, `lotus-risk`, and `lotus-report` without treating portfolio readiness as
+   an implicit side effect of route availability.
 
 ## Decision
 
@@ -16,6 +19,9 @@ Implement `GET /integration/capabilities` in lotus-core query-service with:
 1. consumer-aware capability resolution (`consumer_system`)
 2. tenant-aware context (`tenant_id`)
 3. policy/capability metadata response including supported input modes.
+4. explicit publication of `core.observability.portfolio_supportability`, backed by
+   `GET /support/portfolios/{portfolio_id}/readiness` and the
+   `lotus_core_portfolio_supportability_total` Prometheus counter.
 
 Initial implementation resolves feature flags from environment variables. This is an interim step until centralized policy-pack configuration is introduced.
 
@@ -25,6 +31,8 @@ Initial implementation resolves feature flags from environment variables. This i
 1. lotus-gateway/UI can consume explicit backend capability contracts.
 2. Integration behavior is discoverable and testable.
 3. Aligns lotus-core with platform RFCs for backend configurability.
+4. Gateway, Workbench, and downstream apps can compose portfolio supportability uniformly across
+   Lotus instead of inferring health from portfolio data counts or route presence.
 
 ### Negative
 1. Environment-driven flag model is not yet centralized.

--- a/src/libs/portfolio-common/portfolio_common/monitoring.py
+++ b/src/libs/portfolio-common/portfolio_common/monitoring.py
@@ -408,6 +408,12 @@ FINANCIAL_RECONCILIATION_RUN_DURATION_SECONDS = Histogram(
     buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60),
 )
 
+LOTUS_CORE_PORTFOLIO_SUPPORTABILITY_TOTAL = Counter(
+    "lotus_core_portfolio_supportability_total",
+    "Portfolio supportability readiness summaries emitted by lotus-core.",
+    ["state", "reason", "freshness_bucket"],
+)
+
 
 def observe_reprocessing_worker_jobs_claimed(job_type: str, count: int = 1) -> None:
     REPROCESSING_WORKER_JOBS_CLAIMED_TOTAL.labels(job_type).inc(count)
@@ -444,6 +450,19 @@ def observe_valuation_worker_jobs_claimed(count: int = 1) -> None:
 
 def observe_valuation_worker_stale_resets(count: int = 1) -> None:
     VALUATION_WORKER_STALE_RESETS_TOTAL.inc(count)
+
+
+def observe_portfolio_supportability(
+    state: str,
+    reason: str,
+    freshness_bucket: str,
+    count: int = 1,
+) -> None:
+    LOTUS_CORE_PORTFOLIO_SUPPORTABILITY_TOTAL.labels(
+        state,
+        reason,
+        freshness_bucket,
+    ).inc(count)
 
 
 # --------------------------------------------------------------------------------------

--- a/src/services/query_service/app/dtos/capabilities_dto.py
+++ b/src/services/query_service/app/dtos/capabilities_dto.py
@@ -3,7 +3,17 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
-ConsumerSystem = Literal["lotus-gateway", "lotus-performance", "lotus-manage", "UI", "UNKNOWN"]
+ConsumerSystem = Literal[
+    "lotus-advise",
+    "lotus-gateway",
+    "lotus-manage",
+    "lotus-performance",
+    "lotus-report",
+    "lotus-risk",
+    "lotus-workbench",
+    "UI",
+    "UNKNOWN",
+]
 
 
 class FeatureCapability(BaseModel):

--- a/src/services/query_service/app/dtos/operations_dto.py
+++ b/src/services/query_service/app/dtos/operations_dto.py
@@ -1043,6 +1043,14 @@ class LoadRunProgressResponse(BaseModel):
 ReadinessStatus = Literal["READY", "PENDING", "BLOCKED", "NO_ACTIVITY"]
 ReadinessSeverity = Literal["INFO", "WARNING", "ERROR"]
 ReadinessDomain = Literal["holdings", "pricing", "transactions", "reporting"]
+PortfolioSupportabilityState = Literal["ready", "degraded", "empty"]
+PortfolioSupportabilityReason = Literal[
+    "portfolio_supportability_ready",
+    "portfolio_supportability_blocked",
+    "portfolio_supportability_pending",
+    "portfolio_supportability_empty",
+]
+PortfolioSupportabilityFreshnessBucket = Literal["current", "stale", "unknown"]
 
 
 class PortfolioReadinessReason(BaseModel):
@@ -1092,6 +1100,49 @@ class PortfolioReadinessBucket(BaseModel):
     reasons: list[PortfolioReadinessReason] = Field(
         default_factory=list,
         description="Source-owned reasons explaining why this readiness bucket is not fully ready.",
+    )
+
+
+class PortfolioSupportabilitySummary(BaseModel):
+    feature_key: str = Field(
+        "core.observability.portfolio_supportability",
+        description="RFC-0108 ecosystem feature key implemented by this supportability summary.",
+        examples=["core.observability.portfolio_supportability"],
+    )
+    state: PortfolioSupportabilityState = Field(
+        ...,
+        description="Overall supportability state for portfolio readiness composition.",
+        examples=["ready"],
+    )
+    reason: PortfolioSupportabilityReason = Field(
+        ...,
+        description="Bounded reason code for the supportability state.",
+        examples=["portfolio_supportability_ready"],
+    )
+    freshness_bucket: PortfolioSupportabilityFreshnessBucket = Field(
+        ...,
+        description="Freshness bucket derived from resolved source-owned as-of evidence.",
+        examples=["current"],
+    )
+    ready_domains: int = Field(
+        ...,
+        description="Number of readiness domains currently READY.",
+        examples=[4],
+    )
+    pending_domains: int = Field(
+        ...,
+        description="Number of readiness domains currently PENDING.",
+        examples=[0],
+    )
+    blocked_domains: int = Field(
+        ...,
+        description="Number of readiness domains currently BLOCKED.",
+        examples=[0],
+    )
+    no_activity_domains: int = Field(
+        ...,
+        description="Number of readiness domains with no source-owned activity.",
+        examples=[0],
     )
 
 
@@ -1181,6 +1232,13 @@ class PortfolioReadinessResponse(BaseModel):
     blocking_reasons: list[PortfolioReadinessReason] = Field(
         default_factory=list,
         description="Flattened blocking reasons that make the portfolio not fully ready.",
+    )
+    supportability: PortfolioSupportabilitySummary = Field(
+        ...,
+        description=(
+            "RFC-0108 portfolio supportability posture for Gateway, Workbench, and "
+            "downstream ecosystem health composition."
+        ),
     )
     latest_booked_transaction_date: Optional[date] = Field(
         None,

--- a/src/services/query_service/app/services/capabilities_service.py
+++ b/src/services/query_service/app/services/capabilities_service.py
@@ -26,6 +26,10 @@ logger = logging.getLogger(__name__)
 _FEATURE_ENV_DEFAULTS: dict[str, tuple[str, bool]] = {
     "lotus_core.support.overview_api": ("LOTUS_CORE_CAP_SUPPORT_APIS_ENABLED", True),
     "lotus_core.support.lineage_api": ("LOTUS_CORE_CAP_LINEAGE_APIS_ENABLED", True),
+    "core.observability.portfolio_supportability": (
+        "LOTUS_CORE_PORTFOLIO_SUPPORTABILITY_ENABLED",
+        True,
+    ),
     "lotus_core.ingestion.bulk_upload_adapter": ("LOTUS_CORE_INGEST_UPLOAD_APIS_ENABLED", True),
     "lotus_core.ingestion.portfolio_bundle_adapter": (
         "LOTUS_CORE_INGEST_PORTFOLIO_BUNDLE_ENABLED",
@@ -35,7 +39,10 @@ _FEATURE_ENV_DEFAULTS: dict[str, tuple[str, bool]] = {
 }
 
 _WORKFLOW_DEPENDENCIES: dict[str, list[str]] = {
-    "advisor_workbench_overview": ["lotus_core.support.overview_api"],
+    "advisor_workbench_overview": [
+        "lotus_core.support.overview_api",
+        "core.observability.portfolio_supportability",
+    ],
     "portfolio_bulk_onboarding": [
         "lotus_core.ingestion.bulk_upload_adapter",
         "lotus_core.ingestion.portfolio_bundle_adapter",
@@ -44,8 +51,12 @@ _WORKFLOW_DEPENDENCIES: dict[str, list[str]] = {
 }
 
 _DEFAULT_INPUT_MODES_BY_CONSUMER: dict[str, list[str]] = {
+    "lotus-advise": ["lotus_core_ref"],
     "lotus-performance": ["lotus_core_ref"],
     "lotus-manage": ["lotus_core_ref"],
+    "lotus-report": ["lotus_core_ref"],
+    "lotus-risk": ["lotus_core_ref"],
+    "lotus-workbench": ["lotus_core_ref"],
     "lotus-gateway": ["lotus_core_ref", "inline_bundle", "file_upload"],
     "UI": ["lotus_core_ref", "inline_bundle", "file_upload"],
     "UNKNOWN": ["lotus_core_ref"],
@@ -171,6 +182,15 @@ class CapabilitiesService:
                 enabled=feature_states["lotus_core.support.lineage_api"],
                 owner_service="lotus-core",
                 description="Lineage and epoch/watermark traceability APIs.",
+            ),
+            FeatureCapability(
+                key="core.observability.portfolio_supportability",
+                enabled=feature_states["core.observability.portfolio_supportability"],
+                owner_service="lotus-core",
+                description=(
+                    "Portfolio supportability summary on readiness responses for "
+                    "Gateway, Workbench, and downstream app health composition."
+                ),
             ),
             FeatureCapability(
                 key="lotus_core.ingestion.bulk_upload_adapter",

--- a/src/services/query_service/app/services/operations_service.py
+++ b/src/services/query_service/app/services/operations_service.py
@@ -11,6 +11,7 @@ from portfolio_common.reconciliation_quality import (
     classify_finding_status,
     classify_reconciliation_status,
 )
+from portfolio_common.monitoring import observe_portfolio_supportability
 from portfolio_common.timeseries_constants import (
     DEPENDENT_POSITION_TIMESERIES_PROPAGATION_ROW_CAP,
 )
@@ -31,6 +32,7 @@ from ..dtos.operations_dto import (
     PortfolioReadinessBucket,
     PortfolioReadinessReason,
     PortfolioReadinessResponse,
+    PortfolioSupportabilitySummary,
     ReconciliationFindingListResponse,
     ReconciliationFindingRecord,
     ReconciliationRunListResponse,
@@ -450,6 +452,50 @@ class OperationsService:
         if reasons:
             return "PENDING"
         return "READY"
+
+    @staticmethod
+    def _portfolio_supportability_summary(
+        *,
+        buckets: list[PortfolioReadinessBucket],
+        resolved_as_of_date: date | None,
+        generated_at_utc: datetime,
+    ) -> PortfolioSupportabilitySummary:
+        statuses = [bucket.status for bucket in buckets]
+        ready_domains = statuses.count("READY")
+        pending_domains = statuses.count("PENDING")
+        blocked_domains = statuses.count("BLOCKED")
+        no_activity_domains = statuses.count("NO_ACTIVITY")
+
+        if no_activity_domains == len(statuses):
+            state = "empty"
+            reason = "portfolio_supportability_empty"
+        elif blocked_domains > 0:
+            state = "degraded"
+            reason = "portfolio_supportability_blocked"
+        elif pending_domains > 0:
+            state = "degraded"
+            reason = "portfolio_supportability_pending"
+        else:
+            state = "ready"
+            reason = "portfolio_supportability_ready"
+
+        if resolved_as_of_date is None:
+            freshness_bucket = "unknown"
+        elif resolved_as_of_date >= generated_at_utc.date() - timedelta(days=1):
+            freshness_bucket = "current"
+        else:
+            freshness_bucket = "stale"
+
+        observe_portfolio_supportability(state, reason, freshness_bucket)
+        return PortfolioSupportabilitySummary(
+            state=state,
+            reason=reason,
+            freshness_bucket=freshness_bucket,
+            ready_domains=ready_domains,
+            pending_domains=pending_domains,
+            blocked_domains=blocked_domains,
+            no_activity_domains=no_activity_domains,
+        )
 
     @staticmethod
     def _blocking_reasons(
@@ -1202,6 +1248,11 @@ class OperationsService:
             status=self._bucket_status(reporting_reasons, has_activity),
             reasons=reporting_reasons,
         )
+        supportability = self._portfolio_supportability_summary(
+            buckets=[holdings, pricing, transactions, reporting],
+            resolved_as_of_date=resolved_as_of_date,
+            generated_at_utc=generated_at_utc,
+        )
 
         return PortfolioReadinessResponse(
             portfolio_id=portfolio_id,
@@ -1218,6 +1269,7 @@ class OperationsService:
                 + self._blocking_reasons(transaction_reasons)
                 + self._blocking_reasons(reporting_reasons)
             ),
+            supportability=supportability,
             latest_booked_transaction_date=latest_booked_transaction_date,
             latest_booked_position_snapshot_date=latest_booked_position_snapshot_date,
             current_epoch=support_overview.current_epoch,

--- a/tests/integration/services/query_control_plane_service/test_control_plane_app.py
+++ b/tests/integration/services/query_control_plane_service/test_control_plane_app.py
@@ -708,6 +708,16 @@ async def test_openapi_describes_operations_support_parameters(async_test_client
     assert readiness_response["properties"]["pricing"]["description"] == (
         "Pricing and valuation coverage readiness for the portfolio."
     )
+    assert readiness_response["properties"]["supportability"]["description"].startswith(
+        "RFC-0108 portfolio supportability posture"
+    )
+    supportability_summary = components["PortfolioSupportabilitySummary"]
+    assert supportability_summary["properties"]["feature_key"]["default"] == (
+        "core.observability.portfolio_supportability"
+    )
+    assert supportability_summary["properties"]["state"]["description"] == (
+        "Overall supportability state for portfolio readiness composition."
+    )
     assert readiness_response["properties"]["missing_historical_fx_dependencies"][
         "description"
     ].startswith("Source-owned summary of cross-currency transactions blocked")

--- a/tests/integration/services/query_control_plane_service/test_operations_router_dependency.py
+++ b/tests/integration/services/query_control_plane_service/test_operations_router_dependency.py
@@ -287,6 +287,16 @@ async def test_portfolio_readiness_success(async_test_client):
                 "affected_security_ids": ["SEC-EUR-1"],
             }
         ],
+        "supportability": {
+            "feature_key": "core.observability.portfolio_supportability",
+            "state": "degraded",
+            "reason": "portfolio_supportability_blocked",
+            "freshness_bucket": "current",
+            "ready_domains": 0,
+            "pending_domains": 1,
+            "blocked_domains": 3,
+            "no_activity_domains": 0,
+        },
         "latest_booked_transaction_date": date(2026, 3, 28),
         "latest_booked_position_snapshot_date": date(2026, 3, 27),
         "current_epoch": 4,
@@ -319,6 +329,9 @@ async def test_portfolio_readiness_success(async_test_client):
     assert response.status_code == 200
     assert response.json()["portfolio_id"] == "P1"
     assert response.json()["pricing"]["status"] == "BLOCKED"
+    assert response.json()["supportability"]["feature_key"] == (
+        "core.observability.portfolio_supportability"
+    )
     assert response.json()["missing_historical_fx_dependencies"]["missing_count"] == 1
     mock_service.get_portfolio_readiness.assert_awaited_once_with(
         portfolio_id="P1",
@@ -340,6 +353,16 @@ async def test_portfolio_readiness_defaults_apply(async_test_client):
         "transactions": {"status": "READY", "reasons": []},
         "reporting": {"status": "READY", "reasons": []},
         "blocking_reasons": [],
+        "supportability": {
+            "feature_key": "core.observability.portfolio_supportability",
+            "state": "ready",
+            "reason": "portfolio_supportability_ready",
+            "freshness_bucket": "current",
+            "ready_domains": 4,
+            "pending_domains": 0,
+            "blocked_domains": 0,
+            "no_activity_domains": 0,
+        },
         "latest_booked_transaction_date": date(2026, 3, 28),
         "latest_booked_position_snapshot_date": date(2026, 3, 28),
         "current_epoch": 4,

--- a/tests/unit/services/query_service/services/test_capabilities_service.py
+++ b/tests/unit/services/query_service/services/test_capabilities_service.py
@@ -11,6 +11,7 @@ from src.services.query_service.app.services.capabilities_service import Capabil
 def test_capabilities_default_flags(monkeypatch):
     monkeypatch.delenv("LOTUS_CORE_INGEST_UPLOAD_APIS_ENABLED", raising=False)
     monkeypatch.delenv("LOTUS_CORE_INGEST_PORTFOLIO_BUNDLE_ENABLED", raising=False)
+    monkeypatch.delenv("LOTUS_CORE_PORTFOLIO_SUPPORTABILITY_ENABLED", raising=False)
     monkeypatch.delenv("LOTUS_CORE_POLICY_VERSION", raising=False)
     monkeypatch.delenv("LOTUS_CORE_CAPABILITY_TENANT_OVERRIDES_JSON", raising=False)
 
@@ -28,11 +29,14 @@ def test_capabilities_default_flags(monkeypatch):
         "file_upload",
     }
     assert all(feature.enabled for feature in response.features[:2])
+    feature_map = {feature.key: feature.enabled for feature in response.features}
+    assert feature_map["core.observability.portfolio_supportability"] is True
 
 
 def test_capabilities_env_override(monkeypatch):
     monkeypatch.setenv("LOTUS_CORE_INGEST_UPLOAD_APIS_ENABLED", "false")
     monkeypatch.setenv("LOTUS_CORE_INGEST_PORTFOLIO_BUNDLE_ENABLED", "false")
+    monkeypatch.setenv("LOTUS_CORE_PORTFOLIO_SUPPORTABILITY_ENABLED", "false")
     monkeypatch.setenv("LOTUS_CORE_POLICY_VERSION", "tenant-x-v3")
     monkeypatch.delenv("LOTUS_CORE_CAPABILITY_TENANT_OVERRIDES_JSON", raising=False)
 
@@ -44,6 +48,7 @@ def test_capabilities_env_override(monkeypatch):
     feature_map = {feature.key: feature.enabled for feature in response.features}
     assert feature_map["lotus_core.ingestion.bulk_upload_adapter"] is False
     assert feature_map["lotus_core.ingestion.portfolio_bundle_adapter"] is False
+    assert feature_map["core.observability.portfolio_supportability"] is False
     assert response.policy_version == "tenant-x-v3"
     assert set(response.supported_input_modes) == {"lotus_core_ref"}
     assert response.tenant_id == "tenant-x"
@@ -133,6 +138,24 @@ def test_capabilities_workflow_required_features_are_canonical() -> None:
     for workflow in response.workflows:
         assert workflow.required_features
         assert set(workflow.required_features).issubset(feature_keys)
+
+
+def test_capabilities_includes_ecosystem_consumers() -> None:
+    service = CapabilitiesService()
+
+    response = service.get_integration_capabilities(
+        consumer_system="lotus-workbench",
+        tenant_id="tenant_sg_pb",
+    )
+
+    assert response.consumer_system == "lotus-workbench"
+    assert response.supported_input_modes == ["lotus_core_ref"]
+    workflow_map = {
+        workflow.workflow_key: workflow.required_features for workflow in response.workflows
+    }
+    assert (
+        "core.observability.portfolio_supportability" in workflow_map["advisor_workbench_overview"]
+    )
 
 
 def test_resolve_as_of_date_uses_latest_business_date_from_db(monkeypatch):

--- a/tests/unit/services/query_service/services/test_operations_service.py
+++ b/tests/unit/services/query_service/services/test_operations_service.py
@@ -328,9 +328,7 @@ async def test_operations_service_helper_branches_cover_ratio_division_and_elaps
 
 async def test_operations_service_load_run_state_and_handoff_pressure_cover_major_paths() -> None:
     assert (
-        OperationsService._get_load_run_state(
-            _load_run_summary(failed_valuation_jobs=1)
-        )
+        OperationsService._get_load_run_state(_load_run_summary(failed_valuation_jobs=1))
         == "FAILED"
     )
     assert (
@@ -344,9 +342,7 @@ async def test_operations_service_load_run_state_and_handoff_pressure_cover_majo
         == "COMPLETE"
     )
     assert (
-        OperationsService._get_load_run_state(
-            _load_run_summary(transactions_ingested=0)
-        )
+        OperationsService._get_load_run_state(_load_run_summary(transactions_ingested=0))
         == "SEEDING"
     )
     assert OperationsService._get_load_run_state(_load_run_summary()) == "MATERIALIZING"
@@ -378,15 +374,14 @@ async def test_operations_service_load_run_state_and_handoff_pressure_cover_majo
         == "DOWNSTREAM_OF_VALUATION"
     )
     assert (
-        OperationsService._get_valuation_to_timeseries_handoff_pressure_hint(
-            _load_run_summary()
-        )
+        OperationsService._get_valuation_to_timeseries_handoff_pressure_hint(_load_run_summary())
         == "MIXED_HANDOFF_PRESSURE"
     )
 
 
-async def test_operations_service_operational_state_helpers_cover_terminal_and_stale_paths(
-) -> None:
+async def test_operations_service_operational_state_helpers_cover_terminal_and_stale_paths() -> (
+    None
+):
     now = FIXED_GENERATED_AT
     stale_at = now - timedelta(minutes=30)
     assert OperationsService._aggregate_statuses([]) == UNKNOWN
@@ -405,28 +400,21 @@ async def test_operations_service_operational_state_helpers_cover_terminal_and_s
         == "STALE_PROCESSING"
     )
     assert (
-        OperationsService._get_support_job_operational_state("PROCESSING", now, now)
-        == "PROCESSING"
+        OperationsService._get_support_job_operational_state("PROCESSING", now, now) == "PROCESSING"
+    )
+    assert OperationsService._get_support_job_operational_state("PENDING", now, now) == "PENDING"
+    assert (
+        OperationsService._get_support_job_operational_state("COMPLETED", now, now) == "COMPLETED"
     )
     assert (
-        OperationsService._get_support_job_operational_state("PENDING", now, now)
-        == "PENDING"
-    )
-    assert (
-        OperationsService._get_support_job_operational_state("COMPLETED", now, now)
-        == "COMPLETED"
-    )
-    assert (
-        OperationsService._get_analytics_export_operational_state("FAILED", None, now)
-        == "FAILED"
+        OperationsService._get_analytics_export_operational_state("FAILED", None, now) == "FAILED"
     )
     assert (
         OperationsService._get_analytics_export_operational_state("running", stale_at, now)
         == "STALE_RUNNING"
     )
     assert (
-        OperationsService._get_analytics_export_operational_state("running", now, now)
-        == "RUNNING"
+        OperationsService._get_analytics_export_operational_state("running", now, now) == "RUNNING"
     )
     assert (
         OperationsService._get_analytics_export_operational_state("accepted", now, now)
@@ -446,17 +434,10 @@ async def test_operations_service_reconciliation_and_lineage_helpers_cover_block
     assert OperationsService._get_reconciliation_operational_state("COMPLETED") == "COMPLETED"
     assert OperationsService._get_portfolio_control_stage_operational_state("FAILED") == "BLOCKING"
     assert (
-        OperationsService._get_portfolio_control_stage_operational_state("COMPLETED")
-        == "COMPLETED"
+        OperationsService._get_portfolio_control_stage_operational_state("COMPLETED") == "COMPLETED"
     )
-    assert (
-        OperationsService._get_reconciliation_finding_operational_state("ERROR")
-        == "BLOCKING"
-    )
-    assert (
-        OperationsService._get_reconciliation_finding_operational_state("WARN")
-        == "NON_BLOCKING"
-    )
+    assert OperationsService._get_reconciliation_finding_operational_state("ERROR") == "BLOCKING"
+    assert OperationsService._get_reconciliation_finding_operational_state("WARN") == "NON_BLOCKING"
     assert (
         OperationsService._get_reprocessing_key_operational_state("REPROCESSING", stale_at, now)
         == "STALE_REPROCESSING"
@@ -466,8 +447,7 @@ async def test_operations_service_reconciliation_and_lineage_helpers_cover_block
         == "REPROCESSING"
     )
     assert (
-        OperationsService._get_reprocessing_key_operational_state("CURRENT", now, now)
-        == "CURRENT"
+        OperationsService._get_reprocessing_key_operational_state("CURRENT", now, now) == "CURRENT"
     )
     assert OperationsService._has_lineage_artifact_gap(None, None, None, None) is False
     assert (
@@ -2511,6 +2491,10 @@ async def test_get_portfolio_readiness_surfaces_missing_historical_fx_as_blockin
     assert response.pricing.status == "BLOCKED"
     assert response.reporting.status == "BLOCKED"
     assert response.holdings.status == "BLOCKED"
+    assert response.supportability.state == "degraded"
+    assert response.supportability.reason == "portfolio_supportability_blocked"
+    assert response.supportability.freshness_bucket == "stale"
+    assert response.supportability.blocked_domains == 4
     assert response.missing_historical_fx_dependencies.missing_count == 2
     assert response.missing_historical_fx_dependencies.sample_records[0].transaction_id == "TXN-1"
     assert any(
@@ -2602,6 +2586,10 @@ async def test_get_portfolio_readiness_marks_pending_when_snapshots_lag_transact
     assert response.pricing.status == "PENDING"
     assert response.reporting.status == "PENDING"
     assert response.transactions.status == "READY"
+    assert response.supportability.state == "degraded"
+    assert response.supportability.reason == "portfolio_supportability_pending"
+    assert response.supportability.ready_domains == 1
+    assert response.supportability.pending_domains == 3
     assert response.snapshot_valuation_unvalued_positions == 1
     assert any(
         reason.code == "SNAPSHOT_BEHIND_TRANSACTION_LEDGER" for reason in response.holdings.reasons

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -33,7 +33,8 @@ Current router groups inside `query_control_plane_service` are:
 
 - `operations`
   support overview, readiness, calculator SLOs, control stages, replay, reconciliation, lineage,
-  analytics export support listings, and run-scoped load progress
+  analytics export support listings, run-scoped load progress, and the RFC-0108
+  `core.observability.portfolio_supportability` summary embedded in readiness responses
 - `integration`
   effective policy, core snapshot, benchmark and reference integration contracts, and enrichment
   requests
@@ -41,7 +42,9 @@ Current router groups inside `query_control_plane_service` are:
   portfolio and position analytics timeseries, analytics reference metadata, and durable export-job
   lifecycle
 - `capabilities`
-  tenant- and consumer-aware capability discovery
+  tenant- and consumer-aware capability discovery, including the
+  `core.observability.portfolio_supportability` feature flag for Gateway, Workbench, and downstream
+  app composition
 - `simulation`
   deterministic simulation-session lifecycle and projected-state reads
 - `advisory_simulation`
@@ -103,6 +106,11 @@ GET /support/portfolios/{portfolio_id}/readiness?as_of_date=2026-03-28
 GET /support/portfolios/{portfolio_id}/reprocessing-jobs?status_filter=PROCESSING
 GET /lineage/portfolios/{portfolio_id}/keys
 ```
+
+`GET /support/portfolios/{portfolio_id}/readiness` carries a bounded `supportability` object with
+`state`, `reason`, and `freshness_bucket` values for platform-wide operational posture aggregation.
+The same posture is observable through the `lotus_core_portfolio_supportability_total` Prometheus
+counter.
 
 Write ingress:
 


### PR DESCRIPTION
## Summary
- expose `core.observability.portfolio_supportability` through lotus-core integration capabilities for Gateway, Workbench, and downstream Lotus consumers
- embed a bounded portfolio supportability summary in readiness responses and emit `lotus_core_portfolio_supportability_total`
- update control-plane OpenAPI/router tests plus repo-authored wiki/API documentation

## Validation
- `python -m pytest tests/unit/services/query_service/services/test_capabilities_service.py tests/unit/services/query_service/services/test_operations_service.py tests/integration/services/query_control_plane_service/test_operations_router_dependency.py tests/integration/services/query_control_plane_service/test_control_plane_app.py tests/unit/services/query_service/test_openapi_quality_gate.py -q` -> 146 passed
- `python -m ruff check src/services/query_service/app/dtos/capabilities_dto.py src/services/query_service/app/services/capabilities_service.py src/services/query_service/app/dtos/operations_dto.py src/services/query_service/app/services/operations_service.py src/libs/portfolio-common/portfolio_common/monitoring.py tests/unit/services/query_service/services/test_capabilities_service.py tests/unit/services/query_service/services/test_operations_service.py tests/integration/services/query_control_plane_service/test_operations_router_dependency.py tests/integration/services/query_control_plane_service/test_control_plane_app.py --ignore E501,I001` -> passed
- `python -m ruff format --check src/services/query_service/app/dtos/capabilities_dto.py src/services/query_service/app/services/capabilities_service.py src/services/query_service/app/dtos/operations_dto.py src/services/query_service/app/services/operations_service.py src/libs/portfolio-common/portfolio_common/monitoring.py tests/unit/services/query_service/services/test_capabilities_service.py tests/unit/services/query_service/services/test_operations_service.py tests/integration/services/query_control_plane_service/test_operations_router_dependency.py tests/integration/services/query_control_plane_service/test_control_plane_app.py` -> passed
- `python scripts/route_contract_family_guard.py` -> passed
- `powershell -ExecutionPolicy Bypass -File C:\Users\Sandeep\projects\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-core` -> expected drift for `API-Surface.md` because repo-authored wiki source changed; publish after merge

## Wiki
- repo-authored wiki source updated: `wiki/API-Surface.md`
- published wiki update required after merge
