### PR TITLE
Fix contiguous snapshot detection without history

### DIFF
--- a/src/libs/portfolio-common/portfolio_common/valuation_repository_base.py
+++ b/src/libs/portfolio-common/portfolio_common/valuation_repository_base.py
@@ -311,6 +311,10 @@ class ValuationRepositoryBase:
             .correlate(dps)
             .scalar_subquery()
         )
+        snapshot_quantity_matches_history = (
+            latest_history_quantity_for_snapshot.is_(None)
+            | (dps.quantity == latest_history_quantity_for_snapshot)
+        )
 
         first_gap_subq = (
             (
@@ -322,7 +326,7 @@ class ValuationRepositoryBase:
                         & (dps.security_id == s.security_id)
                         & (dps.epoch == s.epoch)
                         & (dps.date == date_series_subq.c.expected_date)
-                        & (dps.quantity == latest_history_quantity_for_snapshot),
+                        & snapshot_quantity_matches_history,
                     )
                 )
                 .where(dps.id.is_(None))
@@ -337,7 +341,7 @@ class ValuationRepositoryBase:
                     (dps.portfolio_id == s.portfolio_id)
                     & (dps.security_id == s.security_id)
                     & (dps.epoch == s.epoch)
-                    & (dps.quantity == latest_history_quantity_for_snapshot)
+                    & snapshot_quantity_matches_history
                 )
             )
             .correlate(s)


### PR DESCRIPTION
## Summary
- allow contiguous snapshot detection to accept existing daily snapshots when no position-history baseline exists
- keep quantity reconciliation strict when history is present so stale snapshots still stop advancement

## Verification
- python -m pytest tests/integration/services/calculators/position_valuation_calculator/test_int_valuation_repo_empty_open_dates.py::test_find_contiguous_snapshot_dates_handles_empty_first_open_dates tests/integration/services/calculators/position_valuation_calculator/test_int_valuation_repo.py::test_find_contiguous_snapshot_dates_respects_first_open_dates tests/integration/services/calculators/position_valuation_calculator/test_int_valuation_repo.py::test_find_contiguous_snapshot_dates_stops_at_unreconciled_snapshot tests/integration/services/timeseries_generator_service/test_timeseries_repository_integration.py::test_find_and_claim_eligible_jobs_enforces_snapshot_completeness_gate -q