### PR TITLE
Define planned external treasury source products

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ Boundary rules that matter:
    rows by classification, timing, currency, and flow scope without claiming cashflow forecasting,
    funding recommendations, treasury instructions, liquidity advice, execution quality, tax
    methodology, or OMS acknowledgement.
+10. RFC39-WTBD-008 external treasury source products are now governed as planned contracts for
+    future bank-owned ingestion: `ExternalCurrencyExposure:v1`, `ExternalHedgePolicy:v1`,
+    `ExternalFXForwardCurve:v1`, `ExternalEligibleHedgeInstrument:v1`, and
+    `ExternalHedgeExecutionReadiness:v1`. They are not active runtime APIs and do not create
+    hedge advice, forward pricing, treasury instructions, counterparty selection, best execution,
+    OMS acknowledgement, fills, or settlement claims.
 
 ## Architecture At A Glance
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -318,6 +318,13 @@ Most relevant current governance:
     movement direction, empty-window posture, and the explicit boundary from cashflow forecasting,
     funding recommendations, treasury instructions, liquidity advice, tax methodology, execution
     quality, and OMS acknowledgement.
+37. RFC39-WTBD-008 now has planned, not active, external treasury source-product contracts in the
+    in-code planned catalog and repo-native domain-product declaration:
+    `ExternalCurrencyExposure:v1`, `ExternalHedgePolicy:v1`, `ExternalFXForwardCurve:v1`,
+    `ExternalEligibleHedgeInstrument:v1`, and `ExternalHedgeExecutionReadiness:v1`. They define
+    the future Lotus-side ingestion and source boundary for bank-owned treasury evidence without
+    activating runtime routes or claiming hedge advice, forward pricing, treasury instructions,
+    counterparty choice, best execution, OMS acknowledgement, fills, or settlement.
 
 ## Context Maintenance Rule
 

--- a/contracts/domain-data-products/lotus-core-products.v1.json
+++ b/contracts/domain-data-products/lotus-core-products.v1.json
@@ -2253,6 +2253,321 @@
         "tenant_id"
       ],
       "temporal_semantics_ref": "as_of_date"
+    },
+    {
+      "product_name": "ExternalCurrencyExposure",
+      "product_version": "v1",
+      "owner_repository": "lotus-core",
+      "product_family": "dpm_source_data",
+      "authoritative_domain": "portfolio_state",
+      "lifecycle_status": "proposed",
+      "request_scope": {
+        "scope_level": "portfolio",
+        "supports_bulk": false
+      },
+      "temporal_scope": {
+        "primary_time_field": "as_of_date",
+        "freshness_basis": "as_of_date",
+        "supports_restatement": true
+      },
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "tenant_id",
+        "generated_at",
+        "as_of_date",
+        "restatement_version",
+        "reconciliation_status",
+        "data_quality_status",
+        "latest_evidence_timestamp",
+        "source_batch_fingerprint",
+        "snapshot_id",
+        "policy_version",
+        "correlation_id"
+      ],
+      "serving_plane": "query_control_plane_service",
+      "current_routes": [
+        "/integration/portfolios/{portfolio_id}/external-currency-exposure"
+      ],
+      "freshness_policy": {
+        "freshness_class": "intraday",
+        "max_allowed_age_description": "Planned external treasury currency exposure evidence supplied by bank-owned systems."
+      },
+      "completeness_policy": {
+        "default_status": "partial",
+        "partial_allowed": true
+      },
+      "lineage_policy": {
+        "lineage_required": true,
+        "evidence_bundle_required": true,
+        "evidence_access_class_ref": "customer_consumable",
+        "lineage_bundle_class_ref": "customer_lineage_summary"
+      },
+      "security_profile_ref": "system_access:client_sensitive:retain_for_client_record:audit_system_access",
+      "approved_consumers": [
+        "lotus-manage"
+      ],
+      "deprecation_policy": {
+        "state": "not_deprecated",
+        "successor_product": null
+      },
+      "identifier_refs": [
+        "portfolio_id",
+        "tenant_id"
+      ],
+      "temporal_semantics_ref": "as_of_date"
+    },
+    {
+      "product_name": "ExternalHedgePolicy",
+      "product_version": "v1",
+      "owner_repository": "lotus-core",
+      "product_family": "dpm_source_data",
+      "authoritative_domain": "portfolio_management",
+      "lifecycle_status": "proposed",
+      "request_scope": {
+        "scope_level": "portfolio",
+        "supports_bulk": false
+      },
+      "temporal_scope": {
+        "primary_time_field": "as_of_date",
+        "freshness_basis": "as_of_date",
+        "supports_restatement": true
+      },
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "tenant_id",
+        "generated_at",
+        "as_of_date",
+        "restatement_version",
+        "reconciliation_status",
+        "data_quality_status",
+        "latest_evidence_timestamp",
+        "source_batch_fingerprint",
+        "snapshot_id",
+        "policy_version",
+        "correlation_id"
+      ],
+      "serving_plane": "query_control_plane_service",
+      "current_routes": [
+        "/integration/portfolios/{portfolio_id}/external-hedge-policy"
+      ],
+      "freshness_policy": {
+        "freshness_class": "intraday",
+        "max_allowed_age_description": "Planned external treasury hedge policy evidence supplied by bank-owned systems."
+      },
+      "completeness_policy": {
+        "default_status": "partial",
+        "partial_allowed": true
+      },
+      "lineage_policy": {
+        "lineage_required": true,
+        "evidence_bundle_required": true,
+        "evidence_access_class_ref": "customer_consumable",
+        "lineage_bundle_class_ref": "customer_lineage_summary"
+      },
+      "security_profile_ref": "system_access:client_sensitive:retain_for_client_record:audit_system_access",
+      "approved_consumers": [
+        "lotus-manage"
+      ],
+      "deprecation_policy": {
+        "state": "not_deprecated",
+        "successor_product": null
+      },
+      "identifier_refs": [
+        "portfolio_id",
+        "tenant_id"
+      ],
+      "temporal_semantics_ref": "as_of_date"
+    },
+    {
+      "product_name": "ExternalFXForwardCurve",
+      "product_version": "v1",
+      "owner_repository": "lotus-core",
+      "product_family": "dpm_source_data",
+      "authoritative_domain": "market_reference_data",
+      "lifecycle_status": "proposed",
+      "request_scope": {
+        "scope_level": "instrument",
+        "supports_bulk": true
+      },
+      "temporal_scope": {
+        "primary_time_field": "as_of_date",
+        "freshness_basis": "observation_time",
+        "supports_restatement": true
+      },
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "tenant_id",
+        "generated_at",
+        "as_of_date",
+        "restatement_version",
+        "reconciliation_status",
+        "data_quality_status",
+        "latest_evidence_timestamp",
+        "source_batch_fingerprint",
+        "snapshot_id",
+        "policy_version",
+        "correlation_id"
+      ],
+      "serving_plane": "query_control_plane_service",
+      "current_routes": [
+        "/integration/market-data/external-fx-forward-curve"
+      ],
+      "freshness_policy": {
+        "freshness_class": "intraday",
+        "max_allowed_age_description": "Planned external treasury FX forward curve evidence supplied by bank-owned systems."
+      },
+      "completeness_policy": {
+        "default_status": "partial",
+        "partial_allowed": true
+      },
+      "lineage_policy": {
+        "lineage_required": true,
+        "evidence_bundle_required": true,
+        "evidence_access_class_ref": "customer_consumable",
+        "lineage_bundle_class_ref": "customer_lineage_summary"
+      },
+      "security_profile_ref": "system_access:reference_internal:retain_for_source_audit:audit_system_access",
+      "approved_consumers": [
+        "lotus-manage"
+      ],
+      "deprecation_policy": {
+        "state": "not_deprecated",
+        "successor_product": null
+      },
+      "identifier_refs": [
+        "currency_pair",
+        "tenant_id"
+      ],
+      "temporal_semantics_ref": "as_of_date"
+    },
+    {
+      "product_name": "ExternalEligibleHedgeInstrument",
+      "product_version": "v1",
+      "owner_repository": "lotus-core",
+      "product_family": "dpm_source_data",
+      "authoritative_domain": "instrument_reference",
+      "lifecycle_status": "proposed",
+      "request_scope": {
+        "scope_level": "instrument",
+        "supports_bulk": true
+      },
+      "temporal_scope": {
+        "primary_time_field": "as_of_date",
+        "freshness_basis": "as_of_date",
+        "supports_restatement": true
+      },
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "tenant_id",
+        "generated_at",
+        "as_of_date",
+        "restatement_version",
+        "reconciliation_status",
+        "data_quality_status",
+        "latest_evidence_timestamp",
+        "source_batch_fingerprint",
+        "snapshot_id",
+        "policy_version",
+        "correlation_id"
+      ],
+      "serving_plane": "query_control_plane_service",
+      "current_routes": [
+        "/integration/instruments/external-eligible-hedge-instruments"
+      ],
+      "freshness_policy": {
+        "freshness_class": "daily",
+        "max_allowed_age_description": "Planned external treasury eligible hedge instrument evidence supplied by bank-owned systems."
+      },
+      "completeness_policy": {
+        "default_status": "partial",
+        "partial_allowed": true
+      },
+      "lineage_policy": {
+        "lineage_required": true,
+        "evidence_bundle_required": true,
+        "evidence_access_class_ref": "customer_consumable",
+        "lineage_bundle_class_ref": "customer_lineage_summary"
+      },
+      "security_profile_ref": "system_access:reference_internal:retain_for_source_audit:audit_system_access",
+      "approved_consumers": [
+        "lotus-manage"
+      ],
+      "deprecation_policy": {
+        "state": "not_deprecated",
+        "successor_product": null
+      },
+      "identifier_refs": [
+        "instrument_id",
+        "tenant_id"
+      ],
+      "temporal_semantics_ref": "as_of_date"
+    },
+    {
+      "product_name": "ExternalHedgeExecutionReadiness",
+      "product_version": "v1",
+      "owner_repository": "lotus-core",
+      "product_family": "dpm_source_data",
+      "authoritative_domain": "portfolio_management",
+      "lifecycle_status": "proposed",
+      "request_scope": {
+        "scope_level": "portfolio",
+        "supports_bulk": false
+      },
+      "temporal_scope": {
+        "primary_time_field": "as_of_date",
+        "freshness_basis": "as_of_date",
+        "supports_restatement": true
+      },
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "tenant_id",
+        "generated_at",
+        "as_of_date",
+        "restatement_version",
+        "reconciliation_status",
+        "data_quality_status",
+        "latest_evidence_timestamp",
+        "source_batch_fingerprint",
+        "snapshot_id",
+        "policy_version",
+        "correlation_id"
+      ],
+      "serving_plane": "query_control_plane_service",
+      "current_routes": [
+        "/integration/portfolios/{portfolio_id}/external-hedge-execution-readiness"
+      ],
+      "freshness_policy": {
+        "freshness_class": "intraday",
+        "max_allowed_age_description": "Planned external treasury hedge execution-readiness evidence supplied by bank-owned systems."
+      },
+      "completeness_policy": {
+        "default_status": "partial",
+        "partial_allowed": true
+      },
+      "lineage_policy": {
+        "lineage_required": true,
+        "evidence_bundle_required": true,
+        "evidence_access_class_ref": "customer_consumable",
+        "lineage_bundle_class_ref": "customer_lineage_summary"
+      },
+      "security_profile_ref": "system_access:client_sensitive:retain_for_client_record:audit_system_access",
+      "approved_consumers": [
+        "lotus-manage"
+      ],
+      "deprecation_policy": {
+        "state": "not_deprecated",
+        "successor_product": null
+      },
+      "identifier_refs": [
+        "portfolio_id",
+        "tenant_id"
+      ],
+      "temporal_semantics_ref": "as_of_date"
     }
   ]
 }

--- a/docs/architecture/RFC-0083-source-data-product-catalog.md
+++ b/docs/architecture/RFC-0083-source-data-product-catalog.md
@@ -66,6 +66,21 @@ evidence reference rather than omitting the concept.
 | `DataQualityCoverageReport` | Control-plane and policy | `query_control_plane_service` | performance, risk, gateway, manage | `/integration/benchmarks/{benchmark_id}/coverage`, `/integration/reference/risk-free-series/coverage` |
 | `IngestionEvidenceBundle` | Control-plane and policy | `query_control_plane_service` | gateway, manage, report | `/lineage/portfolios/{portfolio_id}/keys`, `/support/portfolios/{portfolio_id}/reprocessing-keys`, `/support/portfolios/{portfolio_id}/reprocessing-jobs` |
 
+## Planned External Treasury Source Products
+
+RFC39-WTBD-008 now has a governed planned source-product boundary for bank-owned treasury data,
+without activating runtime routes or support claims. These products remain `proposed` in the
+repo-native domain-product declaration until ingestion, persistence, APIs, supportability tests,
+and live evidence are implemented:
+
+| Planned product | Intended source evidence | Explicit non-claim |
+| --- | --- | --- |
+| `ExternalCurrencyExposure:v1` | Bank-supplied currency exposure evidence by portfolio, mandate, currency, and as-of date. | No local FX attribution, hedge advice, treasury instruction, or execution claim. |
+| `ExternalHedgePolicy:v1` | Bank-supplied hedge policy constraints, allowed hedge posture, and policy lineage. | No hedge-policy approval, counterparty choice, client suitability approval, or order generation. |
+| `ExternalFXForwardCurve:v1` | Bank-supplied FX forward curve observations with source refs and freshness posture. | No local forward pricing, valuation methodology, best execution, or venue-routing claim. |
+| `ExternalEligibleHedgeInstrument:v1` | Bank-supplied eligible hedge instrument reference evidence. | No suitability approval, product recommendation, counterparty selection, or execution readiness. |
+| `ExternalHedgeExecutionReadiness:v1` | Bank-supplied hedge execution-readiness posture for a portfolio and as-of date. | No OMS acknowledgement, fills, settlement, best execution, or autonomous treasury action. |
+
 ## Paging And Export Rules
 
 1. Small bounded products may remain inline responses.

--- a/src/libs/portfolio-common/portfolio_common/source_data_products.py
+++ b/src/libs/portfolio-common/portfolio_common/source_data_products.py
@@ -548,7 +548,88 @@ SOURCE_DATA_PRODUCT_CATALOG: tuple[SourceDataProductDefinition, ...] = (
     ),
 )
 
-DPM_PLANNED_SOURCE_DATA_PRODUCT_CATALOG: tuple[SourceDataProductDefinition, ...] = ()
+DPM_PLANNED_SOURCE_DATA_PRODUCT_CATALOG: tuple[SourceDataProductDefinition, ...] = (
+    SourceDataProductDefinition(
+        product_name="ExternalCurrencyExposure",
+        product_version="v1",
+        route_family=ANALYTICS_INPUT,
+        serving_plane=QUERY_CONTROL_PLANE_SERVICE,
+        owner="lotus-core",
+        consumers=("lotus-manage",),
+        current_routes=("/integration/portfolios/{portfolio_id}/external-currency-exposure",),
+        paging_mode=INLINE_PAGED,
+        export_mode=NOT_APPLICABLE,
+        notes=(
+            "Planned external treasury source product for bank-supplied currency exposure "
+            "evidence. It will not calculate FX attribution, hedge advice, or execution "
+            "readiness locally."
+        ),
+    ),
+    SourceDataProductDefinition(
+        product_name="ExternalHedgePolicy",
+        product_version="v1",
+        route_family=ANALYTICS_INPUT,
+        serving_plane=QUERY_CONTROL_PLANE_SERVICE,
+        owner="lotus-core",
+        consumers=("lotus-manage",),
+        current_routes=("/integration/portfolios/{portfolio_id}/external-hedge-policy",),
+        paging_mode=INLINE_PAGED,
+        export_mode=NOT_APPLICABLE,
+        notes=(
+            "Planned external treasury source product for bank-supplied hedge policy evidence. "
+            "It will not approve hedge policy, choose counterparties, or issue trade orders."
+        ),
+    ),
+    SourceDataProductDefinition(
+        product_name="ExternalFXForwardCurve",
+        product_version="v1",
+        route_family=ANALYTICS_INPUT,
+        serving_plane=QUERY_CONTROL_PLANE_SERVICE,
+        owner="lotus-core",
+        consumers=("lotus-manage",),
+        current_routes=("/integration/market-data/external-fx-forward-curve",),
+        paging_mode=INLINE_PAGED,
+        export_mode=NOT_APPLICABLE,
+        notes=(
+            "Planned external treasury source product for bank-supplied FX forward curve "
+            "evidence. It will preserve source quotes and supportability without pricing "
+            "forwards locally."
+        ),
+    ),
+    SourceDataProductDefinition(
+        product_name="ExternalEligibleHedgeInstrument",
+        product_version="v1",
+        route_family=ANALYTICS_INPUT,
+        serving_plane=QUERY_CONTROL_PLANE_SERVICE,
+        owner="lotus-core",
+        consumers=("lotus-manage",),
+        current_routes=("/integration/instruments/external-eligible-hedge-instruments",),
+        paging_mode=INLINE_PAGED,
+        export_mode=NOT_APPLICABLE,
+        notes=(
+            "Planned external treasury source product for bank-supplied eligible hedge "
+            "instrument evidence. It will not perform suitability approval or venue routing."
+        ),
+    ),
+    SourceDataProductDefinition(
+        product_name="ExternalHedgeExecutionReadiness",
+        product_version="v1",
+        route_family=ANALYTICS_INPUT,
+        serving_plane=QUERY_CONTROL_PLANE_SERVICE,
+        owner="lotus-core",
+        consumers=("lotus-manage",),
+        current_routes=(
+            "/integration/portfolios/{portfolio_id}/external-hedge-execution-readiness",
+        ),
+        paging_mode=NOT_APPLICABLE,
+        export_mode=NOT_APPLICABLE,
+        notes=(
+            "Planned external treasury source product for bank-supplied hedge execution "
+            "readiness evidence. It will not acknowledge OMS execution, fills, settlement, "
+            "or best execution."
+        ),
+    ),
+)
 
 
 def get_source_data_product(product_name: str) -> SourceDataProductDefinition:

--- a/src/libs/portfolio-common/portfolio_common/source_data_security.py
+++ b/src/libs/portfolio-common/portfolio_common/source_data_security.py
@@ -413,7 +413,56 @@ SOURCE_DATA_SECURITY_PROFILES: tuple[SourceDataSecurityProfile, ...] = (
     ),
 )
 
-DPM_PLANNED_SOURCE_DATA_SECURITY_PROFILES: tuple[SourceDataSecurityProfile, ...] = ()
+DPM_PLANNED_SOURCE_DATA_SECURITY_PROFILES: tuple[SourceDataSecurityProfile, ...] = (
+    SourceDataSecurityProfile(
+        product_name="ExternalCurrencyExposure",
+        tenant_required=True,
+        entitlement_required=True,
+        access_classification=SYSTEM_ACCESS,
+        sensitivity_classification=CLIENT_SENSITIVE,
+        retention_requirement=RETAIN_FOR_CLIENT_RECORD,
+        audit_requirement=AUDIT_SYSTEM_ACCESS,
+        pii_fields=("portfolio_id", "mandate_id", "client_id"),
+    ),
+    SourceDataSecurityProfile(
+        product_name="ExternalHedgePolicy",
+        tenant_required=True,
+        entitlement_required=True,
+        access_classification=SYSTEM_ACCESS,
+        sensitivity_classification=CLIENT_SENSITIVE,
+        retention_requirement=RETAIN_FOR_CLIENT_RECORD,
+        audit_requirement=AUDIT_SYSTEM_ACCESS,
+        pii_fields=("portfolio_id", "mandate_id", "client_id"),
+    ),
+    SourceDataSecurityProfile(
+        product_name="ExternalFXForwardCurve",
+        tenant_required=True,
+        entitlement_required=True,
+        access_classification=SYSTEM_ACCESS,
+        sensitivity_classification=REFERENCE_INTERNAL,
+        retention_requirement=RETAIN_FOR_SOURCE_AUDIT,
+        audit_requirement=AUDIT_SYSTEM_ACCESS,
+    ),
+    SourceDataSecurityProfile(
+        product_name="ExternalEligibleHedgeInstrument",
+        tenant_required=True,
+        entitlement_required=True,
+        access_classification=SYSTEM_ACCESS,
+        sensitivity_classification=REFERENCE_INTERNAL,
+        retention_requirement=RETAIN_FOR_SOURCE_AUDIT,
+        audit_requirement=AUDIT_SYSTEM_ACCESS,
+    ),
+    SourceDataSecurityProfile(
+        product_name="ExternalHedgeExecutionReadiness",
+        tenant_required=True,
+        entitlement_required=True,
+        access_classification=SYSTEM_ACCESS,
+        sensitivity_classification=CLIENT_SENSITIVE,
+        retention_requirement=RETAIN_FOR_CLIENT_RECORD,
+        audit_requirement=AUDIT_SYSTEM_ACCESS,
+        pii_fields=("portfolio_id", "mandate_id", "client_id"),
+    ),
+)
 
 
 def get_source_data_security_profile(product_name: str) -> SourceDataSecurityProfile:

--- a/tests/unit/docs/test_source_data_product_boundaries.py
+++ b/tests/unit/docs/test_source_data_product_boundaries.py
@@ -115,6 +115,27 @@ def test_mesh_wiki_explains_core_source_authority_for_non_engineering_audiences(
     assert "flowchart LR" in wiki
 
 
+def test_external_treasury_source_products_are_planned_not_active_claims() -> None:
+    catalog = _read("docs/architecture/RFC-0083-source-data-product-catalog.md")
+    wiki = _read("wiki/Mesh-Data-Products.md")
+    normalized_wiki = _single_line(wiki)
+
+    for product_name in (
+        "ExternalCurrencyExposure:v1",
+        "ExternalHedgePolicy:v1",
+        "ExternalFXForwardCurve:v1",
+        "ExternalEligibleHedgeInstrument:v1",
+        "ExternalHedgeExecutionReadiness:v1",
+    ):
+        assert f"`{product_name}`" in catalog
+        assert f"`{product_name}`" in wiki
+
+    assert "Planned External Treasury Source Products" in catalog
+    assert "no runtime route is active" in normalized_wiki
+    assert "treasury policy approval, forward pricing, hedge advice" in normalized_wiki
+    assert "OMS acknowledgement, fills, settlement" in normalized_wiki
+
+
 def test_holdings_as_of_methodology_is_implementation_backed() -> None:
     methodology = _read("docs/methodologies/source-data-products/holdings-as-of.md")
     normalized_methodology = _single_line(methodology)

--- a/tests/unit/libs/portfolio-common/test_source_data_products.py
+++ b/tests/unit/libs/portfolio-common/test_source_data_products.py
@@ -71,7 +71,13 @@ def test_dpm_planned_source_products_are_governed_but_not_active_routes() -> Non
         product.product_name: product for product in DPM_PLANNED_SOURCE_DATA_PRODUCT_CATALOG
     }
 
-    assert planned_products.keys() == set()
+    assert planned_products.keys() == {
+        "ExternalCurrencyExposure",
+        "ExternalHedgePolicy",
+        "ExternalFXForwardCurve",
+        "ExternalEligibleHedgeInstrument",
+        "ExternalHedgeExecutionReadiness",
+    }
     assert not set(planned_products) & active_product_names
     assert all(product.owner == "lotus-core" for product in planned_products.values())
     assert all(product.consumers == ("lotus-manage",) for product in planned_products.values())
@@ -95,7 +101,13 @@ def test_dpm_planned_source_products_are_reserved_for_lotus_manage() -> None:
         product.product_name for product in planned_products_for_consumer("lotus-manage")
     }
 
-    assert product_names == set()
+    assert product_names == {
+        "ExternalCurrencyExposure",
+        "ExternalHedgePolicy",
+        "ExternalFXForwardCurve",
+        "ExternalEligibleHedgeInstrument",
+        "ExternalHedgeExecutionReadiness",
+    }
     assert planned_products_for_consumer("lotus-performance") == ()
 
 

--- a/tests/unit/libs/portfolio-common/test_source_data_security.py
+++ b/tests/unit/libs/portfolio-common/test_source_data_security.py
@@ -29,7 +29,13 @@ def test_dpm_planned_source_data_security_profiles_cover_planned_catalog() -> No
 
 
 def test_dpm_planned_source_data_security_profiles_are_system_scoped() -> None:
-    expected_profiles = set()
+    expected_profiles = {
+        "ExternalCurrencyExposure",
+        "ExternalHedgePolicy",
+        "ExternalFXForwardCurve",
+        "ExternalEligibleHedgeInstrument",
+        "ExternalHedgeExecutionReadiness",
+    }
     profiles = {
         profile.product_name: profile for profile in DPM_PLANNED_SOURCE_DATA_SECURITY_PROFILES
     }
@@ -39,6 +45,12 @@ def test_dpm_planned_source_data_security_profiles_are_system_scoped() -> None:
         assert profile.access_classification == SYSTEM_ACCESS
         assert profile.audit_requirement == AUDIT_SYSTEM_ACCESS
         assert profile.operator_only is False
+
+    assert profiles["ExternalCurrencyExposure"].sensitivity_classification == CLIENT_SENSITIVE
+    assert profiles["ExternalHedgePolicy"].sensitivity_classification == CLIENT_SENSITIVE
+    assert (
+        profiles["ExternalHedgeExecutionReadiness"].sensitivity_classification == CLIENT_SENSITIVE
+    )
 
 
 def test_every_source_data_product_has_tenant_and_entitlement_profile() -> None:

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -277,7 +277,13 @@ decisioning, suitability adjudication, or execution pricing into core. New propo
 should be added only through a follow-up RFC or explicit RFC extension with implementation
 evidence.
 
-There are currently no remaining planned DPM source products in the in-code planned catalog.
+RFC39-WTBD-008 now adds planned, not active, external treasury source-product contracts for
+`ExternalCurrencyExposure:v1`, `ExternalHedgePolicy:v1`, `ExternalFXForwardCurve:v1`,
+`ExternalEligibleHedgeInstrument:v1`, and `ExternalHedgeExecutionReadiness:v1`. They are proposed
+domain products only: no runtime route is active, no ingestion table is certified, and no downstream
+consumer may claim treasury policy approval, forward pricing, hedge advice, counterparty selection,
+best execution, OMS acknowledgement, fills, settlement, or autonomous treasury action from these
+planned contracts.
 
 ## Platform relationship
 


### PR DESCRIPTION
## Summary
- adds planned, not active, RFC39-WTBD-008 external treasury source-product contracts for currency exposure, hedge policy, FX forward curves, eligible hedge instruments, and hedge execution readiness
- adds matching planned source-data security profiles and proposed repo-native domain-product declarations
- documents the boundary in README, repository context, RFC-0083 source-data product catalog, and wiki source without activating runtime routes or support claims

## Boundary
- proposed contracts only; no runtime route is active and no ingestion table is certified in this slice
- no hedge advice, forward pricing, treasury instructions, counterparty selection, best execution, OMS acknowledgement, fills, settlement, or autonomous treasury action claim
- `origin/feat/portfolio-realized-tax-summary` remains unmerged and owner-confirm-before-delete/superseded-looking; not touched

## Validation
- `python -m pytest tests/unit/libs/portfolio-common/test_source_data_products.py tests/unit/libs/portfolio-common/test_source_data_security.py tests/unit/test_domain_data_product_contracts.py tests/unit/docs/test_source_data_product_boundaries.py -q` - 56 passed
- `make source-data-product-contract-guard` - passed
- `make domain-product-validate` - passed
- `make lint` - passed
- `make typecheck` - passed
- `make no-alias-gate` - passed
- `make test` - 2045 passed, 9 deselected
- `python ..\lotus-platform\automation\validate_engineering_context_system.py` - passed
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py` - passed
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-core` - expected pre-merge drift: `Mesh-Data-Products.md`