### PR TITLE
Demote institutional completion gate from main pushes

### DIFF
--- a/.github/workflows/main-releasability.yml
+++ b/.github/workflows/main-releasability.yml
@@ -421,6 +421,10 @@ jobs:
 
   institutional-completion-gate:
     name: Main Releasability / Institutional Completion Gate
+    # This approval-grade 100k-transaction bank-day run is intentionally kept
+    # off every main push. It remains available for scheduled and manual
+    # release-readiness validation without blocking routine post-merge health.
+    if: github.event_name != 'push'
     needs: [coverage-gate, failure-recovery-gate]
     runs-on: ubuntu-latest
     timeout-minutes: 180
@@ -462,6 +466,7 @@ jobs:
 
   institutional-signoff-pack:
     name: Main Releasability / Institutional Sign-Off Pack
+    if: github.event_name != 'push'
     needs:
       [docker-smoke-contract, latency-gate, performance-load-gate, failure-recovery-gate, institutional-completion-gate]
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,8 @@ test-release-gates:
 	$(MAKE) test-e2e-all
 	$(MAKE) test-performance-load-gate-full
 	$(MAKE) test-failure-recovery-gate
+
+test-institutional-release-gates:
 	$(MAKE) test-institutional-completion-gate
 	$(MAKE) test-institutional-signoff-pack
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ Important lane mapping:
 Because this repo has a heavy validation contract, targeted local proof plus GitHub-backed heavy
 execution is often the right workflow.
 
+The approval-grade institutional completion and sign-off lane is available through scheduled or
+manual main releasability runs and the `test-institutional-release-gates` make target. Routine
+`main` push runs intentionally skip that 100k-transaction lane while retaining the faster release
+gates as blocking health checks.
+
 ## Contract Notes
 
 Important current core truths:

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -229,9 +229,11 @@ Most relevant current governance:
     the newest artifact timestamp: use `full` profile-tier performance-load artifacts ahead of
     newer `fast` artifacts, and prefer exhaustive bank-day reconciliation artifacts where
     `portfolio_count_evaluated == portfolios_ingested` ahead of newer sampled refresh artifacts,
-28. main releasability now owns a governed RFC-086 institutional completion gate that runs the
-    bank-day load scenario and then exhaustive reconciliation for the generated run before the
-    institutional sign-off pack aggregates artifacts,
+28. scheduled and manually dispatched main releasability runs own the governed RFC-086
+    institutional completion gate that runs the bank-day load scenario and then exhaustive
+    reconciliation for the generated run before the institutional sign-off pack aggregates
+    artifacts; routine `main` push runs keep the lighter release gates blocking and leave the
+    approval-grade institutional lane to the scheduled/manual path,
 29. legacy PAS-era wiki material should be filtered through the platform migration ledger before
     reuse; cross-cutting investor, GTM, or ecosystem rationale now belongs in `lotus-platform`.
 30. RFC-087 DPM source-data work is implemented for `DpmModelPortfolioTarget:v1`,

--- a/docs/operations/Institutional-Signoff-Runbook.md
+++ b/docs/operations/Institutional-Signoff-Runbook.md
@@ -35,15 +35,17 @@ reconciliation for the exact generated `run_id`, producing both:
 
 ## CI Enforcement
 1. GitHub Actions job `Institutional Sign-Off Pack` runs on:
-   1. `main` pushes,
-   2. scheduled pipelines,
-   3. manual workflow dispatch.
+   1. scheduled pipelines,
+   2. manual workflow dispatch.
 2. The job is a required production-readiness gate and fails when:
    1. any required artifact is missing,
    2. any gate status is failed,
    3. any required artifact is older than 24 hours (`--max-age-hours 24`).
-3. The main releasability workflow now generates RFC-086 completion evidence through
+3. The scheduled/manual main releasability workflow generates RFC-086 completion evidence through
    `Main Releasability / Institutional Completion Gate` before sign-off aggregation.
+4. Routine `main` push runs intentionally skip the approval-grade institutional completion and
+   sign-off jobs so post-merge health remains governed by the faster release gates. Use a scheduled
+   or manually dispatched run for institutional release evidence.
 
 ## Go-Live Checklist
 All items must be `yes`:

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -15,7 +15,9 @@
 - `make ci`
   PR merge gate parity
 - `make ci-main`
-  main releasability parity
+  main push releasability parity
+- `make test-institutional-release-gates`
+  scheduled/manual institutional completion and sign-off parity
 
 ## Important gates
 


### PR DESCRIPTION
## Summary

This PR demotes the approval-grade RFC-086 institutional completion lane from routine `main` push runs while preserving it for scheduled/manual release-readiness validation.

Changes:

- skips `Main Releasability / Institutional Completion Gate` on `push` events
- skips `Main Releasability / Institutional Sign-Off Pack` on `push` events
- keeps both jobs active for scheduled and manually dispatched main releasability runs
- splits local make targets so `make ci-main` maps to main-push releasability, while `make test-institutional-release-gates` remains available for the heavy 100k-transaction institutional lane
- updates README, repository context, operations runbook, and wiki source to reflect the new governance truth

## Why

The latest core `main` pipeline failed only in the heavy institutional completion gate. The artifact showed the 1000-portfolio / 100000-transaction bank-day load did not fully drain before the 7200s timeout:

- `complete_portfolios`: `726 / 1000`
- `position_timeseries_count`: `72759 / 100000`
- `open_valuation_jobs`: `50`
- `open_aggregation_jobs`: `2`

Earlier main releasability jobs were green, and the report showed no DLQ pressure or service error lines. This lane is valuable as an approval-grade institutional validation, but it is too heavy and brittle to block every routine post-merge `main` push. Keeping it on scheduled/manual runs preserves release-readiness evidence without making normal main health red on long-tail drain timing.

## Validation

Local validation:

- workflow YAML parse for all `.github/workflows/*.yml` -> passed
- `make -n ci-main` -> passed; confirmed the institutional completion/sign-off targets are no longer in the main-push parity target
- `make -n test-institutional-release-gates` -> passed; confirmed the heavy institutional lane is still available explicitly
- `git diff --check` -> passed

Local limitation:

- `actionlint` is not installed locally, so GitHub `Workflow Lint` remains the authoritative workflow lint check.

## Documentation / Wiki

Updated repo-local docs and wiki source because CI governance truth changed:

- `README.md`
- `REPOSITORY-ENGINEERING-CONTEXT.md`
- `docs/operations/Institutional-Signoff-Runbook.md`
- `wiki/Validation-and-CI.md`