### PR TITLE
Document core realized outcome source boundaries

### DIFF
--- a/docs/architecture/RFC-0083-source-data-product-catalog.md
+++ b/docs/architecture/RFC-0083-source-data-product-catalog.md
@@ -107,6 +107,27 @@ evidence through gateway/product contracts without mutating core state outside c
 `lotus-report` should compose reports from source-data products and evidence bundles, not direct
 database assumptions or report-specific private shapes.
 
+## Realized Outcome Source Boundaries
+
+RFC42-WTBD-006 outcome reviews depend on source-owned realized evidence rather than downstream
+applications reconstructing cash, tax, FX, or execution methodology from private tables. The
+following `lotus-core` products are the current source boundary for those dimensions:
+
+| Product | Source-owned evidence | Downstream rule | Explicit non-claim |
+| --- | --- | --- | --- |
+| `HoldingsAsOf:v1` | Portfolio positions, cash-balance totals, portfolio/base currency, as-of date, supportability metadata, and latest evidence timestamp. | Consumers may use returned cash totals and holdings rows as source facts with the product metadata attached. | Consumers must not infer liquidity ladders, income need, performance returns, or risk exposure methodology from holdings or cash totals alone. |
+| `TransactionLedgerWindow:v1` | Deterministically ordered booked transaction rows, trade fees, transaction-cost records, withholding tax, other interest deductions, net interest, realized capital/FX/total P&L fields, linked cashflow records, FX/event linkage identifiers, and optional reporting-currency restatements. | Consumers may preserve explicit row-level measures, lineage, supportability posture, source field, source unit, and selected row identity. | Consumers must not aggregate rows into tax methodology, FX attribution, cash movement methodology, transaction-cost methodology, or execution-quality conclusions unless a source owner publishes that methodology. |
+| `PortfolioCashflowProjection:v1` | Daily net cashflow points, cumulative cashflow across the returned window, total net cashflow, portfolio currency, include-projected posture, evidence timestamp, and deterministic source fingerprint. | Consumers may use the returned total and points as core-owned operational cashflow evidence. | Consumers must not treat the projection as a liquidity ladder, funding recommendation, income plan, OMS execution forecast, market-impact estimate, or client cash-need methodology. |
+| `PortfolioTaxLotWindow:v1` | Effective tax-lot and cost-basis state for tax-aware discretionary sell decisions. | Consumers may use lot quantity, acquisition date, cost basis, and source supportability to explain candidate sell allocation. | Consumers must not claim complete jurisdiction-specific tax advice, realized-tax optimization, or client-tax approval from lot state alone. |
+| `TransactionCostCurve:v1` | Observed booked fee evidence grouped by security, transaction type, and currency. | Consumers may distinguish source-backed observed cost context from local estimated construction cost. | Consumers must not claim predictive market-impact, venue-routing, fill-quality, best-execution, or minimum-cost execution methodology from observed fee evidence. |
+
+These boundaries are intentionally conservative. `lotus-core` is the source authority for recorded
+portfolio, transaction, cashflow, tax-lot, and observed-fee facts; it is not the owner of
+performance returns, risk methodology, client tax advice, liquidity planning, execution routing, or
+post-trade OMS acknowledgement methodology. Downstream products must carry source refs and
+supportability metadata and must degrade when a required source product is unavailable, partial,
+stale, or outside its explicit methodology boundary.
+
 ## Portfolio Performance Snapshot Boundary
 
 The portfolio workspace performance snapshot is not a `lotus-core` source-data product.

--- a/tests/unit/docs/test_source_data_product_boundaries.py
+++ b/tests/unit/docs/test_source_data_product_boundaries.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def _read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def _single_line(text: str) -> str:
+    return " ".join(text.split())
+
+
+def test_rfc0083_documents_realized_outcome_source_boundaries() -> None:
+    catalog = _read("docs/architecture/RFC-0083-source-data-product-catalog.md")
+    normalized_catalog = _single_line(catalog)
+
+    assert "## Realized Outcome Source Boundaries" in catalog
+    assert "| `TransactionLedgerWindow:v1` |" in catalog
+    assert "trade fees, transaction-cost records, withholding tax" in catalog
+    assert "realized capital/FX/total P&L fields" in catalog
+    assert "linked cashflow records" in catalog
+    assert "must not aggregate rows into tax methodology" in catalog
+    assert "FX attribution, cash movement methodology, transaction-cost methodology" in catalog
+    assert "| `PortfolioCashflowProjection:v1` |" in catalog
+    assert "Daily net cashflow points, cumulative cashflow across the returned window" in catalog
+    assert "must not treat the projection as a liquidity ladder" in catalog
+    assert "| `TransactionCostCurve:v1` |" in catalog
+    assert "must not claim predictive market-impact, venue-routing, fill-quality" in catalog
+    assert "Downstream products must carry source refs and supportability metadata" in (
+        normalized_catalog
+    )
+
+
+def test_mesh_wiki_explains_core_source_authority_for_non_engineering_audiences() -> None:
+    wiki = _read("wiki/Mesh-Data-Products.md")
+    normalized_wiki = _single_line(wiki)
+
+    assert "## Realized Outcome Evidence Boundaries" in wiki
+    assert "Developers and architects" in wiki
+    assert "Sales and client demos" in wiki
+    assert "`TransactionLedgerWindow:v1`" in wiki
+    assert "`PortfolioCashflowProjection:v1`" in wiki
+    assert "not an execution-quality, tax-advice, liquidity-planning" in normalized_wiki
+    assert "Preserve the source measure, source unit, selected field, supportability state" in (
+        normalized_wiki
+    )
+    assert "flowchart LR" in wiki

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -41,6 +41,52 @@ source-data authority.
 | `SustainabilityPreferenceProfile:v1` | `/integration/portfolios/{portfolio_id}/sustainability-preference-profile` | Effective-dated sustainability preference profile for mandate-aware portfolio construction, including allocation bounds, exclusions, positive tilts, framework, source, and lineage. | Implemented and locally proven for RFC40-WTBD-008 source ownership. Canonical seed coverage includes a minimum sustainable allocation, thermal-coal exclusion, and low-carbon-transition positive tilt. Downstream `lotus-manage` consumption remains the next WTBD slice before client-facing proof packs may advertise source-backed sustainability preference enforcement. |
 | `PortfolioCashflowProjection:v1` | `/portfolios/{portfolio_id}/cashflow-projection` | Core-derived daily net cashflow projection for operational liquidity planning. It exposes source-data product identity, portfolio base currency, runtime metadata, data-quality posture, latest evidence timestamp, and deterministic projection fingerprint for downstream outcome and liquidity consumers. | Implemented and locally proven in RFC-0042 WTBD-006 source-owner hardening; live front-office proof remains part of the consuming manage slice. |
 
+## Realized Outcome Evidence Boundaries
+
+Outcome review, proof-pack, and wave surfaces are bank-buyable only when they preserve the
+difference between source-owned evidence and downstream interpretation. `lotus-core` currently owns
+recorded portfolio, transaction, tax-lot, observed-fee, and operational cashflow facts. It does not
+own risk methodology, performance returns, client tax advice, liquidity planning, execution routing,
+or OMS acknowledgement methodology.
+
+| Audience | What this means |
+| --- | --- |
+| Business users | Core supplies recorded facts such as holdings, cash totals, transaction fees, withholding tax, realized FX P&L, linked cashflow rows, tax lots, observed fee evidence, and operational cashflow projections. Decisioning products can explain those facts but must not silently invent a broader methodology. |
+| Developers and architects | Use `HoldingsAsOf:v1`, `TransactionLedgerWindow:v1`, `PortfolioTaxLotWindow:v1`, `TransactionCostCurve:v1`, and `PortfolioCashflowProjection:v1` as explicit source products. Preserve the source measure, source unit, selected field, supportability state, lineage/source ref, evidence timestamp, and product identity in downstream contracts. |
+| Operations | Investigate stale, partial, or missing evidence at the owning source product before treating a manage/risk/performance surface as wrong. If a source product is unavailable or outside scope, downstream products should degrade rather than recalculate locally. |
+| Sales and client demos | Position the platform as source-governed: recorded ledger and portfolio facts are traceable to core, analytics are owned by their specialist services, and unsupported execution/tax/liquidity claims remain visibly outside the supported boundary. |
+
+`TransactionLedgerWindow:v1` is the governed source for explicit transaction-row measures such as
+trade fees, transaction-cost records, withholding tax, other deductions, net interest, realized
+capital/FX/total P&L fields, linked cashflow records, and FX/event linkage identifiers. It is not an
+execution-quality, tax-advice, liquidity-planning, cash-movement aggregation, FX-attribution, or
+transaction-cost methodology product.
+
+`PortfolioCashflowProjection:v1` is the governed source for daily net cashflow points, cumulative
+cashflow over the returned window, total net cashflow, portfolio currency, include-projected posture,
+evidence timestamp, and deterministic source fingerprint. It is not a client income plan, liquidity
+ladder, funding recommendation, market-impact estimate, or OMS execution forecast.
+
+```mermaid
+flowchart LR
+    CoreLedger[core TransactionLedgerWindow:v1<br/>row-level fees, withholding tax, realized FX P&L, linked cashflow]
+    CoreCash[core PortfolioCashflowProjection:v1<br/>daily and total operational cashflow evidence]
+    CoreLots[core PortfolioTaxLotWindow:v1<br/>lot and cost-basis state]
+    CoreFees[core TransactionCostCurve:v1<br/>observed booked fee evidence]
+    Manage[lotus-manage outcome/proof/wave consumers<br/>preserve source refs and supportability]
+    Perf[lotus-performance<br/>performance methodology]
+    Risk[lotus-risk<br/>risk methodology]
+    FutureOwners[future OMS/tax/liquidity owners<br/>execution, tax advice, liquidity ladders]
+
+    CoreLedger --> Manage
+    CoreCash --> Manage
+    CoreLots --> Manage
+    CoreFees --> Manage
+    Perf --> Manage
+    Risk --> Manage
+    FutureOwners -. unsupported until certified .-> Manage
+```
+
 ```mermaid
 flowchart LR
     Upstream[Investment office model system] --> Ingest[core ingest model-portfolios and targets]


### PR DESCRIPTION
## Summary
- document RFC42-WTBD-006 core source boundaries for holdings, transaction ledger, cashflow projection, tax lots, and observed transaction-cost evidence
- enrich Mesh Data Products wiki source with audience-specific guidance and a source-boundary diagram
- add documentation contract tests that pin the source/non-source methodology boundary

## Validation
- python -m pytest tests/unit/docs/test_source_data_product_boundaries.py tests/unit/test_domain_data_product_contracts.py -q
- git diff --check
- Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-core reports expected pre-publication drift for wiki/Mesh-Data-Products.md

## Wiki
Repo-local wiki source changed. Publish after merge with Sync-RepoWikis.ps1 -Publish -Repository lotus-core.