### PR TITLE
Harden canonical front-office reseed cleanup

### DIFF
--- a/docs/operations/Front-Office-Portfolio-Seed-Runbook.md
+++ b/docs/operations/Front-Office-Portfolio-Seed-Runbook.md
@@ -114,8 +114,13 @@ available, check `portfolio_aggregation_jobs` for a pending backlog and
 requires portfolio aggregation to catch up before workbench validation or demo
 screenshots are accepted.
 
-If a prior local load or performance run polluted shared `lotus-core` Docker state, reset the
-Docker-backed core runtime before reseeding instead of broadening the seed cleanup SQL. The
+The seed cleanup remains bounded to `PB_SG_GLOBAL_BAL_001` data plus known volatile replay fences
+for canonical seed topics. It clears stale local `processed_events` fences that can survive when
+Kafka offsets are reset or reused, but it must not delete unrelated processed-event history or broad
+runtime tables.
+
+If a prior local load or performance run polluted broader shared `lotus-core` Docker state, reset
+the Docker-backed core runtime before reseeding instead of broadening the seed cleanup SQL. The
 governed Workbench startup script accepts `-CleanCoreState` for this purpose.
 
 ## Related Documents

--- a/tests/unit/tools/test_front_office_portfolio_seed.py
+++ b/tests/unit/tools/test_front_office_portfolio_seed.py
@@ -411,14 +411,41 @@ def test_portfolio_seed_cleanup_sql_removes_portfolio_owned_state_before_reseed(
     assert "delete from portfolios where portfolio_id = 'PB_SG_GLOBAL_BAL_001';" in sql
     assert "delete from transaction_costs where transaction_id in" in sql
     assert "delete from reprocessing_jobs;" not in sql
-    assert "service_name = 'position-calculator'" not in sql
-    assert "event_id like 'transaction_processing.ready-%'" not in sql
-    assert "event_id like 'transactions.cost.processed-%'" not in sql
-    assert "service_name = 'cost-calculator'" not in sql
-    assert "service_name = 'cashflow-calculator'" not in sql
-    assert "service_name = 'pipeline-orchestrator-processed-txn'" not in sql
-    assert "service_name = 'persistence-portfolios'" not in sql
-    assert "event_id like 'portfolios.raw.received-%'" not in sql
+    assert "delete from processed_events where service_name in" in sql
+    assert "delete from processed_events where portfolio_id = 'PB_SG_GLOBAL_BAL_001';" in sql
+
+
+def test_portfolio_seed_cleanup_sql_resets_only_volatile_replay_fences():
+    sql = build_portfolio_seed_cleanup_sql(portfolio_id="PB_SG_GLOBAL_BAL_001")
+
+    assert "delete from processed_events where service_name in" in sql
+    assert "'persistence-business-dates'" in sql
+    assert "'persistence-fx-rates'" in sql
+    assert "'persistence-instruments'" in sql
+    assert "'persistence-market-prices'" in sql
+    assert "'persistence-portfolios'" in sql
+    assert "'persistence-transactions'" in sql
+    assert "'cost-calculator'" in sql
+    assert "'position-calculator'" in sql
+    assert "'cashflow-calculator'" in sql
+    assert "'pipeline-orchestrator-processed-txn'" in sql
+    assert "'price-event-reprocessing-trigger'" in sql
+    assert "'position-valuation-calculator'" in sql
+    assert "event_id like 'business_dates.raw.received-%'" in sql
+    assert "event_id like 'fx_rates.raw.received-%'" in sql
+    assert "event_id like 'instruments.raw.received-%'" in sql
+    assert "event_id like 'market_prices.raw.received-%'" in sql
+    assert "event_id like 'portfolios.raw.received-%'" in sql
+    assert "event_id like 'market_prices.persisted-%'" in sql
+    assert "event_id like 'transactions.reprocessing.requested-%'" in sql
+    assert "event_id like 'transactions.persisted-%'" in sql
+    assert "event_id like 'transactions.cost.processed-%'" in sql
+    assert "event_id like 'transaction_processing.ready-%'" in sql
+    assert "event_id like 'valuation.job.requested-%'" in sql
+    assert "delete from processed_events where portfolio_id = 'PB_SG_GLOBAL_BAL_001';" in sql
+    assert "delete from processed_events;" not in sql
+    assert "'reporting-export-service'" not in sql
+    assert "event_id like 'portfolio_day.reconciliation.%'" not in sql
 
 
 def test_front_office_seed_ingests_core_data_in_parent_first_order(monkeypatch):

--- a/tools/front_office_portfolio_seed.py
+++ b/tools/front_office_portfolio_seed.py
@@ -36,6 +36,34 @@ DEFAULT_BENCHMARK_COMPONENT_INDEX_IDS = (
     "IDX_GLOBAL_EQUITY_TR",
     "IDX_GLOBAL_BOND_TR",
 )
+FRONT_OFFICE_RESEED_VOLATILE_EVENT_FENCE_SERVICES = (
+    "persistence-business-dates",
+    "persistence-fx-rates",
+    "persistence-instruments",
+    "persistence-market-prices",
+    "persistence-portfolios",
+    "persistence-transactions",
+    "cost-calculator",
+    "position-calculator",
+    "cashflow-calculator",
+    "pipeline-orchestrator-processed-txn",
+    "price-event-reprocessing-trigger",
+    "position-valuation-calculator",
+)
+FRONT_OFFICE_RESEED_VOLATILE_EVENT_TOPIC_PREFIXES = (
+    "business_dates.raw.received-",
+    "fx_rates.raw.received-",
+    "instruments.raw.received-",
+    "market_prices.raw.received-",
+    "portfolios.raw.received-",
+    "transactions.raw.received-",
+    "transactions.reprocessing.requested-",
+    "transactions.persisted-",
+    "transactions.cost.processed-",
+    "transaction_processing.ready-",
+    "market_prices.persisted-",
+    "valuation.job.requested-",
+)
 
 
 @dataclass(frozen=True)
@@ -122,10 +150,9 @@ def build_portfolio_seed_cleanup_sql(*, portfolio_id: str) -> str:
     """
     Build the destructive local reseed cleanup SQL for the canonical front-office seed.
 
-    This cleanup stays scoped to portfolio-owned rows only. If a local Docker-backed runtime has
-    stale shared Kafka, idempotency, or replay state from a prior load or performance run, reset
-    the lotus-core Docker state before reseeding instead of deleting shared runtime tables from the
-    front-office seed tool.
+    This cleanup stays scoped to portfolio-owned rows and known local replay fences. The Docker
+    local stack may retain Postgres idempotency rows while Kafka offsets are reset or reused; clear
+    only the canonical seed topic/service fences that can block a deterministic front-office reseed.
     """
     return "\n".join(
         [
@@ -152,6 +179,16 @@ def build_portfolio_seed_cleanup_sql(*, portfolio_id: str) -> str:
                 f"(select transaction_id from transactions where portfolio_id = '{portfolio_id}');"
             ),
             f"delete from pipeline_stage_state where portfolio_id = '{portfolio_id}';",
+            (
+                "delete from processed_events "
+                "where service_name in "
+                f"({_sql_list(FRONT_OFFICE_RESEED_VOLATILE_EVENT_FENCE_SERVICES)}) "
+                "and ("
+                + _processed_event_topic_prefix_predicate(
+                    FRONT_OFFICE_RESEED_VOLATILE_EVENT_TOPIC_PREFIXES
+                )
+                + ");"
+            ),
             f"delete from processed_events where portfolio_id = '{portfolio_id}';",
             f"delete from cash_account_masters where portfolio_id = '{portfolio_id}';",
             f"delete from portfolio_benchmark_assignments where portfolio_id = '{portfolio_id}';",
@@ -226,6 +263,14 @@ def _interpolate_prices(
 
 def _invert_rate(rate: str, precision: str = "0.000001") -> str:
     return format((Decimal("1") / Decimal(rate)).quantize(Decimal(precision)), "f")
+
+
+def _sql_list(values: tuple[str, ...]) -> str:
+    return ", ".join(f"'{value}'" for value in values)
+
+
+def _processed_event_topic_prefix_predicate(prefixes: tuple[str, ...]) -> str:
+    return " or ".join(f"event_id like '{prefix}%'" for prefix in prefixes)
 
 
 def _tx(

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -52,6 +52,13 @@ When a portfolio or load scenario looks wrong, check in this order:
 5. database facts only when rollout mismatch, migration doubt, or API/schema drift makes the API
    evidence insufficient
 
+## Canonical front-office reseed
+
+Routine canonical front-office reseeding is scoped to `PB_SG_GLOBAL_BAL_001`. The seed tool may
+clear known volatile replay fences for canonical seed topics when local Kafka offsets have been
+reset or reused, but it must not perform broad `processed_events` deletion. If broader local
+runtime state is polluted, reset the Docker-backed core runtime before reseeding.
+
 ## Startup checks
 
 When app-local runtime is unhealthy, check this order:


### PR DESCRIPTION
## Summary
- clear only known volatile canonical replay fences that can block deterministic front-office reseeds after local Kafka offset resets or reuse
- keep portfolio-owned cleanup bounded and avoid broad \processed_events\ deletion
- add focused regression coverage plus docs and repo-authored wiki source for the reseed posture

## Evidence
- \python -m pytest tests/unit/tools/test_front_office_portfolio_seed.py -q\
- \git diff --check\
- live reseed proof: \python tools/front_office_portfolio_seed.py --portfolio-id PB_SG_GLOBAL_BAL_001 --start-date 2025-03-31 --end-date 2026-04-10 --benchmark-start-date 2025-01-06 --wait-seconds 300\
- reseed completed with positions=11, valued_positions=11, transactions=30, cash_accounts=2, pending_valuation_jobs=0, pending_aggregation_jobs=0, positions_data_quality_status=COMPLETE, cash_data_quality_status=COMPLETE

## Wiki
- Repo-authored wiki source updated: \wiki/Operations-Runbook.md\
- \Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-core\ reports expected publication drift for \Operations-Runbook.md\ until this PR is merged and wiki publication runs.