### PR TITLE
Document portfolio tax lot methodology

### DIFF
--- a/docs/architecture/RFC-0083-source-data-product-catalog.md
+++ b/docs/architecture/RFC-0083-source-data-product-catalog.md
@@ -118,7 +118,7 @@ following `lotus-core` products are the current source boundary for those dimens
 | `HoldingsAsOf:v1` | Portfolio positions, cash-balance totals, portfolio/base currency, as-of date, supportability metadata, and latest evidence timestamp. | Consumers may use returned cash totals and holdings rows as source facts with the product metadata attached. | Consumers must not infer liquidity ladders, income need, performance returns, or risk exposure methodology from holdings or cash totals alone. |
 | `TransactionLedgerWindow:v1` | Deterministically ordered booked transaction rows, trade fees, transaction-cost records, withholding tax, other interest deductions, net interest, realized capital/FX/total P&L fields, linked cashflow records, FX/event linkage identifiers, and optional reporting-currency restatements. | Consumers may preserve explicit row-level measures, lineage, supportability posture, source field, source unit, and selected row identity. | Consumers must not aggregate rows into tax methodology, FX attribution, cash movement methodology, transaction-cost methodology, or execution-quality conclusions unless a source owner publishes that methodology. |
 | `PortfolioCashflowProjection:v1` | Daily net cashflow points, cumulative cashflow across the returned window, total net cashflow, portfolio currency, include-projected posture, evidence timestamp, and deterministic source fingerprint. | Consumers may use the returned total and points as core-owned operational cashflow evidence. | Consumers must not treat the projection as a liquidity ladder, funding recommendation, income plan, OMS execution forecast, market-impact estimate, or client cash-need methodology. |
-| `PortfolioTaxLotWindow:v1` | Effective tax-lot and cost-basis state for tax-aware discretionary sell decisions. | Consumers may use lot quantity, acquisition date, cost basis, and source supportability to explain candidate sell allocation. | Consumers must not claim complete jurisdiction-specific tax advice, realized-tax optimization, or client-tax approval from lot state alone. |
+| `PortfolioTaxLotWindow:v1` | Effective tax-lot and cost-basis state for tax-aware discretionary sell decisions. The implementation-backed methodology is documented in `docs/methodologies/source-data-products/portfolio-tax-lot-window.md`. | Consumers may use lot quantity, acquisition date, cost basis, source transaction lineage, calculation policy metadata, and source supportability to explain candidate sell allocation. | Consumers must not claim complete jurisdiction-specific tax advice, realized-tax optimization, wash-sale treatment, client-tax approval, or tax-reporting certification from lot state alone. |
 | `TransactionCostCurve:v1` | Observed booked fee evidence grouped by security, transaction type, and currency. | Consumers may distinguish source-backed observed cost context from local estimated construction cost. | Consumers must not claim predictive market-impact, venue-routing, fill-quality, best-execution, or minimum-cost execution methodology from observed fee evidence. |
 
 These boundaries are intentionally conservative. `lotus-core` is the source authority for recorded
@@ -135,6 +135,14 @@ rows ahead of `trade_fee`; excludes zero-fee and zero-notional observations; com
 notional-weighted average cost bps plus min/max per-transaction cost bps; and preserves the
 non-claim boundary from predictive market-impact, venue-routing, best-execution, OMS
 acknowledgement, and minimum-cost execution methodology.
+
+`PortfolioTaxLotWindow:v1` now has implementation-backed methodology truth in
+`docs/methodologies/source-data-products/portfolio-tax-lot-window.md`. The method selects
+effective-dated lots from `position_lot_state`, applies open/closed lot filtering, preserves
+base/local cost-basis fields, carries source transaction and calculation-policy lineage, uses
+deterministic paging, reports empty full-portfolio source evidence explicitly, and preserves the
+non-claim boundary from jurisdiction-specific tax advice, realized-tax optimization, wash-sale
+treatment, client-tax approval, and tax-reporting certification.
 
 ## Portfolio Performance Snapshot Boundary
 

--- a/docs/methodologies/README.md
+++ b/docs/methodologies/README.md
@@ -8,4 +8,5 @@ downstream applications need auditable formulas, boundaries, and non-claims.
 | Product | Methodology | Scope |
 | --- | --- | --- |
 | `PortfolioCashflowProjection:v1` | [Portfolio Cashflow Projection](./source-data-products/portfolio-cashflow-projection.md) | Operational daily and total cashflow projection, booked-only/projected modes, and non-claims for liquidity ladders, tax, performance, market impact, and OMS execution. |
+| `PortfolioTaxLotWindow:v1` | [Portfolio Tax Lot Window](./source-data-products/portfolio-tax-lot-window.md) | Effective-dated open and closed tax-lot state, cost-basis evidence, deterministic paging, and non-claims for jurisdiction-specific tax advice, realized-tax optimization, and client-tax approval. |
 | `TransactionCostCurve:v1` | [Transaction Cost Curve](./source-data-products/transaction-cost-curve.md) | Observed booked-fee aggregation by security, transaction type, and currency, with non-claims for market impact, venue routing, best execution, OMS acknowledgement, and minimum-cost execution methodology. |

--- a/docs/methodologies/source-data-products/portfolio-tax-lot-window.md
+++ b/docs/methodologies/source-data-products/portfolio-tax-lot-window.md
@@ -1,0 +1,187 @@
+# Portfolio Tax Lot Window Methodology
+
+## Metric
+
+`PortfolioTaxLotWindow:v1` is the core-owned tax-lot and cost-basis evidence product exposed by
+`POST /integration/portfolios/{portfolio_id}/tax-lots`.
+
+It returns effective-dated portfolio tax lots for discretionary portfolio management sell decisions.
+The product supplies source-owned lot quantity, acquisition date, cost-basis, source transaction,
+and calculation-policy lineage. It is not jurisdiction-specific tax advice, realized-tax
+optimization, wash-sale treatment, client-tax approval, tax-reporting certification, or execution
+methodology.
+
+## Endpoint and Mode Coverage
+
+| Request shape | Implemented behavior |
+| --- | --- |
+| `portfolio_id` path parameter | Selects the portfolio whose tax-lot state is requested. |
+| `as_of_date` | Includes lots acquired on or before the as-of date. |
+| optional `security_ids` | Restricts evidence to requested securities and reports missing requested securities as supportability gaps. |
+| optional `lot_status_filter=OPEN` | Returns lots with positive open quantity. |
+| optional `lot_status_filter=CLOSED` | Returns lots with zero or negative open quantity. |
+| `include_closed_lots=false` with no status filter | Returns open lots by default. |
+| `include_closed_lots=true` with no status filter | Returns open and closed lots. |
+| `page.page_size` / `page.page_token` | Returns deterministic cursor pages ordered by acquisition date and lot id. |
+
+The product currently has one implemented methodology: source lot-state exposure from
+`position_lot_state`. It does not switch into tax optimization, tax-loss harvesting, wash-sale, or
+jurisdiction-specific advice modes.
+
+## Inputs
+
+| Input | Source | Required | Meaning |
+| --- | --- | --- | --- |
+| `portfolio_id` | Path parameter | Yes | Portfolio whose tax-lot evidence is returned. |
+| `as_of_date` | Request body | Yes | Effective date for lot inclusion. |
+| `security_ids` | Request body | No | Optional security filter and supportability coverage expectation. |
+| `lot_status_filter` | Request body | No | Optional explicit `OPEN` or `CLOSED` status filter. |
+| `include_closed_lots` | Request body | No, default `false` | Includes closed lots only when no explicit status filter is supplied. |
+| `tenant_id` | Request body | No | Included in request-scope paging identity. |
+
+## Upstream Data Sources
+
+| Source | Used fields | Inclusion rule |
+| --- | --- | --- |
+| `portfolios` | `portfolio_id` | Portfolio must exist. |
+| `position_lot_state` | `portfolio_id`, `security_id`, `instrument_id`, `lot_id`, `open_quantity`, `original_quantity`, `acquisition_date`, `lot_cost_base`, `lot_cost_local`, `source_transaction_id`, `source_system`, `calculation_policy_id`, `calculation_policy_version`, `updated_at` | Lot must match the portfolio, optional security filter, as-of date, and status filter. |
+| `transactions` | `transaction_id`, `trade_currency` | Optional outer join by `source_transaction_id` to populate local lot currency. |
+
+The product preserves lot state already calculated and stored in `position_lot_state`. Cost-basis
+fields are preserved, not recalculated, reallocated, or tax-optimized by the endpoint.
+
+## Unit Conventions
+
+`open_quantity` and `original_quantity` use the instrument quantity unit carried by the source lot
+state.
+
+`cost_basis_base` uses the portfolio base currency represented by `lot_cost_base`.
+`cost_basis_local` uses the local trade currency represented by `lot_cost_local` and
+`transactions.trade_currency` when available.
+
+No FX conversion, realized-tax calculation, tax-rate application, loss-harvesting optimization, or
+wash-sale adjustment is performed by this product.
+
+## Variable Dictionary
+
+| Symbol | Response or source field | Definition |
+| --- | --- | --- |
+| `P` | `portfolio_id` | Requested portfolio. |
+| `A` | `as_of_date` | Effective lot-state date. |
+| `S` | `security_ids` | Optional requested securities. |
+| `F` | `lot_status_filter` | Optional explicit lot status filter. |
+| `C` | `include_closed_lots` | Closed-lot inclusion flag used only when `F` is omitted. |
+| `Q_open` | `open_quantity` | Current open quantity for the lot. |
+| `Q_orig` | `original_quantity` | Original acquired quantity for the lot. |
+| `CB_base` | `cost_basis_base` | Current lot cost basis in portfolio base currency. |
+| `CB_local` | `cost_basis_local` | Current lot cost basis in local trade currency. |
+| `Status` | `tax_lot_status` | `OPEN` when `Q_open > 0`, otherwise `CLOSED`. |
+
+## Methodology and Formulas
+
+For every source lot row:
+
+`Status = OPEN if Q_open > 0 else CLOSED`
+
+`cost_basis_base = lot_cost_base`
+
+`cost_basis_local = lot_cost_local`
+
+`local_currency = transactions.trade_currency when the source transaction is available else null`
+
+The endpoint does not calculate unrealized gain, realized gain, tax payable, tax alpha, wash-sale
+adjustment, or optimal disposal sequence.
+
+## Step-by-Step Computation
+
+1. Verify that the requested portfolio exists.
+2. Build a request-scope fingerprint from portfolio id, as-of date, security filter, lot-status
+   filter, closed-lot inclusion flag, and tenant id.
+3. Decode and validate the optional page token against the request-scope fingerprint.
+4. Build the source query over `position_lot_state` where `portfolio_id=P` and
+   `acquisition_date <= A`.
+5. Apply `security_ids` when supplied.
+6. Apply lot status: `OPEN` filters to `open_quantity > 0`; `CLOSED` filters to
+   `open_quantity <= 0`; omitted status with `include_closed_lots=false` returns open lots by
+   default; omitted status with `include_closed_lots=true` returns both open and closed lots.
+7. Apply cursor continuation by `(acquisition_date, lot_id)` when a valid page token is supplied.
+8. Outer join `transactions` by `source_transaction_id` to obtain local currency when available.
+9. Sort by `acquisition_date` ascending, then `lot_id` ascending.
+10. Fetch `page_size + 1` rows to detect whether the page is partial.
+11. Map each returned lot into `PortfolioTaxLotRecord`, preserving source transaction and
+    calculation-policy lineage.
+12. Emit supportability, pagination metadata, lineage, and source-data product runtime metadata.
+
+## Validation and Failure Behavior
+
+| Condition | Behavior |
+| --- | --- |
+| Portfolio id does not exist | Service raises `LookupError`; the API maps it to HTTP `404`. |
+| Blank or duplicate `security_ids` | Request validation rejects the request. |
+| Page token scope does not match the request | Service raises `ValueError`; the API maps it to HTTP `400`. |
+| More rows exist than the page size | Response carries supportability `DEGRADED` and reason `TAX_LOTS_PAGE_PARTIAL`. |
+| Requested securities have no matching lots in the complete page scope | Response carries supportability `INCOMPLETE` and reason `TAX_LOTS_MISSING_FOR_REQUESTED_SECURITIES`. |
+| Full-portfolio request returns no lots | Response carries supportability `UNAVAILABLE`, reason `TAX_LOTS_EMPTY`, and `data_quality_status=MISSING`. |
+
+`data_quality_status` is `COMPLETE` only when supportability is `READY`; it is `MISSING` for
+`UNAVAILABLE` and `PARTIAL` for degraded or incomplete responses. This status certifies source
+tax-lot evidence availability only, not tax advice or tax optimization.
+
+## Configuration Options
+
+| Option | Current value |
+| --- | --- |
+| Default page size | `250` tax lots |
+| Maximum page size | `1000` tax lots |
+| Default status behavior | Open lots only |
+| Sort order | `acquisition_date:asc,lot_id:asc` |
+| Product identity | `PortfolioTaxLotWindow:v1` |
+
+## Outputs
+
+| Field | Methodology mapping |
+| --- | --- |
+| `lots[].portfolio_id` | Source lot portfolio id. |
+| `lots[].security_id` | Source lot security id. |
+| `lots[].instrument_id` | Source lot instrument id. |
+| `lots[].lot_id` | Stable source lot id. |
+| `lots[].open_quantity` | `Q_open`. |
+| `lots[].original_quantity` | `Q_orig`. |
+| `lots[].acquisition_date` | Lot acquisition date used for ordering and paging. |
+| `lots[].cost_basis_base` | `CB_base`. |
+| `lots[].cost_basis_local` | `CB_local`. |
+| `lots[].local_currency` | Joined source transaction trade currency when available. |
+| `lots[].tax_lot_status` | `Status`. |
+| `lots[].source_lineage` | Source system, source transaction id, calculation policy id, and calculation policy version. |
+| `supportability` | Readiness state for tax-lot evidence only. |
+
+## Worked Example
+
+Request:
+
+`POST /integration/portfolios/PB_SG_GLOBAL_BAL_001/tax-lots`
+
+```json
+{
+  "as_of_date": "2026-04-10",
+  "security_ids": ["EQ_US_AAPL"],
+  "lot_status_filter": "OPEN",
+  "page": {"page_size": 250}
+}
+```
+
+Source facts:
+
+| Lot | Security | Open quantity `Q_open` | Original quantity `Q_orig` | Acquisition date | Base cost `CB_base` | Local cost `CB_local` | Currency |
+| --- | --- | ---: | ---: | --- | ---: | ---: | --- |
+| `LOT-AAPL-001` | `EQ_US_AAPL` | 100 | 100 | 2026-03-25 | 15005.50 | 15005.50 | USD |
+
+Final output mapping:
+
+| Response field | Value |
+| --- | --- |
+| `lots[0].lot_id` | `LOT-AAPL-001` |
+| `lots[0].tax_lot_status` | `OPEN` |
+| `lots[0].cost_basis_base` | `15005.50` |
+| `lots[0].cost_basis_local` | `15005.50` |
+| `supportability.state` | `READY` |

--- a/src/services/query_service/app/services/integration_service.py
+++ b/src/services/query_service/app/services/integration_service.py
@@ -1153,7 +1153,10 @@ class IntegrationService:
         )
         supportability_state: Literal["READY", "DEGRADED", "INCOMPLETE", "UNAVAILABLE"] = "READY"
         supportability_reason = "TAX_LOTS_READY"
-        if has_more:
+        if not lots and not request.security_ids:
+            supportability_state = "UNAVAILABLE"
+            supportability_reason = "TAX_LOTS_EMPTY"
+        elif has_more:
             supportability_state = "DEGRADED"
             supportability_reason = "TAX_LOTS_PAGE_PARTIAL"
         elif request.security_ids and missing_security_ids:
@@ -1186,7 +1189,13 @@ class IntegrationService:
             },
             **self._runtime_metadata_for_existing_as_of_date(
                 request.as_of_date,
-                data_quality_status="COMPLETE" if supportability_state == "READY" else "PARTIAL",
+                data_quality_status=(
+                    "COMPLETE"
+                    if supportability_state == "READY"
+                    else "MISSING"
+                    if supportability_state == "UNAVAILABLE"
+                    else "PARTIAL"
+                ),
                 latest_evidence_timestamp=self._latest_reference_evidence_timestamp(
                     [lot for lot, _ in page_rows]
                 ),

--- a/tests/unit/docs/test_source_data_product_boundaries.py
+++ b/tests/unit/docs/test_source_data_product_boundaries.py
@@ -27,6 +27,9 @@ def test_rfc0083_documents_realized_outcome_source_boundaries() -> None:
     assert "| `PortfolioCashflowProjection:v1` |" in catalog
     assert "Daily net cashflow points, cumulative cashflow across the returned window" in catalog
     assert "must not treat the projection as a liquidity ladder" in catalog
+    assert "| `PortfolioTaxLotWindow:v1` |" in catalog
+    assert "portfolio-tax-lot-window.md" in catalog
+    assert "wash-sale treatment" in catalog
     assert "| `TransactionCostCurve:v1` |" in catalog
     assert "must not claim predictive market-impact, venue-routing, fill-quality" in catalog
     assert "transaction-cost-curve.md" in catalog
@@ -45,12 +48,15 @@ def test_mesh_wiki_explains_core_source_authority_for_non_engineering_audiences(
     assert "Sales and client demos" in wiki
     assert "`TransactionLedgerWindow:v1`" in wiki
     assert "`PortfolioCashflowProjection:v1`" in wiki
+    assert "`PortfolioTaxLotWindow:v1`" in wiki
     assert "not an execution-quality, tax-advice, liquidity-planning" in normalized_wiki
     assert "Preserve the source measure, source unit, selected field, supportability state" in (
         normalized_wiki
     )
     assert "settlement-dated future external `DEPOSIT` and `WITHDRAWAL` movements" in wiki
     assert "Same-day booked and projected movements are additive" in wiki
+    assert "position_lot_state" in wiki
+    assert "wash-sale treatment" in wiki
     assert "observed booked transaction-fee evidence" in wiki
     assert "explicit `transaction_costs` rows when present" in wiki
     assert "best-execution, OMS acknowledgement" in normalized_wiki
@@ -123,9 +129,41 @@ def test_transaction_cost_curve_methodology_is_implementation_backed() -> None:
     assert "| `curve_points[0].average_cost_bps` | 13.3333 |" in methodology
 
 
+def test_portfolio_tax_lot_window_methodology_is_implementation_backed() -> None:
+    methodology = _read("docs/methodologies/source-data-products/portfolio-tax-lot-window.md")
+    normalized_methodology = _single_line(methodology)
+
+    expected_sections = [
+        "## Metric",
+        "## Endpoint and Mode Coverage",
+        "## Inputs",
+        "## Upstream Data Sources",
+        "## Unit Conventions",
+        "## Variable Dictionary",
+        "## Methodology and Formulas",
+        "## Step-by-Step Computation",
+        "## Validation and Failure Behavior",
+        "## Configuration Options",
+        "## Outputs",
+        "## Worked Example",
+    ]
+    section_positions = [methodology.index(section) for section in expected_sections]
+
+    assert section_positions == sorted(section_positions)
+    assert "`PortfolioTaxLotWindow:v1`" in methodology
+    assert "`position_lot_state`" in methodology
+    assert "returns open lots by default" in normalized_methodology
+    assert "not recalculated, reallocated, or tax-optimized" in normalized_methodology
+    assert "TAX_LOTS_EMPTY" in methodology
+    assert "wash-sale treatment" in methodology
+    assert "| `lots[0].tax_lot_status` | `OPEN` |" in methodology
+
+
 def test_methodology_index_links_source_data_product_methodologies() -> None:
     index = _read("docs/methodologies/README.md")
 
     assert "source-data-products/portfolio-cashflow-projection.md" in index
+    assert "source-data-products/portfolio-tax-lot-window.md" in index
     assert "source-data-products/transaction-cost-curve.md" in index
+    assert "Effective-dated open and closed tax-lot state" in index
     assert "Observed booked-fee aggregation by security, transaction type, and currency" in index

--- a/tests/unit/services/query_service/services/test_integration_service.py
+++ b/tests/unit/services/query_service/services/test_integration_service.py
@@ -1837,6 +1837,26 @@ async def test_portfolio_tax_lot_window_reports_missing_requested_security() -> 
 
 
 @pytest.mark.asyncio
+async def test_portfolio_tax_lot_window_marks_empty_full_portfolio_unavailable() -> None:
+    service = make_service()
+    service._buy_state_repository = SimpleNamespace(  # type: ignore[assignment]
+        portfolio_exists=AsyncMock(return_value=True),
+        list_portfolio_tax_lots=AsyncMock(return_value=[]),
+    )
+
+    response = await service.get_portfolio_tax_lot_window(
+        portfolio_id="PB_EMPTY",
+        request=PortfolioTaxLotWindowRequest(as_of_date=date(2026, 4, 10)),
+    )
+
+    assert response.supportability.state == "UNAVAILABLE"
+    assert response.supportability.reason == "TAX_LOTS_EMPTY"
+    assert response.supportability.returned_lot_count == 0
+    assert response.supportability.missing_security_ids == []
+    assert response.data_quality_status == "MISSING"
+
+
+@pytest.mark.asyncio
 async def test_portfolio_tax_lot_window_rejects_page_token_scope_mismatch() -> None:
     service = make_service()
     service._buy_state_repository = SimpleNamespace(  # type: ignore[assignment]

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -74,6 +74,12 @@ before the projection start date. Same-day booked and projected movements are ad
 carry forward the prior cumulative value, and all monetary fields remain in the portfolio base
 currency.
 
+`PortfolioTaxLotWindow:v1` is the governed source for effective-dated lot and cost-basis state from
+`position_lot_state`, including open/original quantity, acquisition date, base and local cost basis,
+local currency when source transaction currency is available, source transaction id, calculation
+policy id/version, and supportability. It is not jurisdiction-specific tax advice, realized-tax
+optimization, wash-sale treatment, client-tax approval, or tax-reporting certification.
+
 `TransactionCostCurve:v1` is the governed source for observed booked transaction-fee evidence
 grouped by security, transaction type, and fee currency. Its implementation-backed methodology uses
 explicit `transaction_costs` rows when present, falls back to `trade_fee` only when explicit cost


### PR DESCRIPTION
## Summary
- adds v3 implementation-backed PortfolioTaxLotWindow:v1 methodology documentation
- hardens empty full-portfolio tax-lot supportability to UNAVAILABLE/TAX_LOTS_EMPTY instead of READY
- updates source-product catalog, methodology index, wiki source, service/doc tests, and source-data boundary guards

## Local proof
- python -m ruff format --check src\services\query_service\app\services\integration_service.py tests\unit\services\query_service\services\test_integration_service.py tests\unit\docs\test_source_data_product_boundaries.py
- python -m ruff check src\services\query_service\app\services\integration_service.py tests\unit\services\query_service\services\test_integration_service.py tests\unit\docs\test_source_data_product_boundaries.py
- python -m pytest tests\unit\services\query_service\services\test_integration_service.py -k "portfolio_tax_lot_window" -q
- python -m pytest tests\unit\docs\test_source_data_product_boundaries.py -q
- make source-data-product-contract-guard
- make openapi-gate
- git diff --check
- stranded-truth reconciliation: git fetch origin --prune; git branch -r --no-merged origin/main produced no unmerged governance branch output
- wiki check-only reports expected pre-merge drift for wiki/Mesh-Data-Products.md until repo-local wiki source is published after merge