### PR TITLE
docs: sync agent done definition

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,8 @@ Always:
 7. keep commits small, meaningful, and truthful,
 8. remove dead code, duplicate logic, and stale non-standard handling when encountered,
 9. ensure every UI feature is genuinely backed by supported backend functionality,
-10. ensure RFC/docs/wiki/context/contract closure truth is present on `main`, not stranded on an
+10. treat "merged to `main` and validated" as the definition of done; ensure
+    RFC/docs/wiki/context/contract closure truth is present on `main`, not stranded on an
     unmerged side branch.
 
 For RFC, documentation, wiki, context, contract, supported-features, API-governance, migration, or


### PR DESCRIPTION
## Summary
- synchronizes AGENTS.md with the Lotus operating contract
- preserves the rule that done means merged to main and validated, not stranded branch-local truth

## Evidence
- generated by lotus-platform/automation/Sync-AgentOperatingContract.ps1 -AllRepoRoots -IncludeDeployedTarget

## Wiki
No repo-local wiki source change.