### PR TITLE
Document transaction ledger methodology

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -256,13 +256,21 @@ Most relevant current governance:
     declarations, OpenAPI proof, live validator coverage where applicable, and canonical
     front-office seed support for `PB_SG_GLOBAL_BAL_001`.
 31. RFC42-WTBD-006 source-owner methodology depth now includes the implementation-backed
+    `TransactionLedgerWindow:v1` methodology under
+    `docs/methodologies/source-data-products/transaction-ledger-window.md`; it pins row filtering
+    by portfolio, instrument/security, transaction type, FX/event linkage, date window, and
+    effective as-of date; joined transaction-cost and cashflow row preservation; optional
+    reporting-currency restatement from latest available FX rates; empty, complete, and paged
+    window data-quality posture; and explicit boundaries from tax advice, FX attribution, cash
+    aggregation, transaction-cost methodology, execution quality, and OMS acknowledgement.
+32. RFC42-WTBD-006 source-owner methodology depth now includes the implementation-backed
     `PortfolioCashflowProjection:v1` methodology under
     `docs/methodologies/source-data-products/portfolio-cashflow-projection.md`; it pins the
     booked-only versus projected modes, latest-cashflow-row selection, settlement-dated external
     `DEPOSIT`/`WITHDRAWAL` inclusion rule, same-day booked/projected additivity, portfolio-base
     currency convention, and explicit boundary from liquidity ladders, tax, performance,
     market-impact, and OMS execution methodology.
-32. RFC42-WTBD-006 source-owner methodology depth now also includes the implementation-backed
+33. RFC42-WTBD-006 source-owner methodology depth now also includes the implementation-backed
     `TransactionCostCurve:v1` methodology under
     `docs/methodologies/source-data-products/transaction-cost-curve.md`; it pins observed
     booked-fee grouping by security, transaction type, and currency; explicit transaction-cost row

--- a/docs/architecture/RFC-0083-source-data-product-catalog.md
+++ b/docs/architecture/RFC-0083-source-data-product-catalog.md
@@ -116,7 +116,7 @@ following `lotus-core` products are the current source boundary for those dimens
 | Product | Source-owned evidence | Downstream rule | Explicit non-claim |
 | --- | --- | --- | --- |
 | `HoldingsAsOf:v1` | Portfolio positions, cash-balance totals, portfolio/base currency, as-of date, supportability metadata, and latest evidence timestamp. | Consumers may use returned cash totals and holdings rows as source facts with the product metadata attached. | Consumers must not infer liquidity ladders, income need, performance returns, or risk exposure methodology from holdings or cash totals alone. |
-| `TransactionLedgerWindow:v1` | Deterministically ordered booked transaction rows, trade fees, transaction-cost records, withholding tax, other interest deductions, net interest, realized capital/FX/total P&L fields, linked cashflow records, FX/event linkage identifiers, and optional reporting-currency restatements. | Consumers may preserve explicit row-level measures, lineage, supportability posture, source field, source unit, and selected row identity. | Consumers must not aggregate rows into tax methodology, FX attribution, cash movement methodology, transaction-cost methodology, or execution-quality conclusions unless a source owner publishes that methodology. |
+| `TransactionLedgerWindow:v1` | Deterministically ordered booked transaction rows, trade fees, transaction-cost records, withholding tax, other interest deductions, net interest, realized capital/FX/total P&L fields, linked cashflow records, FX/event linkage identifiers, and optional reporting-currency restatements. The implementation-backed methodology is documented in `docs/methodologies/source-data-products/transaction-ledger-window.md`. | Consumers may preserve explicit row-level measures, lineage, supportability posture, source field, source unit, and selected row identity. | Consumers must not aggregate rows into tax methodology, FX attribution, cash movement methodology, transaction-cost methodology, or execution-quality conclusions unless a source owner publishes that methodology. |
 | `PortfolioCashflowProjection:v1` | Daily net cashflow points, cumulative cashflow across the returned window, total net cashflow, portfolio currency, include-projected posture, evidence timestamp, and deterministic source fingerprint. | Consumers may use the returned total and points as core-owned operational cashflow evidence. | Consumers must not treat the projection as a liquidity ladder, funding recommendation, income plan, OMS execution forecast, market-impact estimate, or client cash-need methodology. |
 | `PortfolioTaxLotWindow:v1` | Effective tax-lot and cost-basis state for tax-aware discretionary sell decisions. The implementation-backed methodology is documented in `docs/methodologies/source-data-products/portfolio-tax-lot-window.md`. | Consumers may use lot quantity, acquisition date, cost basis, source transaction lineage, calculation policy metadata, and source supportability to explain candidate sell allocation. | Consumers must not claim complete jurisdiction-specific tax advice, realized-tax optimization, wash-sale treatment, client-tax approval, or tax-reporting certification from lot state alone. |
 | `TransactionCostCurve:v1` | Observed booked fee evidence grouped by security, transaction type, and currency. | Consumers may distinguish source-backed observed cost context from local estimated construction cost. | Consumers must not claim predictive market-impact, venue-routing, fill-quality, best-execution, or minimum-cost execution methodology from observed fee evidence. |
@@ -127,6 +127,15 @@ performance returns, risk methodology, client tax advice, liquidity planning, ex
 post-trade OMS acknowledgement methodology. Downstream products must carry source refs and
 supportability metadata and must degrade when a required source product is unavailable, partial,
 stale, or outside its explicit methodology boundary.
+
+`TransactionLedgerWindow:v1` now has implementation-backed methodology truth in
+`docs/methodologies/source-data-products/transaction-ledger-window.md`. The method filters booked
+rows by portfolio, optional instrument/security, transaction type, FX/event linkage, date window,
+and effective as-of date; preserves joined row-level transaction-cost and cashflow evidence;
+populates optional reporting-currency fields from latest available FX rates; classifies empty,
+complete, and paged windows; and preserves the non-claim boundary from tax advice, FX attribution,
+cash-movement aggregation, transaction-cost methodology, execution quality, and OMS
+acknowledgement.
 
 `TransactionCostCurve:v1` now has implementation-backed methodology truth in
 `docs/methodologies/source-data-products/transaction-cost-curve.md`. The method groups observed

--- a/docs/methodologies/README.md
+++ b/docs/methodologies/README.md
@@ -7,6 +7,7 @@ downstream applications need auditable formulas, boundaries, and non-claims.
 
 | Product | Methodology | Scope |
 | --- | --- | --- |
+| `TransactionLedgerWindow:v1` | [Transaction Ledger Window](./source-data-products/transaction-ledger-window.md) | Governed booked transaction-row windowing, filters, linked row evidence, reporting-currency restatement, data-quality posture, and non-claims for tax, FX attribution, cash aggregation, transaction-cost methodology, and execution quality. |
 | `PortfolioCashflowProjection:v1` | [Portfolio Cashflow Projection](./source-data-products/portfolio-cashflow-projection.md) | Operational daily and total cashflow projection, booked-only/projected modes, and non-claims for liquidity ladders, tax, performance, market impact, and OMS execution. |
 | `PortfolioTaxLotWindow:v1` | [Portfolio Tax Lot Window](./source-data-products/portfolio-tax-lot-window.md) | Effective-dated open and closed tax-lot state, cost-basis evidence, deterministic paging, and non-claims for jurisdiction-specific tax advice, realized-tax optimization, and client-tax approval. |
 | `TransactionCostCurve:v1` | [Transaction Cost Curve](./source-data-products/transaction-cost-curve.md) | Observed booked-fee aggregation by security, transaction type, and currency, with non-claims for market impact, venue routing, best execution, OMS acknowledgement, and minimum-cost execution methodology. |

--- a/docs/methodologies/source-data-products/transaction-ledger-window.md
+++ b/docs/methodologies/source-data-products/transaction-ledger-window.md
@@ -1,0 +1,191 @@
+# Transaction Ledger Window Methodology
+
+## Metric
+
+`TransactionLedgerWindow:v1` is the core-owned operational transaction-ledger product exposed by
+`GET /portfolios/{portfolio_id}/transactions`.
+
+It returns governed booked transaction rows for one portfolio with source-data product identity,
+runtime metadata, optional filters, offset pagination, linked cost/cashflow evidence, and
+optional reporting-currency restatement fields. The product is source evidence for row-level
+portfolio activity. It is not a tax methodology, FX attribution methodology, cash-movement
+aggregation methodology, transaction-cost curve methodology, execution-quality assessment, OMS
+acknowledgement, or client advice output.
+
+## Endpoint and Mode Coverage
+
+| Mode | Request shape | Implemented behavior |
+| --- | --- | --- |
+| Default booked ledger | No `as_of_date`, `include_projected=false` | Resolves `as_of_date` to the latest business date when available, otherwise the current application date. Returns rows with `transaction_date <= as_of_date`. |
+| Explicit as-of ledger | `as_of_date=<date>` | Returns rows with `transaction_date <= as_of_date`. |
+| Projected-inclusive ledger | `include_projected=true` | Does not apply the default business-date cap when `as_of_date` is omitted, allowing future-dated projected rows that match the other filters. |
+| Reporting-currency restated ledger | `reporting_currency=<ccy>` with an effective `as_of_date` | Adds reporting-currency monetary fields by applying the latest available FX rate on or before the effective `as_of_date`. Raw ledger monetary fields remain unchanged. |
+
+## Inputs
+
+| Input | Source | Required | Meaning |
+| --- | --- | --- | --- |
+| `portfolio_id` | Path parameter | Yes | Portfolio whose transaction ledger is queried. |
+| `instrument_id` | Query parameter | No | Restricts rows to one instrument. |
+| `security_id` | Query parameter | No | Restricts rows to one security for holdings drill-down. |
+| `transaction_type` | Query parameter | No | Restricts rows to one canonical transaction type. |
+| `component_type` | Query parameter | No | Restricts rows to one FX component type. |
+| `linked_transaction_group_id` | Query parameter | No | Restricts rows to one linked economic-event group. |
+| `fx_contract_id` | Query parameter | No | Restricts rows to one FX contract. |
+| `swap_event_id` | Query parameter | No | Restricts rows to one FX swap event. |
+| `near_leg_group_id` | Query parameter | No | Restricts rows to one FX swap near-leg group. |
+| `far_leg_group_id` | Query parameter | No | Restricts rows to one FX swap far-leg group. |
+| `start_date` | Query parameter | No | Inclusive lower bound on `transaction_date`. |
+| `end_date` | Query parameter | No | Inclusive upper bound on `transaction_date`. |
+| `as_of_date` | Query parameter | No | Booked-state cap on `transaction_date`. |
+| `include_projected` | Query parameter | No, default `false` | Controls whether the default latest-business-date cap is skipped when no explicit `as_of_date` is supplied. |
+| `reporting_currency` | Query parameter | No | Currency used to populate restated reporting-currency monetary fields. |
+| `skip`, `limit` | Pagination parameters | No | Offset pagination controls. |
+| `sort_by`, `sort_order` | Sorting parameters | No | Sorts by an allowed transaction field; defaults to `transaction_date` descending. |
+
+## Upstream Data Sources
+
+| Source | Used fields | Inclusion rule |
+| --- | --- | --- |
+| `portfolios` | `portfolio_id` | Portfolio must exist. |
+| `business_dates` | `date`, `calendar_code` | Supplies the default `as_of_date` when the caller omits it and `include_projected=false`. |
+| `transactions` | transaction identity, dates, type, instrument/security ids, quantities, prices, monetary fields, FX fields, linked-event fields, source fields, and `updated_at` | Rows must match the requested portfolio and filters. Date filters use `transaction_date`. |
+| `transaction_costs` | `fee_type`, `amount`, `currency` | Joined as row-level cost evidence and returned without aggregation. |
+| `cashflows` | cashflow row fields linked to the transaction | Joined as row-level linked cashflow evidence when present. |
+| `fx_rates` | `from_currency`, `to_currency`, `rate_date`, `rate` | Used only for optional reporting-currency restatement fields. |
+
+## Unit Conventions
+
+Raw monetary fields remain in the transaction row currency conventions already stored on the
+ledger row. The response does not convert or overwrite raw ledger values.
+
+When `reporting_currency` is supplied and an effective `as_of_date` exists, the service applies the
+latest FX rate with `rate_date <= as_of_date` from each row currency to the requested reporting
+currency and populates only the `*_reporting_currency` fields. Same-currency restatement uses a
+rate of `1`.
+
+No tax calculation, FX attribution, cash movement aggregation, transaction-cost curve aggregation,
+market-impact adjustment, execution-quality assessment, or OMS status inference is performed by
+this product.
+
+## Variable Dictionary
+
+| Symbol | Response or source field | Definition |
+| --- | --- | --- |
+| `P` | `portfolio_id` | Requested portfolio. |
+| `S` | `start_date` | Optional inclusive start date. |
+| `E` | `end_date` | Optional inclusive end date. |
+| `A` | `as_of_date` | Effective booked-state cap. |
+| `I` | `include_projected` | Flag controlling default as-of capping when no explicit `A` is supplied. |
+| `F` | filter set | Instrument, security, transaction type, FX, linked-group, and leg filters. |
+| `N` | `total` | Count of all rows matching `P`, `F`, and date/as-of filters. |
+| `K` | `skip` | Offset into the matching row set. |
+| `L` | `limit` | Maximum returned rows. |
+| `R` | `transactions[]` | Returned page of transaction rows. |
+| `Q` | `data_quality_status` | `COMPLETE`, `PARTIAL`, or `UNKNOWN` page quality posture. |
+| `X_c` | reporting FX rate | Latest FX rate from row currency to reporting currency on or before `A`. |
+
+## Methodology and Formulas
+
+The matching row set is:
+
+`M = rows where portfolio_id = P and all requested filters F match`
+
+Date filters are applied as:
+
+`transaction_date >= start_of_day(S)` when `S` is supplied
+
+`transaction_date < start_of_next_day(E)` when `E` is supplied
+
+`transaction_date < start_of_next_day(A)` when an effective `A` is supplied
+
+Reporting-currency fields are computed independently for each populated raw monetary field:
+
+`amount_reporting_currency = amount * X_c`
+
+The raw amount remains unchanged. The product does not derive cross-row measures from the returned
+page.
+
+## Step-by-Step Computation
+
+1. Verify the portfolio exists.
+2. Resolve the effective `A`: use request `as_of_date` when supplied; otherwise, if
+   `include_projected=false`, use the latest business date for the default business calendar or
+   the current application date when no business date exists; otherwise leave `A` unset.
+3. Build the transaction ledger filter set from portfolio, instrument/security, transaction type,
+   FX component, linked group, FX contract, swap event, near-leg, far-leg, start date, end date,
+   and effective as-of date.
+4. Count all matching rows for `total`.
+5. Query the requested page with eager row-level `cashflow` and `transaction_costs` evidence.
+6. Sort by the requested allowed field and direction; when no allowed field is supplied, sort by
+   `transaction_date` descending.
+7. Convert each row into `TransactionRecord`, preserving row-level cost records and linked cashflow
+   records when present.
+8. If `reporting_currency` is supplied and `A` exists, populate supported
+   `*_reporting_currency` fields using the latest FX rate on or before `A`.
+9. Compute `data_quality_status` from `total`, returned row count, and `skip`.
+10. Return source-data runtime metadata including product identity, version, effective as-of date,
+    latest evidence timestamp, reconciliation status, restatement version, and data-quality status.
+
+## Validation and Failure Behavior
+
+| Condition | Behavior |
+| --- | --- |
+| Portfolio id does not exist | Service raises `LookupError`; the API maps it to HTTP `404`. |
+| `reporting_currency` is supplied but no FX rate exists for a row currency as of `A` | Service raises `ValueError`; the API maps it to HTTP `400`. |
+| No rows match the filters | Returns an empty page with `total=0` and `data_quality_status=UNKNOWN`. |
+| Returned page is smaller than all matching rows or `skip > 0` | Returns `data_quality_status=PARTIAL`. |
+| Returned page contains all matching rows from offset zero | Returns `data_quality_status=COMPLETE`. |
+| `sort_by` is not in the allowed sort-field set | Falls back to `transaction_date`. |
+| Row-level `transaction_costs` exist | Returned as `costs[]`; this endpoint does not aggregate them into cost curves. |
+| Row-level linked `cashflow` exists | Returned as `cashflow`; this endpoint does not aggregate it into operational cashflow methodology. |
+
+## Configuration Options
+
+| Option | Current value |
+| --- | --- |
+| Default sort field | `transaction_date` |
+| Default sort order | `desc` |
+| Allowed sort fields | `transaction_date`, `settlement_date`, `quantity`, `price`, `gross_transaction_amount` |
+| Default business calendar | `DEFAULT_BUSINESS_CALENDAR_CODE` |
+| Product identity | `TransactionLedgerWindow:v1` |
+
+## Outputs
+
+| Field | Methodology mapping |
+| --- | --- |
+| `product_name`, `product_version` | Governed source-data product identity. |
+| `portfolio_id` | Requested portfolio. |
+| `reporting_currency` | Requested reporting currency, if supplied. |
+| `total`, `skip`, `limit` | Matching row count and page controls. |
+| `transactions[]` | Row-level transaction evidence after filters, sorting, and pagination. |
+| `transactions[].costs[]` | Joined explicit transaction-cost rows without aggregation. |
+| `transactions[].cashflow` | Joined linked cashflow row when present. |
+| `*_reporting_currency` fields | Optional row-level restatement into requested reporting currency. |
+| `as_of_date` | Effective booked-state cap or fallback output date. |
+| `data_quality_status` | Page completeness posture for the returned ledger window. |
+| `latest_evidence_timestamp` | Latest durable transaction `updated_at` timestamp for the filtered ledger window. |
+
+## Worked Example
+
+Request:
+
+`GET /portfolios/P1/transactions?as_of_date=2026-03-10&reporting_currency=SGD&limit=10`
+
+Source facts:
+
+| Row | Raw field | Raw amount | Currency | FX rate to SGD | Restated field | Restated amount |
+| --- | --- | ---: | --- | ---: | --- | ---: |
+| T1 | `trade_fee` | 12.50 | USD | 1.36 | `trade_fee_reporting_currency` | 17.00 |
+| T1 | `realized_gain_loss` | 250.00 | USD | 1.36 | `realized_gain_loss_reporting_currency` | 340.00 |
+| T2 | `withholding_tax_amount` | 10.00 | USD | 1.36 | `withholding_tax_amount_reporting_currency` | 13.60 |
+| T2 | `net_interest_amount` | 110.00 | USD | 1.36 | `net_interest_amount_reporting_currency` | 149.60 |
+
+Final output mapping:
+
+| Response field | Value |
+| --- | ---: |
+| `total` | 2 |
+| `data_quality_status` | `COMPLETE` |
+| `transactions[0].trade_fee_reporting_currency` | 17.00 |
+| `transactions[1].withholding_tax_amount_reporting_currency` | 13.60 |

--- a/src/services/query_service/app/repositories/transaction_repository.py
+++ b/src/services/query_service/app/repositories/transaction_repository.py
@@ -128,7 +128,6 @@ class TransactionRepository:
         """
         Constructs a base query with all the common filters.
         """
-        # FIX: Change from selectinload to joinedload for reliable eager loading
         stmt = select(Transaction).options(
             joinedload(Transaction.cashflow), joinedload(Transaction.costs)
         )

--- a/tests/unit/docs/test_source_data_product_boundaries.py
+++ b/tests/unit/docs/test_source_data_product_boundaries.py
@@ -22,6 +22,7 @@ def test_rfc0083_documents_realized_outcome_source_boundaries() -> None:
     assert "trade fees, transaction-cost records, withholding tax" in catalog
     assert "realized capital/FX/total P&L fields" in catalog
     assert "linked cashflow records" in catalog
+    assert "transaction-ledger-window.md" in catalog
     assert "must not aggregate rows into tax methodology" in catalog
     assert "FX attribution, cash movement methodology, transaction-cost methodology" in catalog
     assert "| `PortfolioCashflowProjection:v1` |" in catalog
@@ -53,6 +54,9 @@ def test_mesh_wiki_explains_core_source_authority_for_non_engineering_audiences(
     assert "Preserve the source measure, source unit, selected field, supportability state" in (
         normalized_wiki
     )
+    assert "filters booked transaction rows by portfolio" in normalized_wiki
+    assert "optional instrument/security, transaction type, FX/event linkage" in normalized_wiki
+    assert "classifies empty, complete, and paged windows" in normalized_wiki
     assert "settlement-dated future external `DEPOSIT` and `WITHDRAWAL` movements" in wiki
     assert "Same-day booked and projected movements are additive" in wiki
     assert "position_lot_state" in wiki
@@ -96,6 +100,40 @@ def test_portfolio_cashflow_projection_methodology_is_implementation_backed() ->
     assert "Same-day booked and projected movements exist" in methodology
     assert "No FX conversion, tax methodology, liquidity bucketing" in normalized_methodology
     assert "| `points[2026-03-04].net_cashflow` | -18000 |" in methodology
+
+
+def test_transaction_ledger_window_methodology_is_implementation_backed() -> None:
+    methodology = _read("docs/methodologies/source-data-products/transaction-ledger-window.md")
+    normalized_methodology = _single_line(methodology)
+
+    expected_sections = [
+        "## Metric",
+        "## Endpoint and Mode Coverage",
+        "## Inputs",
+        "## Upstream Data Sources",
+        "## Unit Conventions",
+        "## Variable Dictionary",
+        "## Methodology and Formulas",
+        "## Step-by-Step Computation",
+        "## Validation and Failure Behavior",
+        "## Configuration Options",
+        "## Outputs",
+        "## Worked Example",
+    ]
+    section_positions = [methodology.index(section) for section in expected_sections]
+
+    assert section_positions == sorted(section_positions)
+    assert "`TransactionLedgerWindow:v1`" in methodology
+    assert "Default booked ledger" in methodology
+    assert "Projected-inclusive ledger" in methodology
+    assert "Reporting-currency restated ledger" in methodology
+    assert "transaction_date < start_of_next_day(A)" in methodology
+    assert "amount_reporting_currency = amount * X_c" in methodology
+    assert "row-level `cashflow` and `transaction_costs` evidence" in (normalized_methodology)
+    assert "No tax calculation, FX attribution" in normalized_methodology
+    assert "| `transactions[1].withholding_tax_amount_reporting_currency` | 13.60 |" in (
+        methodology
+    )
 
 
 def test_transaction_cost_curve_methodology_is_implementation_backed() -> None:
@@ -162,8 +200,10 @@ def test_portfolio_tax_lot_window_methodology_is_implementation_backed() -> None
 def test_methodology_index_links_source_data_product_methodologies() -> None:
     index = _read("docs/methodologies/README.md")
 
+    assert "source-data-products/transaction-ledger-window.md" in index
     assert "source-data-products/portfolio-cashflow-projection.md" in index
     assert "source-data-products/portfolio-tax-lot-window.md" in index
     assert "source-data-products/transaction-cost-curve.md" in index
     assert "Effective-dated open and closed tax-lot state" in index
+    assert "Governed booked transaction-row windowing" in index
     assert "Observed booked-fee aggregation by security, transaction type, and currency" in index

--- a/tests/unit/services/query_service/services/test_transaction_service.py
+++ b/tests/unit/services/query_service/services/test_transaction_service.py
@@ -19,7 +19,6 @@ def mock_transaction_repo() -> AsyncMock:
     """Provides a mock TransactionRepository."""
     repo = AsyncMock(spec=TransactionRepository)
     repo.portfolio_exists.return_value = True
-    # FIX: Provide full, valid data for the mock objects
     repo.get_transactions.return_value = [
         Transaction(
             transaction_id="T1",
@@ -373,13 +372,8 @@ async def test_get_transactions_applies_reporting_currency_restated_fields(
     assert first_transaction.trade_fee_reporting_currency == Decimal("17.000")
     assert first_transaction.realized_gain_loss_reporting_currency == Decimal("340.00")
     assert income_transaction.gross_transaction_amount_reporting_currency == Decimal("170.00")
-    assert (
-        income_transaction.withholding_tax_amount_reporting_currency == Decimal("13.60")
-    )
-    assert (
-        income_transaction.other_interest_deductions_amount_reporting_currency
-        == Decimal("6.80")
-    )
+    assert income_transaction.withholding_tax_amount_reporting_currency == Decimal("13.60")
+    assert income_transaction.other_interest_deductions_amount_reporting_currency == Decimal("6.80")
     assert income_transaction.net_interest_amount_reporting_currency == Decimal("149.60")
     assert mock_transaction_repo.get_latest_fx_rate.await_count == 1
 

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -62,6 +62,13 @@ capital/FX/total P&L fields, linked cashflow records, and FX/event linkage ident
 execution-quality, tax-advice, liquidity-planning, cash-movement aggregation, FX-attribution, or
 transaction-cost methodology product.
 
+Its current implementation-backed methodology is deterministic: the product filters booked
+transaction rows by portfolio, optional instrument/security, transaction type, FX/event linkage,
+date window, and effective as-of date; preserves joined row-level transaction-cost and cashflow
+evidence; optionally populates reporting-currency fields from latest available FX rates; and
+classifies empty, complete, and paged windows without deriving tax advice, FX attribution,
+cash-movement aggregation, transaction-cost curves, execution quality, or OMS acknowledgement.
+
 `PortfolioCashflowProjection:v1` is the governed source for daily net cashflow points, cumulative
 cashflow over the returned window, total net cashflow, portfolio currency, include-projected posture,
 evidence timestamp, and deterministic source fingerprint. It is not a client income plan, liquidity


### PR DESCRIPTION
## Summary
- Adds implementation-backed TransactionLedgerWindow:v1 methodology truth for row filters, as-of handling, reporting-currency restatement, pagination/data-quality posture, and non-claim boundaries
- Updates the methodology index, RFC-0083 source-data catalog, repo context, and Mesh Data Products wiki source
- Extends source-data documentation guards and removes stale FIX comments from the transaction-ledger path

## Validation
- python -m ruff format --check src\services\query_service\app\repositories\transaction_repository.py tests\unit\docs\test_source_data_product_boundaries.py tests\unit\services\query_service\services\test_transaction_service.py
- python -m ruff check src\services\query_service\app\repositories\transaction_repository.py tests\unit\docs\test_source_data_product_boundaries.py tests\unit\services\query_service\services\test_transaction_service.py
- python -m pytest tests\unit\docs\test_source_data_product_boundaries.py -q
- python -m pytest tests\unit\services\query_service\services\test_transaction_service.py -q
- make source-data-product-contract-guard
- make openapi-gate
- git diff --check
- Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-core reports expected drift for Mesh-Data-Products.md until this PR is merged and wiki-published

## WTBD posture
- Advances RFC42-WTBD-006 only
- Does not close RFC42-WTBD-006