### PR TITLE
Prove mandate review fields in live DPM validator

### DIFF
--- a/scripts/validate_live_dpm_source_products.py
+++ b/scripts/validate_live_dpm_source_products.py
@@ -152,6 +152,10 @@ def _probe_mandate_binding(
         and body_dict.get("mandate_type") == "discretionary"
         and body_dict.get("discretionary_authority_status") == "active"
         and body_dict.get("model_portfolio_id") == model_portfolio_id
+        and bool(body_dict.get("mandate_objective"))
+        and bool(body_dict.get("review_cadence"))
+        and bool(body_dict.get("last_review_date"))
+        and bool(body_dict.get("next_review_due_date"))
     )
     return _result(
         "dpm_mandate_binding_ready",
@@ -162,6 +166,10 @@ def _probe_mandate_binding(
             "supportability_state": _supportability_state(body_dict),
             "mandate_type": body_dict.get("mandate_type"),
             "model_portfolio_id": body_dict.get("model_portfolio_id"),
+            "mandate_objective_present": bool(body_dict.get("mandate_objective")),
+            "review_cadence": body_dict.get("review_cadence"),
+            "last_review_date": body_dict.get("last_review_date"),
+            "next_review_due_date": body_dict.get("next_review_due_date"),
         },
     )
 

--- a/tests/unit/scripts/test_validate_live_dpm_source_products.py
+++ b/tests/unit/scripts/test_validate_live_dpm_source_products.py
@@ -37,6 +37,12 @@ def _mandate_binding() -> dict:
         "mandate_type": "discretionary",
         "discretionary_authority_status": "active",
         "model_portfolio_id": validator.DEFAULT_MODEL_PORTFOLIO_ID,
+        "mandate_objective": (
+            "Preserve and grow global balanced wealth within controlled drawdown limits."
+        ),
+        "review_cadence": "quarterly",
+        "last_review_date": "2026-03-31",
+        "next_review_due_date": "2026-06-30",
     }
 
 
@@ -229,6 +235,27 @@ def test_live_dpm_source_validator_reports_stale_market_data_coverage() -> None:
     assert failure["name"] == "dpm_market_data_coverage_ready"
     assert failure["details"]["supportability_state"] == "STALE"
     assert failure["details"]["stale_instrument_ids"] == ["FO_EQ_SAP_DE"]
+
+
+def test_live_dpm_source_validator_requires_mandate_review_cycle_truth() -> None:
+    mandate_binding = _mandate_binding()
+    mandate_binding.pop("mandate_objective")
+    mandate_binding["next_review_due_date"] = None
+
+    summary = _run(
+        {
+            f"/integration/portfolios/{validator.DEFAULT_PORTFOLIO_ID}/mandate-binding": (
+                200,
+                mandate_binding,
+            )
+        }
+    )
+
+    assert summary["failed"] == 1
+    failure = summary["failures"][0]
+    assert failure["name"] == "dpm_mandate_binding_ready"
+    assert failure["details"]["mandate_objective_present"] is False
+    assert failure["details"]["next_review_due_date"] is None
 
 
 def test_live_dpm_source_validator_keeps_probe_name_on_bad_response_shape() -> None:


### PR DESCRIPTION
## Summary
- Tighten the live DPM source validator so `DiscretionaryMandateBinding:v1` only passes when source-owned mandate objective and review-cycle fields are present.
- Add a unit regression that fails when mandate objective or next review due date is missing.

## Evidence
- `python -m pytest tests/unit/scripts/test_validate_live_dpm_source_products.py -q` => 6 passed
- `python -m ruff check scripts/validate_live_dpm_source_products.py tests/unit/scripts/test_validate_live_dpm_source_products.py`
- `python -m ruff format --check scripts/validate_live_dpm_source_products.py tests/unit/scripts/test_validate_live_dpm_source_products.py`
- `git diff --check`
- `make live-dpm-source-validate` against running canonical stack: 9/9 passed, including mandate objective present and review cadence/date fields

## Wiki
No wiki-source change. This hardens an existing validation command already documented in `wiki/Mesh-Data-Products.md`.