### PR TITLE
fix: pass caller context in front-office seed validation

### DIFF
--- a/tests/unit/tools/test_front_office_portfolio_seed.py
+++ b/tests/unit/tools/test_front_office_portfolio_seed.py
@@ -10,6 +10,7 @@ from tools.front_office_portfolio_seed import (
     DEFAULT_DPM_MODEL_PORTFOLIO_ID,
     DEFAULT_DPM_MODEL_PORTFOLIO_VERSION,
     FRONT_OFFICE_EXPECTATION,
+    FRONT_OFFICE_GATEWAY_CALLER_HEADERS,
     FRONT_OFFICE_SEED_CONTRACT,
     _collect_front_office_readiness_diagnostics,
     _extract_readiness_summary,
@@ -1074,8 +1075,12 @@ def test_front_office_seed_verification_counts_projected_transactions(monkeypatc
         ),
     }
 
-    def fake_request(method, url, *, payload=None):
+    gateway_header_calls: list[dict[str, str]] = []
+
+    def fake_request(method, url, *, payload=None, headers=None):
         requested_urls.append(url)
+        if url.startswith("http://gateway.dev/"):
+            gateway_header_calls.append(headers or {})
         return responses[url]
 
     monkeypatch.setattr("tools.front_office_portfolio_seed._request_json", fake_request)
@@ -1107,3 +1112,4 @@ def test_front_office_seed_verification_counts_projected_transactions(monkeypatc
     assert any("include_projected=true" in url for url in requested_urls)
     assert all("income-summary/query" not in url for url in requested_urls)
     assert all("activity-summary/query" not in url for url in requested_urls)
+    assert gateway_header_calls == [FRONT_OFFICE_GATEWAY_CALLER_HEADERS]

--- a/tools/demo_data_pack.py
+++ b/tools/demo_data_pack.py
@@ -1137,12 +1137,20 @@ def _ingest_demo_reference_data(ingestion_base_url: str, bundle: dict[str, Any])
         _request_json("POST", f"{ingestion_base_url}{endpoint}", payload=payload)
 
 
-def _request_json(method: str, url: str, payload: dict[str, Any] | None = None) -> tuple[int, Any]:
+def _request_json(
+    method: str,
+    url: str,
+    payload: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+) -> tuple[int, Any]:
+    request_headers = {"Content-Type": "application/json"}
+    if headers:
+        request_headers.update(headers)
     req = request.Request(
         url=url,
         method=method.upper(),
         data=(None if payload is None else json.dumps(payload).encode("utf-8")),
-        headers={"Content-Type": "application/json"},
+        headers=request_headers,
     )
     try:
         with request.urlopen(req, timeout=15) as response:

--- a/tools/front_office_portfolio_seed.py
+++ b/tools/front_office_portfolio_seed.py
@@ -38,6 +38,11 @@ DEFAULT_BENCHMARK_COMPONENT_INDEX_IDS = (
 )
 DEFAULT_DPM_MODEL_PORTFOLIO_ID = "MODEL_PB_SG_GLOBAL_BAL_DPM"
 DEFAULT_DPM_MODEL_PORTFOLIO_VERSION = "2026.04"
+FRONT_OFFICE_GATEWAY_CALLER_HEADERS = {
+    "X-Actor-Id": "workbench-system",
+    "X-Tenant-Id": "tenant-sg",
+    "X-Region": "APAC",
+}
 FRONT_OFFICE_RESEED_VOLATILE_EVENT_FENCE_SERVICES = (
     "persistence-business-dates",
     "persistence-fx-rates",
@@ -1984,9 +1989,10 @@ def _verify_front_office_portfolio(
                 f"{gateway_base_url}/api/v1/workbench/{expected.portfolio_id}/performance/summary"
                 f"?period=YTD&chart_frequency=monthly&contribution_dimension=asset_class"
                 f"&attribution_dimension=asset_class&detail_basis=NET",
+                headers=FRONT_OFFICE_GATEWAY_CALLER_HEADERS,
             )
-        except RuntimeError:
-            LOGGER.info("Verification still waiting on downstream services.")
+        except RuntimeError as exc:
+            LOGGER.info("Verification still waiting on downstream services: %s", exc)
             continue
 
         positions = positions_payload.get("positions") or []


### PR DESCRIPTION
## Summary\n- allow demo data pack JSON requests to include explicit headers\n- pass canonical Workbench/Gateway caller context when the front-office seed verifier probes Gateway performance summary\n- log verifier wait failures with the actual runtime reason\n\n## Evidence\n- python -m py_compile tools/demo_data_pack.py tools/front_office_portfolio_seed.py\n- live seed verification advanced past missing caller-context failures during RFC42 Workbench proof\n\n## RFC / Ledger\nSupports governed canonical front-office evidence for lotus-manage RFC42 and future Workbench proof runs.