### PR TITLE
Seed observed transaction cost evidence for canonical portfolio

### DIFF
--- a/tests/unit/tools/test_front_office_portfolio_seed.py
+++ b/tests/unit/tools/test_front_office_portfolio_seed.py
@@ -445,6 +445,32 @@ def test_front_office_bundle_cash_economics_are_plausible_by_currency():
     assert cash_balance_by_currency["EUR"] == Decimal("19805.50")
 
 
+def test_front_office_product_trades_include_observed_fee_evidence_for_cost_curve():
+    bundle = _build_bundle()
+
+    product_trade_ids = {
+        "TXN-BUY-AAPL-001",
+        "TXN-BUY-MSFT-001",
+        "TXN-BUY-SAP-001",
+        "TXN-BUY-WORLD-ETF-001",
+        "TXN-BUY-BLK-ALLOC-001",
+        "TXN-BUY-PIMCO-INC-001",
+        "TXN-BUY-UST-001",
+        "TXN-BUY-SIEMENS-BOND-001",
+        "TXN-BUY-PRIVCREDIT-001",
+    }
+    product_trades = [
+        transaction
+        for transaction in bundle["transactions"]
+        if transaction["transaction_id"] in product_trade_ids
+    ]
+
+    assert len(product_trades) == len(product_trade_ids)
+    assert all(
+        Decimal(str(transaction.get("trade_fee", "0"))) > 0 for transaction in product_trades
+    )
+
+
 def test_front_office_cash_transaction_validator_rejects_non_normalized_cash_rows():
     bundle = _build_bundle()
     advisory_fee = next(
@@ -555,8 +581,8 @@ def test_portfolio_seed_cleanup_sql_removes_portfolio_owned_state_before_reseed(
         in sql
     )
     assert (
-        "delete from sustainability_preference_profiles where portfolio_id = 'PB_SG_GLOBAL_BAL_001';"
-        in sql
+        "delete from sustainability_preference_profiles "
+        "where portfolio_id = 'PB_SG_GLOBAL_BAL_001';" in sql
     )
     assert (
         "delete from portfolio_mandate_bindings where portfolio_id = 'PB_SG_GLOBAL_BAL_001';" in sql

--- a/tools/front_office_portfolio_seed.py
+++ b/tools/front_office_portfolio_seed.py
@@ -199,7 +199,8 @@ def build_portfolio_seed_cleanup_sql(*, portfolio_id: str) -> str:
             f"delete from processed_events where portfolio_id = '{portfolio_id}';",
             f"delete from cash_account_masters where portfolio_id = '{portfolio_id}';",
             f"delete from portfolio_benchmark_assignments where portfolio_id = '{portfolio_id}';",
-            f"delete from sustainability_preference_profiles where portfolio_id = '{portfolio_id}';",
+            "delete from sustainability_preference_profiles "
+            f"where portfolio_id = '{portfolio_id}';",
             f"delete from client_restriction_profiles where portfolio_id = '{portfolio_id}';",
             f"delete from portfolio_mandate_bindings where portfolio_id = '{portfolio_id}';",
             "delete from instrument_eligibility_profiles "
@@ -809,6 +810,7 @@ def build_front_office_portfolio_bundle(
             price="184.50",
             gross="77490.00",
             trade_currency="USD",
+            trade_fee="38.75",
             source_system="LOTUS_FRONT_OFFICE_SEED",
             **_paired_internal_leg_metadata(portfolio_id=portfolio_id, event_code="BUY-AAPL-001"),
         ),
@@ -840,6 +842,7 @@ def build_front_office_portfolio_bundle(
             price="401.25",
             gross="104325.00",
             trade_currency="USD",
+            trade_fee="52.16",
             source_system="LOTUS_FRONT_OFFICE_SEED",
             **_paired_internal_leg_metadata(portfolio_id=portfolio_id, event_code="BUY-MSFT-001"),
         ),
@@ -871,6 +874,7 @@ def build_front_office_portfolio_bundle(
             price="121.40",
             gross="82552.00",
             trade_currency="EUR",
+            trade_fee="49.53",
             transaction_fx_rate=fx_rate_for_transaction(tx_dt(20), from_currency="EUR"),
             source_system="LOTUS_FRONT_OFFICE_SEED",
             **_paired_internal_leg_metadata(portfolio_id=portfolio_id, event_code="BUY-SAP-001"),
@@ -904,6 +908,7 @@ def build_front_office_portfolio_bundle(
             price="98.25",
             gross="90390.00",
             trade_currency="USD",
+            trade_fee="27.12",
             source_system="LOTUS_FRONT_OFFICE_SEED",
             **_paired_internal_leg_metadata(
                 portfolio_id=portfolio_id, event_code="BUY-WORLD-ETF-001"
@@ -939,6 +944,7 @@ def build_front_office_portfolio_bundle(
             price="107.25",
             gross="158730.00",
             trade_currency="EUR",
+            trade_fee="95.24",
             transaction_fx_rate=fx_rate_for_transaction(tx_dt(49), from_currency="EUR"),
             source_system="LOTUS_FRONT_OFFICE_SEED",
             **_paired_internal_leg_metadata(
@@ -976,6 +982,7 @@ def build_front_office_portfolio_bundle(
             price="101.80",
             gross="244320.00",
             trade_currency="USD",
+            trade_fee="97.73",
             source_system="LOTUS_FRONT_OFFICE_SEED",
             **_paired_internal_leg_metadata(
                 portfolio_id=portfolio_id, event_code="BUY-PIMCO-INC-001"
@@ -1011,6 +1018,7 @@ def build_front_office_portfolio_bundle(
             price="992.80",
             gross="178704.00",
             trade_currency="USD",
+            trade_fee="71.48",
             source_system="LOTUS_FRONT_OFFICE_SEED",
             **_paired_internal_leg_metadata(portfolio_id=portfolio_id, event_code="BUY-UST-001"),
         ),
@@ -1042,6 +1050,7 @@ def build_front_office_portfolio_bundle(
             price="985.50",
             gross="73912.50",
             trade_currency="EUR",
+            trade_fee="44.35",
             transaction_fx_rate=fx_rate_for_transaction(tx_dt(118), from_currency="EUR"),
             source_system="LOTUS_FRONT_OFFICE_SEED",
             **_paired_internal_leg_metadata(
@@ -1079,6 +1088,7 @@ def build_front_office_portfolio_bundle(
             price="100.00",
             gross="125000.00",
             trade_currency="USD",
+            trade_fee="87.50",
             source_system="LOTUS_FRONT_OFFICE_SEED",
             **_paired_internal_leg_metadata(
                 portfolio_id=portfolio_id, event_code="BUY-PRIVCREDIT-001"


### PR DESCRIPTION
## Summary

- adds observed booked trade-fee evidence to the governed front-office product trade seed rows
- guards the canonical seed with a unit test so `TransactionCostCurve:v1` can return source-owned cost points for `PB_SG_GLOBAL_BAL_001`

## Evidence

- `python -m pytest tests/unit/tools/test_front_office_portfolio_seed.py -q` -> 43 passed
- `python -m ruff check tools/front_office_portfolio_seed.py tests/unit/tools/test_front_office_portfolio_seed.py` -> passed
- `python -m ruff format --check tools/front_office_portfolio_seed.py tests/unit/tools/test_front_office_portfolio_seed.py` -> passed
- live source probe after reseed: `TransactionCostCurve:v1` returned 9 curve points and `TRANSACTION_COST_CURVE_READY` for `PB_SG_GLOBAL_BAL_001`

## Notes

This is source-owner seed evidence only. It does not add predictive execution cost, venue routing, market-impact, or best-execution methodology.