### PR TITLE
Keep canonical cashflow horizon populated

### DIFF
--- a/docs/operations/Front-Office-Portfolio-Seed-Contract.md
+++ b/docs/operations/Front-Office-Portfolio-Seed-Contract.md
@@ -119,7 +119,8 @@ The seed must make the following product surfaces materially usable.
 ### Liquidity and cashflow
 
 - multiple cash accounts
-- projected cash movements over a forward window
+- projected cash movements over both the canonical contract window and the current Workbench
+  forward-liquidity horizon
 - future-dated settlement activity or projected cash events
 - benchmark and FX coverage through the forward validation horizon so next-day
   analytics requests do not fail on missing reference data
@@ -298,7 +299,8 @@ Recommended transaction storyline:
 - one coupon or interest receipt
 - one advisory or custody fee
 - one withholding-tax event
-- one future-dated settlement or projected cash event
+- future-dated settlement or projected cash events that keep both canonical and current
+  forward-liquidity windows non-empty
 
 Each transaction should carry meaningful values for all attributes that affect
 downstream surfaces, including where supported:

--- a/docs/operations/Front-Office-Portfolio-Seed-Runbook.md
+++ b/docs/operations/Front-Office-Portfolio-Seed-Runbook.md
@@ -41,7 +41,7 @@ not part of canonical Workbench runtime bring-up.
 - discretionary mandate binding, model target, instrument eligibility, tax-lot, market-data,
   client-restriction, and sustainability-preference source records for DPM assembly proof
 - income, fee, tax, sell, and withdrawal activity
-- one future-dated withdrawal inside the forward cashflow horizon
+- two future/planned withdrawals covering both the canonical and current forward cashflow horizons
 - canonical paired product-and-cash transactions aligned with the core demo ingest pattern
 - normalized cash-book transaction rows with `price = 1` and
   `quantity = gross_transaction_amount`
@@ -99,11 +99,11 @@ the RFC-0075 Slice 4 derived-state readiness fix with these outcomes:
 - `lotus-core query_service`
   - positions: `11`
   - valued positions: `11`
-  - transactions: `30`, including future transaction
-    `TXN-WITHDRAWAL-FUTURE-001`
+  - transactions: `31`, including future/planned transactions
+    `TXN-WITHDRAWAL-FUTURE-001` and `TXN-WITHDRAWAL-CURRENT-HORIZON-001`
   - cash accounts: `2`
-  - cashflow projection: `31` points with one non-zero point on `2026-04-17`
-    for `-18000`
+  - cashflow projection: `31` points with non-zero planned withdrawal points on
+    `2026-04-17` for `-18000` and `2026-04-30` for `-12000`
   - allocation views: `asset_class`, `sector`, `region`, `currency`
   - market price coverage through `2026-04-10`
   - EUR/USD FX, benchmark return, and USD risk-free coverage through `2026-05-10`

--- a/tests/unit/tools/test_front_office_portfolio_seed.py
+++ b/tests/unit/tools/test_front_office_portfolio_seed.py
@@ -101,6 +101,10 @@ def test_front_office_bundle_includes_income_and_paired_cash_transactions():
     assert future_withdrawal["transaction_type"] == "WITHDRAWAL"
     assert future_withdrawal["transaction_date"].startswith("2026-04-17")
     assert future_withdrawal["settlement_date"].startswith("2026-04-20")
+    current_horizon_withdrawal = by_txn["TXN-WITHDRAWAL-CURRENT-HORIZON-001"]
+    assert current_horizon_withdrawal["transaction_type"] == "WITHDRAWAL"
+    assert current_horizon_withdrawal["transaction_date"].startswith("2026-04-30")
+    assert current_horizon_withdrawal["settlement_date"].startswith("2026-05-16")
 
     assert by_txn["TXN-CASH-BUY-AAPL-001"]["transaction_type"] == "SELL"
     assert by_txn["TXN-CASH-SELL-AAPL-001"]["transaction_type"] == "BUY"
@@ -133,11 +137,18 @@ def test_front_office_bundle_honors_explicit_end_date_for_market_prices():
         for transaction in bundle["transactions"]
         if transaction["transaction_id"] == "TXN-WITHDRAWAL-FUTURE-001"
     )
+    current_horizon_withdrawal = next(
+        transaction
+        for transaction in bundle["transactions"]
+        if transaction["transaction_id"] == "TXN-WITHDRAWAL-CURRENT-HORIZON-001"
+    )
 
     assert max(aapl_prices) == "2026-04-17"
     assert max(cash_prices) == "2026-04-17"
     assert future_withdrawal["transaction_date"].startswith("2026-04-24")
     assert future_withdrawal["settlement_date"].startswith("2026-04-27")
+    assert current_horizon_withdrawal["transaction_date"].startswith("2026-05-07")
+    assert current_horizon_withdrawal["settlement_date"].startswith("2026-05-23")
 
 
 def test_front_office_bundle_pairs_internal_transactions_under_shared_event_linkage():
@@ -273,10 +284,18 @@ def test_front_office_bundle_includes_forward_cashflow_event_inside_projection_w
 
     assert future_txns
     assert {transaction["transaction_id"] for transaction in future_txns} == {
-        "TXN-WITHDRAWAL-FUTURE-001"
+        "TXN-WITHDRAWAL-FUTURE-001",
+        "TXN-WITHDRAWAL-CURRENT-HORIZON-001",
     }
-    assert future_txns[0]["transaction_date"].startswith("2026-04-17")
-    assert future_txns[0]["settlement_date"].startswith("2026-04-20")
+    future_by_id = {transaction["transaction_id"]: transaction for transaction in future_txns}
+    assert future_by_id["TXN-WITHDRAWAL-FUTURE-001"]["transaction_date"].startswith("2026-04-17")
+    assert future_by_id["TXN-WITHDRAWAL-FUTURE-001"]["settlement_date"].startswith("2026-04-20")
+    assert future_by_id["TXN-WITHDRAWAL-CURRENT-HORIZON-001"][
+        "transaction_date"
+    ].startswith("2026-04-30")
+    assert future_by_id["TXN-WITHDRAWAL-CURRENT-HORIZON-001"][
+        "settlement_date"
+    ].startswith("2026-05-16")
 
 
 def test_front_office_bundle_carries_full_price_coverage_through_as_of_date():
@@ -475,7 +494,7 @@ def test_front_office_bundle_cash_economics_are_plausible_by_currency():
 
     assert cash_balance_by_currency["USD"] > Decimal("0")
     assert cash_balance_by_currency["EUR"] > Decimal("0")
-    assert cash_balance_by_currency["USD"] == Decimal("101347.00")
+    assert cash_balance_by_currency["USD"] == Decimal("89347.00")
     assert cash_balance_by_currency["EUR"] == Decimal("19805.50")
 
 

--- a/tools/front_office_portfolio_seed.py
+++ b/tools/front_office_portfolio_seed.py
@@ -492,6 +492,8 @@ def build_front_office_portfolio_bundle(
     as_of_date = end_date.isoformat()
     forward_withdrawal_date = end_date + timedelta(days=7)
     forward_withdrawal_settlement_date = end_date + timedelta(days=10)
+    current_horizon_planned_withdrawal_date = end_date + timedelta(days=20)
+    current_horizon_planned_withdrawal_settlement_date = end_date + timedelta(days=36)
 
     def tx_dt(day_offset: int, hour: int = 10) -> datetime:
         current = start_date + timedelta(days=day_offset)
@@ -1271,6 +1273,22 @@ def build_front_office_portfolio_bundle(
             quantity="18000",
             price="1",
             gross="18000",
+            trade_currency="USD",
+            settlement_cash_account_id="CASH-ACC-USD-001",
+            movement_direction="OUTFLOW",
+            source_system="LOTUS_FRONT_OFFICE_SEED",
+        ),
+        _tx(
+            "TXN-WITHDRAWAL-CURRENT-HORIZON-001",
+            portfolio_id=portfolio_id,
+            instrument_id="USD-CASH",
+            security_id="CASH_USD_BOOK_OPERATING",
+            when=date_dt(current_horizon_planned_withdrawal_date),
+            settlement_date=date_dt(current_horizon_planned_withdrawal_settlement_date, 16),
+            tx_type="WITHDRAWAL",
+            quantity="12000",
+            price="1",
+            gross="12000",
             trade_currency="USD",
             settlement_cash_account_id="CASH-ACC-USD-001",
             movement_direction="OUTFLOW",

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -83,6 +83,11 @@ clear known volatile replay fences for canonical seed topics when local Kafka of
 reset or reused, but it must not perform broad `processed_events` deletion. If broader local
 runtime state is polluted, reset the Docker-backed core runtime before reseeding.
 
+The canonical seed includes planned withdrawal evidence for both the fixed contract as-of window
+and the current Workbench forward-liquidity horizon. After reseeding, `PortfolioCashflowProjection`
+should show at least one non-zero point for the canonical window and one non-zero current-horizon
+planned settlement point.
+
 ## Startup checks
 
 When app-local runtime is unhealthy, check this order:


### PR DESCRIPTION
## Summary
- add a deterministic current-horizon planned withdrawal to the canonical front-office seed so the current Workbench liquidity horizon is not a zero-cashflow demo path
- update seed unit tests for transaction dates, projected future events, and USD cash economics
- update seed contract/runbook and repo-local wiki operations note for the dual cashflow horizons

## Evidence
- `python -m pytest tests/unit/tools/test_front_office_portfolio_seed.py tests/unit/services/query_service/services/test_liquidity_ladder_service.py -q` -> 51 passed
- `git diff --check` -> passed; CRLF warnings only
- live reseed with `--force-ingest` -> transaction count 31, projected_cashflow_points 31, has_non_zero_projection True; command timed out only because Core aggregation backlog stayed open
- Core cashflow API `as_of_date=2026-05-08&horizon_days=30` -> non-zero projected outflow `-12000.0000000000` on `2026-05-16`, total `-12000.0000000000`
- Gateway liquidity API -> current cashflow outlook includes `-12000.0` on `2026-05-16`, no warnings or partial failures
- `npm run live:validate` in `lotus-workbench` -> passed for `PB_SG_GLOBAL_BAL_001`; screenshots in `C:\Users\Sandeep\projects\lotus-workbench\output\playwright\live-canonical`
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-core` -> expected drift on `Operations-Runbook.md` because repo-local wiki changed and must be published after merge

## Operational note
The live Core readiness endpoint still reports `AGGREGATION_BACKLOG_OPEN` after reseed, with no failed aggregation jobs observed. This PR does not weaken readiness semantics; it fixes missing cashflow evidence and leaves backlog health visible as an operational signal.