### PR TITLE
Document transaction cost curve methodology

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -262,6 +262,14 @@ Most relevant current governance:
     `DEPOSIT`/`WITHDRAWAL` inclusion rule, same-day booked/projected additivity, portfolio-base
     currency convention, and explicit boundary from liquidity ladders, tax, performance,
     market-impact, and OMS execution methodology.
+32. RFC42-WTBD-006 source-owner methodology depth now also includes the implementation-backed
+    `TransactionCostCurve:v1` methodology under
+    `docs/methodologies/source-data-products/transaction-cost-curve.md`; it pins observed
+    booked-fee grouping by security, transaction type, and currency; explicit transaction-cost row
+    precedence over `trade_fee`; zero-fee and zero-notional exclusion; notional-weighted average
+    cost bps; min/max cost bps; deterministic paging; and the explicit boundary from
+    market-impact, venue-routing, best-execution, OMS acknowledgement, and minimum-cost execution
+    methodology.
 
 ## Context Maintenance Rule
 

--- a/docs/architecture/RFC-0083-source-data-product-catalog.md
+++ b/docs/architecture/RFC-0083-source-data-product-catalog.md
@@ -128,6 +128,14 @@ post-trade OMS acknowledgement methodology. Downstream products must carry sourc
 supportability metadata and must degrade when a required source product is unavailable, partial,
 stale, or outside its explicit methodology boundary.
 
+`TransactionCostCurve:v1` now has implementation-backed methodology truth in
+`docs/methodologies/source-data-products/transaction-cost-curve.md`. The method groups observed
+booked-fee evidence by security, transaction type, and currency; uses explicit transaction-cost
+rows ahead of `trade_fee`; excludes zero-fee and zero-notional observations; computes
+notional-weighted average cost bps plus min/max per-transaction cost bps; and preserves the
+non-claim boundary from predictive market-impact, venue-routing, best-execution, OMS
+acknowledgement, and minimum-cost execution methodology.
+
 ## Portfolio Performance Snapshot Boundary
 
 The portfolio workspace performance snapshot is not a `lotus-core` source-data product.

--- a/docs/methodologies/README.md
+++ b/docs/methodologies/README.md
@@ -1,0 +1,11 @@
+# lotus-core Methodology Index
+
+This index collects implementation-backed methodology notes for source-data products where
+downstream applications need auditable formulas, boundaries, and non-claims.
+
+## Source-Data Products
+
+| Product | Methodology | Scope |
+| --- | --- | --- |
+| `PortfolioCashflowProjection:v1` | [Portfolio Cashflow Projection](./source-data-products/portfolio-cashflow-projection.md) | Operational daily and total cashflow projection, booked-only/projected modes, and non-claims for liquidity ladders, tax, performance, market impact, and OMS execution. |
+| `TransactionCostCurve:v1` | [Transaction Cost Curve](./source-data-products/transaction-cost-curve.md) | Observed booked-fee aggregation by security, transaction type, and currency, with non-claims for market impact, venue routing, best execution, OMS acknowledgement, and minimum-cost execution methodology. |

--- a/docs/methodologies/source-data-products/transaction-cost-curve.md
+++ b/docs/methodologies/source-data-products/transaction-cost-curve.md
@@ -1,0 +1,196 @@
+# Transaction Cost Curve Methodology
+
+## Metric
+
+`TransactionCostCurve:v1` is the core-owned observed transaction-cost evidence product exposed by
+`POST /integration/portfolios/{portfolio_id}/transaction-cost-curve`.
+
+It returns observed booked fee evidence grouped by security, transaction type, and fee currency for
+a requested portfolio and transaction-date window. The product lets downstream proof packs
+distinguish source-backed booked-fee evidence from local estimated construction cost. It is not a
+predictive market-impact model, venue-routing model, fill-quality measure, best-execution
+assessment, OMS acknowledgement, or minimum-cost execution optimizer.
+
+## Endpoint and Mode Coverage
+
+| Request shape | Implemented behavior |
+| --- | --- |
+| `portfolio_id` path parameter | Selects the portfolio whose booked transaction-cost evidence is requested. |
+| `as_of_date` | Bounds the request scope and product runtime metadata. |
+| `window.start_date` / `window.end_date` | Inclusive transaction-date window used for observed evidence. |
+| optional `security_ids` | Restricts evidence to requested securities and reports missing requested securities as supportability gaps. |
+| optional `transaction_types` | Restricts evidence to requested transaction types after upper-case normalization. |
+| `min_observation_count` | Suppresses curve points whose group has fewer observed transactions than the threshold. |
+| `page.page_size` / `page.page_token` | Returns deterministic cursor pages ordered by security id, transaction type, and currency. |
+
+The product currently has one implemented methodology: observed booked-fee aggregation. It does not
+switch into simulated, quoted, venue, broker, or expected-cost modes.
+
+## Inputs
+
+| Input | Source | Required | Meaning |
+| --- | --- | --- | --- |
+| `portfolio_id` | Path parameter | Yes | Portfolio whose evidence is returned. |
+| `as_of_date` | Request body | Yes | Business date for request identity and metadata. |
+| `window.start_date`, `window.end_date` | Request body | Yes | Inclusive transaction-date evidence window. |
+| `security_ids` | Request body | No | Optional security filter and supportability coverage expectation. |
+| `transaction_types` | Request body | No | Optional transaction-type filter. |
+| `min_observation_count` | Request body | No, default `1` | Minimum number of qualifying booked transactions for a curve point. |
+
+## Upstream Data Sources
+
+| Source | Used fields | Inclusion rule |
+| --- | --- | --- |
+| `portfolios` | `portfolio_id` | Portfolio must exist. |
+| `transactions` | `transaction_id`, `security_id`, `transaction_type`, `currency`, `transaction_date`, `gross_transaction_amount`, `trade_fee`, `updated_at` | Transaction must match the portfolio, requested filters, as-of scope, and requested transaction-date window. Gross transaction amount must be non-zero after absolute-value normalization. |
+| `transaction_costs` | `amount` | If explicit transaction-cost rows exist, their amounts are summed and used as the fee amount. If no explicit cost rows exist, the transaction `trade_fee` field is used. |
+
+Transactions with zero or missing fee evidence, or zero gross notional, do not contribute to a curve
+point. Cost rows take precedence over `trade_fee` so the product does not double count fees when
+both representations are present.
+
+## Unit Conventions
+
+All grouped monetary fields use the transaction fee currency returned as `currency`.
+
+`gross_transaction_amount` is converted to absolute notional before aggregation so buy and sell
+notionals are comparable as observed cost denominators. Fee amounts must be positive. Negative or
+zero fees are treated as unusable evidence rather than rebates or execution-quality conclusions.
+
+No FX conversion, market-impact adjustment, broker spread estimate, venue normalization, tax
+calculation, or liquidity bucketing is performed by this product.
+
+## Variable Dictionary
+
+| Symbol | Response or source field | Definition |
+| --- | --- | --- |
+| `P` | `portfolio_id` | Requested portfolio. |
+| `A` | `as_of_date` | Business as-of date for request scope. |
+| `W` | `window` | Inclusive transaction-date evidence window. |
+| `G` | `(security_id, transaction_type, currency)` | Deterministic grouping key. |
+| `n_G` | `observation_count` | Number of qualifying booked transactions in group `G`. |
+| `F_i` | transaction-cost amount or `trade_fee` | Positive observed fee amount for transaction `i`. |
+| `N_i` | `abs(gross_transaction_amount)` | Positive observed transaction notional for transaction `i`. |
+| `TC_G` | `total_cost` | Sum of observed fees in group `G`. |
+| `TN_G` | `total_notional` | Sum of absolute gross notionals in group `G`. |
+| `B_i` | per-transaction cost bps | `F_i / N_i * 10000`. |
+| `AB_G` | `average_cost_bps` | Notional-weighted observed average cost in basis points for group `G`. |
+| `MIN_G` | `min_cost_bps` | Minimum per-transaction observed cost bps in group `G`. |
+| `MAX_G` | `max_cost_bps` | Maximum per-transaction observed cost bps in group `G`. |
+
+## Methodology and Formulas
+
+For each qualifying group `G`:
+
+`TC_G = sum(F_i for each transaction i in G)`
+
+`TN_G = sum(N_i for each transaction i in G)`
+
+`B_i = F_i / N_i * 10000`
+
+`AB_G = TC_G / TN_G * 10000`
+
+`MIN_G = min(B_i for each transaction i in G)`
+
+`MAX_G = max(B_i for each transaction i in G)`
+
+`average_cost_bps`, `min_cost_bps`, and `max_cost_bps` are rounded to four decimal places.
+
+## Step-by-Step Computation
+
+1. Verify that the requested portfolio exists.
+2. Build a request-scope fingerprint from portfolio id, as-of date, window, filters, minimum
+   observation count, and tenant scope.
+3. Decode and validate the optional page token against the request-scope fingerprint.
+4. Query booked transactions and explicit transaction-cost rows for the portfolio, as-of date,
+   requested transaction-date window, and optional filters.
+5. For each transaction, determine `F_i` from summed explicit `transaction_costs.amount` when cost
+   rows exist; otherwise use `trade_fee`.
+6. Exclude transactions where `F_i <= 0` or `abs(gross_transaction_amount) <= 0`.
+7. Group remaining transactions by `(security_id, upper(transaction_type), upper(currency))`.
+8. Exclude groups whose `observation_count` is less than `min_observation_count`.
+9. Compute total cost, total notional, average cost bps, min cost bps, max cost bps, first observed
+   date, last observed date, and a bounded deterministic sample of up to five transaction ids.
+10. Sort curve points by security id, transaction type, and currency.
+11. Apply cursor paging and emit a next page token when more grouped points remain.
+12. Return supportability, lineage, and runtime source-data product metadata.
+
+## Validation and Failure Behavior
+
+| Condition | Behavior |
+| --- | --- |
+| Portfolio id does not exist | Service raises `LookupError`; the API maps it to HTTP `404`. |
+| `window.end_date < window.start_date` | Request validation rejects the request. |
+| Blank or duplicate `security_ids` | Request validation rejects the request. |
+| Blank or duplicate `transaction_types` | Request validation rejects the request after upper-case normalization. |
+| Page token scope does not match the request | Service raises `ValueError`; the API maps it to HTTP `400`. |
+| No qualifying observed cost evidence | Response returns no curve points with supportability `UNAVAILABLE` and reason `TRANSACTION_COST_EVIDENCE_NOT_FOUND`. |
+| Requested securities are missing qualifying points | Response carries supportability `INCOMPLETE` and reason `TRANSACTION_COST_EVIDENCE_MISSING_FOR_SECURITIES`. |
+| More grouped points exist than the page size | Response carries supportability `DEGRADED` and reason `TRANSACTION_COST_CURVE_PAGE_PARTIAL` for that page. |
+
+`data_quality_status` is `COMPLETE` only when the returned supportability is `READY`; otherwise it
+is `PARTIAL`. This status certifies the observed-fee evidence response only, not execution quality
+or best execution.
+
+## Configuration Options
+
+| Option | Current value |
+| --- | --- |
+| Default page size | `250` curve points |
+| Maximum page size | `1000` curve points |
+| Default minimum observation count | `1` transaction |
+| Maximum minimum observation count | `100` transactions |
+| Sort order | `security_id:asc,transaction_type:asc,currency:asc` |
+| Product identity | `TransactionCostCurve:v1` |
+
+## Outputs
+
+| Field | Methodology mapping |
+| --- | --- |
+| `curve_points[].security_id` | Group key security id. |
+| `curve_points[].transaction_type` | Group key transaction type, normalized to upper case. |
+| `curve_points[].currency` | Group key fee/notional currency, normalized to upper case. |
+| `curve_points[].observation_count` | `n_G`. |
+| `curve_points[].total_cost` | `TC_G`. |
+| `curve_points[].total_notional` | `TN_G`. |
+| `curve_points[].average_cost_bps` | `AB_G`. |
+| `curve_points[].min_cost_bps` | `MIN_G`. |
+| `curve_points[].max_cost_bps` | `MAX_G`. |
+| `curve_points[].first_observed_date` | Earliest transaction date in group `G`. |
+| `curve_points[].last_observed_date` | Latest transaction date in group `G`. |
+| `curve_points[].sample_transaction_ids` | Deterministic sorted sample of up to five source transaction ids. |
+| `supportability` | Readiness state for observed cost evidence only. |
+
+## Worked Example
+
+Request:
+
+`POST /integration/portfolios/PB_SG_GLOBAL_BAL_001/transaction-cost-curve`
+
+```json
+{
+  "as_of_date": "2026-05-03",
+  "window": {"start_date": "2026-04-01", "end_date": "2026-04-30"},
+  "security_ids": ["EQ_US_AAPL"],
+  "transaction_types": ["BUY"],
+  "min_observation_count": 2
+}
+```
+
+Source facts:
+
+| Transaction | Security | Type | Currency | Fee `F_i` | Notional `N_i` | Cost bps `B_i` |
+| --- | --- | --- | --- | ---: | ---: | ---: |
+| `TXN-AAPL-001` | `EQ_US_AAPL` | `BUY` | `USD` | 10 | 10000 | 10 |
+| `TXN-AAPL-002` | `EQ_US_AAPL` | `BUY` | `USD` | 30 | 20000 | 15 |
+
+Final output mapping:
+
+| Response field | Value |
+| --- | ---: |
+| `curve_points[0].observation_count` | 2 |
+| `curve_points[0].total_cost` | 40 |
+| `curve_points[0].total_notional` | 30000 |
+| `curve_points[0].average_cost_bps` | 13.3333 |
+| `curve_points[0].min_cost_bps` | 10.0000 |
+| `curve_points[0].max_cost_bps` | 15.0000 |

--- a/src/services/query_service/app/services/integration_service.py
+++ b/src/services/query_service/app/services/integration_service.py
@@ -28,16 +28,16 @@ from ..dtos.reference_integration_dto import (
     BenchmarkMarketSeriesResponse,
     BenchmarkReturnSeriesRequest,
     BenchmarkReturnSeriesResponse,
-    ClientRestrictionProfileEntry,
-    ClientRestrictionProfileRequest,
-    ClientRestrictionProfileResponse,
-    ClientRestrictionProfileSupportability,
     CioModelChangeAffectedCohortRequest,
     CioModelChangeAffectedCohortResponse,
     CioModelChangeAffectedCohortSupportability,
     CioModelChangeAffectedMandate,
     ClassificationTaxonomyEntry,
     ClassificationTaxonomyResponse,
+    ClientRestrictionProfileEntry,
+    ClientRestrictionProfileRequest,
+    ClientRestrictionProfileResponse,
+    ClientRestrictionProfileSupportability,
     ComponentSeriesResponse,
     CoverageResponse,
     DiscretionaryMandateBindingRequest,
@@ -1206,6 +1206,70 @@ class IntegrationService:
             return Decimal("0")
         return IntegrationService._as_decimal(trade_fee)
 
+    @staticmethod
+    def _transaction_cost_curve_key(transaction: Any) -> tuple[str, str, str]:
+        return (
+            str(transaction.security_id),
+            str(transaction.transaction_type).upper(),
+            str(transaction.currency).upper(),
+        )
+
+    @classmethod
+    def _has_observed_transaction_cost_evidence(cls, transaction: Any) -> bool:
+        fee_amount = cls._transaction_fee_amount(transaction)
+        notional = abs(cls._as_decimal(transaction.gross_transaction_amount))
+        return fee_amount > 0 and notional > 0
+
+    @classmethod
+    def _build_transaction_cost_curve_point(
+        cls,
+        *,
+        portfolio_id: str,
+        key: tuple[str, str, str],
+        rows: list[Any],
+    ) -> TransactionCostCurvePoint | None:
+        security_id, transaction_type, currency = key
+        total_cost = sum(cls._transaction_fee_amount(row) for row in rows)
+        total_notional = sum(abs(cls._as_decimal(row.gross_transaction_amount)) for row in rows)
+        if total_cost <= 0 or total_notional <= 0:
+            return None
+
+        cost_bps_values = [
+            (cls._transaction_fee_amount(row) / abs(cls._as_decimal(row.gross_transaction_amount)))
+            * Decimal("10000")
+            for row in rows
+            if abs(cls._as_decimal(row.gross_transaction_amount)) > 0
+        ]
+        if not cost_bps_values:
+            return None
+
+        observed_dates = [row.transaction_date.date() for row in rows]
+        return TransactionCostCurvePoint(
+            portfolio_id=portfolio_id,
+            security_id=security_id,
+            transaction_type=transaction_type,
+            currency=currency,
+            observation_count=len(rows),
+            total_notional=total_notional,
+            total_cost=total_cost,
+            average_cost_bps=(total_cost / total_notional * Decimal("10000")).quantize(
+                Decimal("0.0001")
+            ),
+            min_cost_bps=min(cost_bps_values).quantize(Decimal("0.0001")),
+            max_cost_bps=max(cost_bps_values).quantize(Decimal("0.0001")),
+            first_observed_date=min(observed_dates),
+            last_observed_date=max(observed_dates),
+            sample_transaction_ids=[
+                str(row.transaction_id)
+                for row in sorted(rows, key=lambda row: row.transaction_id)[:5]
+            ],
+            source_lineage={
+                "source_system": "transactions",
+                "source_table": "transactions,transaction_costs",
+                "contract_version": "rfc_040_wtbd_007_v1",
+            },
+        )
+
     async def get_transaction_cost_curve(
         self,
         *,
@@ -1246,66 +1310,24 @@ class IntegrationService:
 
         grouped: dict[tuple[str, str, str], list[Any]] = {}
         for transaction in transactions:
-            fee_amount = self._transaction_fee_amount(transaction)
-            notional = abs(self._as_decimal(transaction.gross_transaction_amount))
-            if fee_amount <= 0 or notional <= 0:
+            if not self._has_observed_transaction_cost_evidence(transaction):
                 continue
-            key = (
-                str(transaction.security_id),
-                str(transaction.transaction_type).upper(),
-                str(transaction.currency).upper(),
+            grouped.setdefault(self._transaction_cost_curve_key(transaction), []).append(
+                transaction
             )
-            grouped.setdefault(key, []).append(transaction)
 
         all_points: list[TransactionCostCurvePoint] = []
         for key in sorted(grouped):
             rows = grouped[key]
             if len(rows) < request.min_observation_count:
                 continue
-            security_id, transaction_type, currency = key
-            total_cost = sum(self._transaction_fee_amount(row) for row in rows)
-            total_notional = sum(
-                abs(self._as_decimal(row.gross_transaction_amount)) for row in rows
+            point = self._build_transaction_cost_curve_point(
+                portfolio_id=portfolio_id,
+                key=key,
+                rows=rows,
             )
-            cost_bps_values = [
-                (
-                    self._transaction_fee_amount(row)
-                    / abs(self._as_decimal(row.gross_transaction_amount))
-                )
-                * Decimal("10000")
-                for row in rows
-                if abs(self._as_decimal(row.gross_transaction_amount)) > 0
-            ]
-            if not cost_bps_values:
-                continue
-            observed_dates = [row.transaction_date.date() for row in rows]
-            all_points.append(
-                TransactionCostCurvePoint(
-                    portfolio_id=portfolio_id,
-                    security_id=security_id,
-                    transaction_type=transaction_type,
-                    currency=currency,
-                    observation_count=len(rows),
-                    total_notional=total_notional,
-                    total_cost=total_cost,
-                    average_cost_bps=(total_cost / total_notional * Decimal("10000")).quantize(
-                        Decimal("0.0001")
-                    ),
-                    min_cost_bps=min(cost_bps_values).quantize(Decimal("0.0001")),
-                    max_cost_bps=max(cost_bps_values).quantize(Decimal("0.0001")),
-                    first_observed_date=min(observed_dates),
-                    last_observed_date=max(observed_dates),
-                    sample_transaction_ids=[
-                        str(row.transaction_id)
-                        for row in sorted(rows, key=lambda row: row.transaction_id)[:5]
-                    ],
-                    source_lineage={
-                        "source_system": "transactions",
-                        "source_table": "transactions,transaction_costs",
-                        "contract_version": "rfc_040_wtbd_007_v1",
-                    },
-                )
-            )
+            if point is not None:
+                all_points.append(point)
 
         paged_candidates = [
             point

--- a/tests/unit/docs/test_source_data_product_boundaries.py
+++ b/tests/unit/docs/test_source_data_product_boundaries.py
@@ -29,6 +29,8 @@ def test_rfc0083_documents_realized_outcome_source_boundaries() -> None:
     assert "must not treat the projection as a liquidity ladder" in catalog
     assert "| `TransactionCostCurve:v1` |" in catalog
     assert "must not claim predictive market-impact, venue-routing, fill-quality" in catalog
+    assert "transaction-cost-curve.md" in catalog
+    assert "notional-weighted average cost bps plus min/max" in catalog
     assert "Downstream products must carry source refs and supportability metadata" in (
         normalized_catalog
     )
@@ -49,6 +51,9 @@ def test_mesh_wiki_explains_core_source_authority_for_non_engineering_audiences(
     )
     assert "settlement-dated future external `DEPOSIT` and `WITHDRAWAL` movements" in wiki
     assert "Same-day booked and projected movements are additive" in wiki
+    assert "observed booked transaction-fee evidence" in wiki
+    assert "explicit `transaction_costs` rows when present" in wiki
+    assert "best-execution, OMS acknowledgement" in normalized_wiki
     assert "flowchart LR" in wiki
 
 
@@ -85,3 +90,42 @@ def test_portfolio_cashflow_projection_methodology_is_implementation_backed() ->
     assert "Same-day booked and projected movements exist" in methodology
     assert "No FX conversion, tax methodology, liquidity bucketing" in normalized_methodology
     assert "| `points[2026-03-04].net_cashflow` | -18000 |" in methodology
+
+
+def test_transaction_cost_curve_methodology_is_implementation_backed() -> None:
+    methodology = _read("docs/methodologies/source-data-products/transaction-cost-curve.md")
+    normalized_methodology = _single_line(methodology)
+
+    expected_sections = [
+        "## Metric",
+        "## Endpoint and Mode Coverage",
+        "## Inputs",
+        "## Upstream Data Sources",
+        "## Unit Conventions",
+        "## Variable Dictionary",
+        "## Methodology and Formulas",
+        "## Step-by-Step Computation",
+        "## Validation and Failure Behavior",
+        "## Configuration Options",
+        "## Outputs",
+        "## Worked Example",
+    ]
+    section_positions = [methodology.index(section) for section in expected_sections]
+
+    assert section_positions == sorted(section_positions)
+    assert "`TransactionCostCurve:v1`" in methodology
+    assert "grouped by security, transaction type, and fee currency" in methodology
+    assert "Cost rows take precedence over `trade_fee`" in methodology
+    assert "No FX conversion, market-impact adjustment" in normalized_methodology
+    assert "best-execution assessment, OMS acknowledgement" in normalized_methodology
+    assert "`AB_G = TC_G / TN_G * 10000`" in methodology
+    assert "security_id:asc,transaction_type:asc,currency:asc" in methodology
+    assert "| `curve_points[0].average_cost_bps` | 13.3333 |" in methodology
+
+
+def test_methodology_index_links_source_data_product_methodologies() -> None:
+    index = _read("docs/methodologies/README.md")
+
+    assert "source-data-products/portfolio-cashflow-projection.md" in index
+    assert "source-data-products/transaction-cost-curve.md" in index
+    assert "Observed booked-fee aggregation by security, transaction type, and currency" in index

--- a/tests/unit/services/query_service/services/test_integration_service.py
+++ b/tests/unit/services/query_service/services/test_integration_service.py
@@ -8,8 +8,8 @@ from portfolio_common.reconciliation_quality import BLOCKED, COMPLETE, PARTIAL, 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.services.query_service.app.dtos.reference_integration_dto import (
-    ClientRestrictionProfileRequest,
     CioModelChangeAffectedCohortRequest,
+    ClientRestrictionProfileRequest,
     DiscretionaryMandateBindingRequest,
     DpmSourceReadinessRequest,
     InstrumentEligibilityBulkRequest,
@@ -1920,6 +1920,75 @@ async def test_transaction_cost_curve_returns_ready_observed_fee_evidence() -> N
         security_ids=["EQ_US_AAPL"],
         transaction_types=["BUY"],
     )
+
+
+@pytest.mark.asyncio
+async def test_transaction_cost_curve_groups_by_security_type_and_currency() -> None:
+    service = make_service()
+    service._transaction_repository = SimpleNamespace(  # type: ignore[assignment]
+        portfolio_exists=AsyncMock(return_value=True),
+        list_transaction_cost_evidence=AsyncMock(
+            return_value=[
+                transaction_cost_row(
+                    transaction_id="TXN-AAPL-BUY-USD-001",
+                    security_id="EQ_US_AAPL",
+                    transaction_type="BUY",
+                    currency="USD",
+                    gross_transaction_amount=Decimal("10000.00"),
+                    trade_fee=Decimal("10.00"),
+                ),
+                transaction_cost_row(
+                    transaction_id="TXN-AAPL-BUY-USD-002",
+                    security_id="EQ_US_AAPL",
+                    transaction_type="BUY",
+                    currency="USD",
+                    gross_transaction_amount=Decimal("20000.00"),
+                    trade_fee=Decimal("30.00"),
+                ),
+                transaction_cost_row(
+                    transaction_id="TXN-AAPL-SELL-USD-001",
+                    security_id="EQ_US_AAPL",
+                    transaction_type="SELL",
+                    currency="USD",
+                    gross_transaction_amount=Decimal("15000.00"),
+                    trade_fee=Decimal("15.00"),
+                ),
+                transaction_cost_row(
+                    transaction_id="TXN-AAPL-BUY-SGD-001",
+                    security_id="EQ_US_AAPL",
+                    transaction_type="BUY",
+                    currency="SGD",
+                    gross_transaction_amount=Decimal("12000.00"),
+                    trade_fee=Decimal("24.00"),
+                ),
+            ]
+        ),
+    )
+
+    response = await service.get_transaction_cost_curve(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        request=TransactionCostCurveRequest(
+            as_of_date=date(2026, 5, 3),
+            window={"start_date": date(2026, 4, 1), "end_date": date(2026, 4, 30)},
+        ),
+    )
+
+    points = {
+        (point.security_id, point.transaction_type, point.currency): point
+        for point in response.curve_points
+    }
+
+    assert sorted(points) == [
+        ("EQ_US_AAPL", "BUY", "SGD"),
+        ("EQ_US_AAPL", "BUY", "USD"),
+        ("EQ_US_AAPL", "SELL", "USD"),
+    ]
+    assert points[("EQ_US_AAPL", "BUY", "USD")].observation_count == 2
+    assert points[("EQ_US_AAPL", "BUY", "USD")].average_cost_bps == Decimal("13.3333")
+    assert points[("EQ_US_AAPL", "BUY", "USD")].min_cost_bps == Decimal("10.0000")
+    assert points[("EQ_US_AAPL", "BUY", "USD")].max_cost_bps == Decimal("15.0000")
+    assert points[("EQ_US_AAPL", "BUY", "SGD")].average_cost_bps == Decimal("20.0000")
+    assert points[("EQ_US_AAPL", "SELL", "USD")].average_cost_bps == Decimal("10.0000")
 
 
 @pytest.mark.asyncio

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -74,6 +74,14 @@ before the projection start date. Same-day booked and projected movements are ad
 carry forward the prior cumulative value, and all monetary fields remain in the portfolio base
 currency.
 
+`TransactionCostCurve:v1` is the governed source for observed booked transaction-fee evidence
+grouped by security, transaction type, and fee currency. Its implementation-backed methodology uses
+explicit `transaction_costs` rows when present, falls back to `trade_fee` only when explicit cost
+rows are absent, filters unusable zero-fee or zero-notional observations, and computes total cost,
+total absolute notional, notional-weighted average cost bps, min cost bps, and max cost bps for each
+group. It is not an execution-quality, market-impact, venue-routing, best-execution, OMS
+acknowledgement, or minimum-cost execution methodology.
+
 ```mermaid
 flowchart LR
     CoreLedger[core TransactionLedgerWindow:v1<br/>row-level fees, withholding tax, realized FX P&L, linked cashflow]


### PR DESCRIPTION
## Summary
- add an implementation-backed v3 methodology for `TransactionCostCurve:v1`
- refactor observed transaction-cost curve point construction into named helpers while preserving the existing API contract
- update source-data product catalog, methodology index, repo context, and wiki source so downstream teams can use the methodology without overclaiming execution quality
- add focused behavior/docs regression tests for grouping, formulas, boundaries, and index discoverability

## Evidence
- `python -m ruff format --check src\services\query_service\app\services\integration_service.py tests\unit\services\query_service\services\test_integration_service.py tests\unit\docs\test_source_data_product_boundaries.py`
- `python -m ruff check src\services\query_service\app\services\integration_service.py tests\unit\services\query_service\services\test_integration_service.py tests\unit\docs\test_source_data_product_boundaries.py`
- `python -m pytest tests\unit\services\query_service\services\test_integration_service.py -k transaction_cost_curve -q`
- `python -m pytest tests\unit\docs\test_source_data_product_boundaries.py -q`
- `python -m pytest tests\integration\services\query_control_plane_service\test_control_plane_app.py -k transaction_cost_curve -q`
- `python -m pytest tests\unit\services\query_control_plane_service\routers\test_integration_router.py -k transaction_cost_curve -q`
- `make source-data-product-contract-guard`
- `make openapi-gate`
- `git diff --check` (passed with normal LF-to-CRLF warnings)
- `git fetch origin --prune; git branch -r --no-merged origin/main` (no unmerged governance branches reported)

## Wiki
- Repo-local `wiki/Mesh-Data-Products.md` changed.
- Pre-merge `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-core` reports expected drift for `Mesh-Data-Products.md`; publish after merge from repo-local wiki source.