### PR TITLE
feat: add DPM source readiness trust telemetry

### DIFF
--- a/contracts/trust-telemetry/README.md
+++ b/contracts/trust-telemetry/README.md
@@ -7,6 +7,8 @@ The current first-wave snapshot is:
 
 1. `portfolio-state-snapshot.telemetry.v1.json`
    Runtime trust proof for `lotus-core:PortfolioStateSnapshot:v1`.
+2. `dpm-source-readiness.telemetry.v1.json`
+   Runtime trust proof for `lotus-core:DpmSourceReadiness:v1`.
 
 Validate locally with:
 

--- a/contracts/trust-telemetry/dpm-source-readiness.telemetry.v1.json
+++ b/contracts/trust-telemetry/dpm-source-readiness.telemetry.v1.json
@@ -1,0 +1,60 @@
+{
+  "contract_id": "lotus-domain-product-trust-telemetry-snapshot",
+  "contract_version": "1.0.0",
+  "governed_by_rfcs": [
+    "RFC-0087"
+  ],
+  "emitted_at_utc": "2026-05-22T00:00:00Z",
+  "product_id": "lotus-core:DpmSourceReadiness:v1",
+  "producer_repository": "lotus-core",
+  "product_name": "DpmSourceReadiness",
+  "product_version": "v1",
+  "source_repository": "lotus-core",
+  "freshness": {
+    "freshness_class": "intraday",
+    "freshness_state": "current",
+    "evaluated_at_utc": "2026-05-22T00:00:00Z",
+    "observed_at_utc": "2026-05-22T00:00:00Z",
+    "age_seconds": 0,
+    "max_allowed_age_seconds": 3600
+  },
+  "completeness_status": "complete",
+  "reconciliation_status": "reconciled",
+  "data_quality_status": "quality_passed",
+  "lineage": {
+    "lineage_materialized": true,
+    "lineage_bundle_id": "lineage:lotus-core:dpm-source-readiness:PB_SG_GLOBAL_BAL_001:2026-05-22",
+    "evidence_access_class": "operator_only",
+    "evidence_uris": [
+      "lotus-core://evidence/dpm-source-readiness/PB_SG_GLOBAL_BAL_001/2026-05-22"
+    ]
+  },
+  "blocking": {
+    "blocked": false
+  },
+  "observed_trust_metadata": {
+    "product_name": "DpmSourceReadiness",
+    "product_version": "v1",
+    "tenant_id": "TENANT_PRIVATE_BANKING_DEMO",
+    "generated_at": "2026-05-22T00:00:00Z",
+    "as_of_date": "2026-05-22",
+    "restatement_version": "restatement:2026-05-22:0",
+    "reconciliation_status": "reconciled",
+    "data_quality_status": "quality_passed",
+    "latest_evidence_timestamp": "2026-05-22T00:00:00Z",
+    "source_batch_fingerprint": "sha256:dpm-source-readiness-demo-batch",
+    "snapshot_id": "PB_SG_GLOBAL_BAL_001:2026-05-22:dpm-source-readiness",
+    "policy_version": "dpm-source-readiness-policy.v1",
+    "correlation_id": "rfc-0087-lotus-core-dpm-source-readiness"
+  },
+  "evidence": {
+    "correlation_id": "rfc-0087-lotus-core-dpm-source-readiness",
+    "validation_lanes": [
+      "feature",
+      "pr-merge",
+      "main-releasability"
+    ],
+    "source_event_id": "source-event:lotus-core:dpm-source-readiness:PB_SG_GLOBAL_BAL_001:2026-05-22",
+    "source_artifact_uri": "lotus-core://contracts/trust-telemetry/dpm-source-readiness.telemetry.v1.json"
+  }
+}

--- a/requirements/shared-runtime.lock.txt
+++ b/requirements/shared-runtime.lock.txt
@@ -45,7 +45,7 @@ httptools==0.7.1
     # via uvicorn
 httpx==0.28.1
     # via -r C:/Users/Sandeep/projects/lotus-core/requirements/shared-runtime.in
-idna==3.11
+idna==3.15
     # via
     #   anyio
     #   httpx

--- a/tests/unit/test_trust_telemetry.py
+++ b/tests/unit/test_trust_telemetry.py
@@ -12,6 +12,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 PLATFORM_ROOT = REPO_ROOT.parent / "lotus-platform"
 TELEMETRY_DIR = REPO_ROOT / "contracts" / "trust-telemetry"
 SNAPSHOT_PATH = TELEMETRY_DIR / "portfolio-state-snapshot.telemetry.v1.json"
+DPM_SOURCE_READINESS_PATH = TELEMETRY_DIR / "dpm-source-readiness.telemetry.v1.json"
 DECLARATION_PATH = REPO_ROOT / "contracts" / "domain-data-products" / "lotus-core-products.v1.json"
 
 
@@ -40,29 +41,34 @@ def test_portfolio_state_snapshot_trust_telemetry_validates_with_platform_contra
     assert issues == []
 
 
-def test_portfolio_state_snapshot_trust_telemetry_is_tied_to_repo_declaration() -> None:
-    snapshot = _load_json(SNAPSHOT_PATH)
-    declaration = _load_json(DECLARATION_PATH)
-    declared_product = next(
-        product
-        for product in declaration["products"]
-        if product["product_name"] == "PortfolioStateSnapshot"
-    )
+def test_required_trust_telemetry_files_exist() -> None:
+    assert SNAPSHOT_PATH.exists()
+    assert DPM_SOURCE_READINESS_PATH.exists()
 
-    assert snapshot["product_id"] == "lotus-core:PortfolioStateSnapshot:v1"
-    assert snapshot["producer_repository"] == declaration["producer_repository"]
-    assert snapshot["product_name"] == declared_product["product_name"]
-    assert snapshot["product_version"] == declared_product["product_version"]
-    assert (
-        snapshot["freshness"]["freshness_class"]
-        == (declared_product["freshness_policy"]["freshness_class"])
-    )
-    assert set(snapshot["observed_trust_metadata"]) == set(
-        declared_product["required_trust_metadata"]
-    )
-    assert snapshot["lineage"]["lineage_materialized"] is True
-    assert (
-        snapshot["lineage"]["evidence_access_class"]
-        == (declared_product["lineage_policy"]["evidence_access_class_ref"])
-    )
-    assert snapshot["blocking"]["blocked"] is False
+
+def test_trust_telemetry_is_tied_to_repo_declaration() -> None:
+    declaration = _load_json(DECLARATION_PATH)
+    declared_products = {product["product_name"]: product for product in declaration["products"]}
+
+    for telemetry_path in (SNAPSHOT_PATH, DPM_SOURCE_READINESS_PATH):
+        snapshot = _load_json(telemetry_path)
+        declared_product = declared_products[snapshot["product_name"]]
+
+        assert snapshot["product_id"] == (
+            f"lotus-core:{declared_product['product_name']}:{declared_product['product_version']}"
+        )
+        assert snapshot["producer_repository"] == declaration["producer_repository"]
+        assert snapshot["product_version"] == declared_product["product_version"]
+        assert (
+            snapshot["freshness"]["freshness_class"]
+            == (declared_product["freshness_policy"]["freshness_class"])
+        )
+        assert set(snapshot["observed_trust_metadata"]) == set(
+            declared_product["required_trust_metadata"]
+        )
+        assert snapshot["lineage"]["lineage_materialized"] is True
+        assert (
+            snapshot["lineage"]["evidence_access_class"]
+            == (declared_product["lineage_policy"]["evidence_access_class_ref"])
+        )
+        assert snapshot["blocking"]["blocked"] is False


### PR DESCRIPTION
## Summary
- add RFC-0087 static trust telemetry for `lotus-core:DpmSourceReadiness:v1`
- document the new telemetry fixture in `contracts/trust-telemetry/README.md`
- generalize the trust telemetry unit test so every first-wave telemetry fixture is tied to the repo-native product declaration

## Validation
- `python -m ruff check tests\unit\test_trust_telemetry.py`
- `python -m ruff format --check tests\unit\test_trust_telemetry.py`
- `python -m pytest tests\unit\test_trust_telemetry.py -q`
- `make domain-product-validate`

## Notes
- No API shape change.
- No runtime behavior change.
- Supports platform promotion of `DpmSourceReadiness:v1` into the enterprise mesh maturity scope.