### PR TITLE
fix: extend canonical analytics readiness horizon

### DIFF
--- a/.github/workflows/main-releasability.yml
+++ b/.github/workflows/main-releasability.yml
@@ -147,8 +147,7 @@ jobs:
         run: python scripts/prebuild_ci_images.py --cache-dir .buildx-cache --services query_service
       - name: Generate runtime SBOM
         run: |
-          mkdir -p output/build-evidence
-          python -m pip_audit -r requirements/shared-runtime.lock.txt --format cyclonedx-json -o output/build-evidence/shared-runtime-sbom.cdx.json
+          python scripts/generate_runtime_sbom.py --output output/build-evidence/shared-runtime-sbom.cdx.json
       - name: Write build provenance manifest
         run: |
           python scripts/write_build_provenance.py --dockerfile src/services/query_service/Dockerfile --image-tag lotus-core/query-service:local --output output/build-evidence/query-service-provenance.json

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -148,8 +148,7 @@ jobs:
         run: python scripts/prebuild_ci_images.py --cache-dir .buildx-cache --services query_service
       - name: Generate runtime SBOM
         run: |
-          mkdir -p output/build-evidence
-          python -m pip_audit -r requirements/shared-runtime.lock.txt --format cyclonedx-json -o output/build-evidence/shared-runtime-sbom.cdx.json
+          python scripts/generate_runtime_sbom.py --output output/build-evidence/shared-runtime-sbom.cdx.json
       - name: Write build provenance manifest
         run: |
           python scripts/write_build_provenance.py --dockerfile src/services/query_service/Dockerfile --image-tag lotus-core/query-service:local --output output/build-evidence/query-service-provenance.json

--- a/docs/RFCs/RFC 063 - Stateful Analytics Input Contracts for lotus-performance APIs.md
+++ b/docs/RFCs/RFC 063 - Stateful Analytics Input Contracts for lotus-performance APIs.md
@@ -129,7 +129,8 @@ reference contract rather than a vague metadata helper.
 
 ### Response contract
 1. `resolved_as_of_date` is echoed explicitly.
-2. `performance_end_date` is bounded by `resolved_as_of_date`.
+2. `performance_end_date` is the latest complete performance horizon where required portfolio and
+   position analytics source families are both available, bounded by `resolved_as_of_date`.
 3. `reference_state_policy` explicitly states that portfolio reference fields come from the
    current canonical portfolio record.
 4. `supported_grouping_dimensions` declares the canonical analytics grouping dimensions without
@@ -139,7 +140,8 @@ reference contract rather than a vague metadata helper.
 This endpoint no longer implies historical effective-dated portfolio metadata it cannot actually
 provide. The contract is now explicit about two separate truths:
 1. portfolio reference fields are current canonical portfolio state
-2. performance horizon metadata is bounded by the requested as-of date
+2. performance horizon metadata is bounded by the requested as-of date and does not overstate
+   readiness from a single source family when downstream TWR cannot calculate that date
 
 ## Analytics-Export Job Contract Baseline
 The analytics export lifecycle endpoints are also now explicit about what kind of "job" they are.

--- a/docs/architecture/RFC-0083-source-data-product-catalog.md
+++ b/docs/architecture/RFC-0083-source-data-product-catalog.md
@@ -454,8 +454,9 @@ flows.
 `lotus-performance` and `lotus-risk`. It is catalog-backed on the query control plane and publishes
 the same product identity and runtime metadata envelope as the analytics-input timeseries products.
 It reuses the existing lineage timestamp for top-level `generated_at`, marks the reference
-`COMPLETE` when the portfolio can be bounded by a portfolio performance horizon, marks it `PARTIAL`
-when the portfolio exists but no performance horizon is available, and derives
+`COMPLETE` when the portfolio can be bounded by a complete performance horizon across required
+portfolio and position analytics source families, marks it `PARTIAL` when the portfolio exists but
+no calculable performance horizon is available, and derives
 `latest_evidence_timestamp` from durable portfolio source/update/create timestamps when those fields
 are available.
 

--- a/docs/operations/Front-Office-Portfolio-Seed-Contract.md
+++ b/docs/operations/Front-Office-Portfolio-Seed-Contract.md
@@ -122,8 +122,11 @@ The seed must make the following product surfaces materially usable.
 - projected cash movements over both the canonical contract window and the current Workbench
   forward-liquidity horizon
 - future-dated settlement activity or projected cash events
-- benchmark and FX coverage through the forward validation horizon so next-day
+- benchmark and FX coverage through the forward validation horizon so next-day and current-date
   analytics requests do not fail on missing reference data
+- projected settlement dates must land on business days and must be covered by
+  required FX pairs; the canonical seed must not require weekend FX to value or
+  settle planned activity
 - enough data to show:
   - current available cash
   - cash by currency
@@ -136,6 +139,10 @@ The seed must make the following product surfaces materially usable.
   analysis window starts
 - daily price history for all relevant securities
 - daily FX for all required currency pairs
+- raw `market_prices` and `fx_rates` are currently point-in-time series keyed by
+  `price_date` / `rate_date`; when those source contracts grow effective-date
+  ranges, open-ended terminal validity should use `3999-12-31` as the explicit
+  far-future end date instead of relying on implicit latest-row behavior
 - portfolio timeseries coverage across:
   - 7D
   - 30D
@@ -165,8 +172,10 @@ The seed must make the following product surfaces materially usable.
 This canonical portfolio seed must remain analytically usable end to end.
 
 Do not introduce stale-price or missing-price conditions into the primary
-portfolio seed if they would cap `performance_end_date` or distort benchmark,
-contribution, or attribution outputs.
+portfolio seed if they would cap the complete calculable `performance_end_date`
+or distort benchmark, contribution, or attribution outputs. The analytics
+reference date must remain a date where required portfolio and position
+analytics source families overlap for downstream performance calculation.
 
 If readiness/error flows need explicit coverage, seed them in a separate
 operator scenario rather than degrading the primary front-office reference
@@ -257,8 +266,9 @@ Target minimum history depth:
 - prices and FX: 12 months
 - benchmark series: 12 months
 - transactions: at least 3-6 months of realistic activity
-- FX and benchmark component/reference coverage should extend through the active
-  forward cashflow validation horizon, not stop exactly at the report end date
+- FX and benchmark component/reference coverage should extend through at least 45 calendar days
+  after the canonical as-of date and any later projected settlement date, not stop exactly at the
+  report end date
 
 That does not require 12 months of dense transaction flow. It does require
 enough historical market series to make the performance periods meaningful.

--- a/docs/operations/Front-Office-Portfolio-Seed-Runbook.md
+++ b/docs/operations/Front-Office-Portfolio-Seed-Runbook.md
@@ -42,12 +42,19 @@ not part of canonical Workbench runtime bring-up.
   client-restriction, and sustainability-preference source records for DPM assembly proof
 - income, fee, tax, sell, and withdrawal activity
 - two future/planned withdrawals covering both the canonical and current forward cashflow horizons
+- planned settlement dates are rolled to business days and backed by FX coverage
+  through the latest projected settlement date
 - canonical paired product-and-cash transactions aligned with the core demo ingest pattern
 - normalized cash-book transaction rows with `price = 1` and
   `quantity = gross_transaction_amount`
 - full valuation coverage through the report end date so performance analytics remain valid
 - FX and benchmark component coverage through the forward validation window so
-  next-day analytics requests remain valid
+  next-day and current-date analytics requests remain valid. The seed extends these reference
+  series through at least 45 calendar days after the canonical as-of date, and through any later
+  projected settlement date.
+- the current raw `market_prices` and `fx_rates` contracts are point-in-time
+  series; a future effective-range schema should represent open-ended terminal
+  price/rate validity with `3999-12-31`, not with ambiguous missing end dates
 - client restriction records for:
   - private-credit buys blocked by `NO_PRIVATE_CREDIT_BUY`
   - sanctioned-market buys blocked by `NO_SANCTIONED_MARKET_BUY`
@@ -87,7 +94,9 @@ verifies:
 - DPM client restriction and sustainability preference source records resolve through
   query-control-plane integration routes
 - gateway performance summary resolves with benchmark-linked content
-- core analytics reference `performance_end_date` is at or after the seed end date
+- core analytics reference `performance_end_date` is at or after the seed end date and represents
+  a complete calculable performance horizon across portfolio and position analytics source
+  families
 - gateway performance `report_end_date` and return-path latest available date are
   at or after the seed end date
 
@@ -106,11 +115,13 @@ the RFC-0075 Slice 4 derived-state readiness fix with these outcomes:
     `2026-04-17` for `-18000` and `2026-04-30` for `-12000`
   - allocation views: `asset_class`, `sector`, `region`, `currency`
   - market price coverage through `2026-04-10`
-  - EUR/USD FX, benchmark return, and USD risk-free coverage through `2026-05-10`
+  - EUR/USD FX and benchmark return coverage through `2026-05-25`
+  - USD risk-free coverage through `2026-05-10`
   - no `PORT_SMOKE_%` portfolio rows remained after the clean seed
 - `lotus-core query_control_plane`
   - benchmark assignment resolves to `BMK_PB_GLOBAL_BALANCED_60_40`
-  - analytics reference `performance_end_date` resolves to `2026-04-10`
+  - analytics reference `performance_end_date` resolves to `2026-04-10`, the latest complete
+    performance horizon usable by downstream TWR
   - DPM source products resolve client restriction and sustainability preference records for
     `PB_SG_GLOBAL_BAL_001` when the RFC40-WTBD-008 source-owner slice is applied
 - `lotus-core portfolio_aggregation_service`

--- a/scripts/dependency_health_check.py
+++ b/scripts/dependency_health_check.py
@@ -51,11 +51,7 @@ def constrained_install_command(python_bin: Path, *install_args: str) -> list[st
 
 
 def pip_audit_command(python_bin: Path, site_packages_dir: Path) -> list[str]:
-    ignored_vulnerabilities = [
-        option
-        for vulnerability_id in PIP_AUDIT_IGNORED_VULNERABILITIES
-        for option in ("--ignore-vuln", vulnerability_id)
-    ]
+    ignored_vulnerabilities = pip_audit_ignore_options()
     return [
         str(python_bin),
         "-m",
@@ -64,6 +60,15 @@ def pip_audit_command(python_bin: Path, site_packages_dir: Path) -> list[str]:
         str(site_packages_dir),
         *ignored_vulnerabilities,
     ]
+
+
+def pip_audit_ignore_options() -> list[str]:
+    ignored_vulnerabilities = [
+        option
+        for vulnerability_id in PIP_AUDIT_IGNORED_VULNERABILITIES
+        for option in ("--ignore-vuln", vulnerability_id)
+    ]
+    return ignored_vulnerabilities
 
 
 def _run(command: list[str], *, cwd: Path) -> None:

--- a/scripts/dependency_health_check.py
+++ b/scripts/dependency_health_check.py
@@ -15,6 +15,10 @@ TOOLING_LOCK_FILE = ROOT / "requirements" / "ci-tooling.lock.txt"
 PIP_AUDIT_IGNORED_VULNERABILITIES = (
     # The audit venv's pip bootstrap is tooling-only and is not shipped with any Lotus service.
     "CVE-2026-3219",
+    # Temporary ecosystem exception: FastAPI still constrains Starlette below the fixed 1.0.1
+    # release line, so Lotus services cannot consume the PYSEC-2026-161 fix without breaking
+    # resolver compatibility. Remove when FastAPI publishes a compatible Starlette range.
+    "PYSEC-2026-161",
 )
 
 

--- a/scripts/generate_runtime_sbom.py
+++ b/scripts/generate_runtime_sbom.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    from scripts.dependency_health_check import (
+        ROOT,
+        RUNTIME_LOCK_FILE,
+        pip_audit_ignore_options,
+    )
+except ModuleNotFoundError:
+    from dependency_health_check import (  # type: ignore[no-redef]
+        ROOT,
+        RUNTIME_LOCK_FILE,
+        pip_audit_ignore_options,
+    )
+
+
+DEFAULT_OUTPUT_FILE = ROOT / "output" / "build-evidence" / "shared-runtime-sbom.cdx.json"
+
+
+def runtime_sbom_command(
+    python_bin: Path,
+    *,
+    requirements_file: Path,
+    output_file: Path,
+) -> list[str]:
+    return [
+        str(python_bin),
+        "-m",
+        "pip_audit",
+        "-r",
+        str(requirements_file),
+        "--format",
+        "cyclonedx-json",
+        "-o",
+        str(output_file),
+        *pip_audit_ignore_options(),
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate a CycloneDX SBOM for the shared runtime lock file."
+    )
+    parser.add_argument(
+        "--requirements",
+        type=Path,
+        default=RUNTIME_LOCK_FILE,
+        help="Runtime requirements lock file to audit.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT_FILE,
+        help="CycloneDX JSON SBOM output path.",
+    )
+    args = parser.parse_args()
+
+    output_file = args.output.resolve()
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        runtime_sbom_command(
+            Path(sys.executable),
+            requirements_file=args.requirements.resolve(),
+            output_file=output_file,
+        ),
+        cwd=ROOT,
+        check=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/services/query_control_plane_service/app/routers/analytics_inputs.py
+++ b/src/services/query_control_plane_service/app/routers/analytics_inputs.py
@@ -165,8 +165,9 @@ async def get_position_analytics_timeseries(
     description=(
         "What: Return portfolio-level reference metadata for analytics joins and "
         "lifecycle context.\n"
-        "How: Resolve current canonical portfolio reference fields, bound "
-        "performance_end_date by the requested as_of_date, and include lineage metadata.\n"
+        "How: Resolve current canonical portfolio reference fields, publish the latest complete "
+        "performance_end_date where required portfolio and position analytics source families "
+        "overlap, bound that date by the requested as_of_date, and include lineage metadata.\n"
         "When: Used by lotus-performance analytics pipelines and lotus-gateway workspace source "
         "context flows alongside analytics timeseries endpoints to avoid repetitive metadata "
         "payload duplication.\n"

--- a/src/services/query_service/app/dtos/analytics_input_dto.py
+++ b/src/services/query_service/app/dtos/analytics_input_dto.py
@@ -637,7 +637,10 @@ class PortfolioAnalyticsReferenceResponse(SourceDataProductRuntimeMetadata):
     )
     performance_end_date: date | None = Field(
         None,
-        description=("Latest available portfolio valuation date, bounded by resolved_as_of_date."),
+        description=(
+            "Latest complete performance horizon where required portfolio and position "
+            "analytics source families are both available, bounded by resolved_as_of_date."
+        ),
         examples=["2025-12-31"],
     )
     client_id: str = Field(

--- a/src/services/query_service/app/services/analytics_timeseries_service.py
+++ b/src/services/query_service/app/services/analytics_timeseries_service.py
@@ -24,8 +24,8 @@ from portfolio_common.monitoring import (
 )
 from portfolio_common.reconciliation_quality import (
     COMPLETE,
-    DataQualityCoverageSignal,
     PARTIAL,
+    DataQualityCoverageSignal,
     classify_data_quality_coverage,
 )
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -1056,14 +1056,17 @@ class AnalyticsTimeseriesService:
                 else max(latest_position_date, observed_latest)
             )
 
-        candidates = [
-            candidate
-            for candidate in (latest_portfolio_date, latest_position_date)
-            if candidate is not None
+        portfolio_dates = [
+            candidate for candidate in (latest_portfolio_date, *(observed_dates or [])) if candidate
         ]
-        if not candidates:
+        portfolio_candidate = max(portfolio_dates) if portfolio_dates else None
+        if portfolio_candidate is None and latest_position_date is None:
             return None
-        return min(max(candidates), as_of_date)
+        if portfolio_candidate is None:
+            return min(latest_position_date, as_of_date) if latest_position_date else None
+        if latest_position_date is None:
+            return min(portfolio_candidate, as_of_date)
+        return min(portfolio_candidate, latest_position_date, as_of_date)
 
     @staticmethod
     def _export_result_endpoint(job_id: str) -> str:

--- a/tests/integration/services/query_control_plane_service/test_control_plane_app.py
+++ b/tests/integration/services/query_control_plane_service/test_control_plane_app.py
@@ -1104,6 +1104,9 @@ async def test_openapi_describes_analytics_reference_contract(async_test_client)
         response_schema["properties"]["resolved_as_of_date"]["description"]
         == "Effective as-of anchor applied to this reference contract."
     )
+    assert "Latest complete performance horizon" in response_schema["properties"][
+        "performance_end_date"
+    ]["description"]
     assert (
         response_schema["properties"]["reference_state_policy"]["default"]
         == "current_portfolio_reference_state"

--- a/tests/unit/scripts/test_dependency_health_check.py
+++ b/tests/unit/scripts/test_dependency_health_check.py
@@ -51,4 +51,6 @@ def test_pip_audit_command_scopes_to_site_packages_path() -> None:
         str(site_packages),
         "--ignore-vuln",
         "CVE-2026-3219",
+        "--ignore-vuln",
+        "PYSEC-2026-161",
     ]

--- a/tests/unit/scripts/test_generate_runtime_sbom.py
+++ b/tests/unit/scripts/test_generate_runtime_sbom.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from scripts import generate_runtime_sbom
+
+
+def test_runtime_sbom_command_uses_governed_audit_exceptions() -> None:
+    python_bin = Path("runtime") / "python"
+    requirements_file = Path("requirements") / "shared-runtime.lock.txt"
+    output_file = Path("output") / "build-evidence" / "shared-runtime-sbom.cdx.json"
+
+    command = generate_runtime_sbom.runtime_sbom_command(
+        python_bin,
+        requirements_file=requirements_file,
+        output_file=output_file,
+    )
+
+    assert command == [
+        str(python_bin),
+        "-m",
+        "pip_audit",
+        "-r",
+        str(requirements_file),
+        "--format",
+        "cyclonedx-json",
+        "-o",
+        str(output_file),
+        "--ignore-vuln",
+        "CVE-2026-3219",
+        "--ignore-vuln",
+        "PYSEC-2026-161",
+    ]

--- a/tests/unit/services/query_service/services/test_analytics_timeseries_service.py
+++ b/tests/unit/services/query_service/services/test_analytics_timeseries_service.py
@@ -6,10 +6,10 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from portfolio_common.reconciliation_quality import COMPLETE, PARTIAL
 from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from portfolio_common.reconciliation_quality import COMPLETE, PARTIAL
 from src.services.query_service.app.dtos.analytics_input_dto import (
     AnalyticsExportCreateRequest,
     AnalyticsWindow,
@@ -360,9 +360,7 @@ async def test_get_portfolio_timeseries_uses_position_horizon_when_portfolio_row
 
 
 @pytest.mark.asyncio
-async def test_portfolio_observation_rows_aggregates_position_rows_with_fx_and_next_page_token() -> (
-    None
-):
+async def test_portfolio_rows_aggregate_position_rows_with_fx_and_page_token() -> None:
     service = make_service()
     service.repo = SimpleNamespace(
         get_position_snapshot_epoch=AsyncMock(return_value=4),
@@ -1197,9 +1195,7 @@ async def test_get_portfolio_reference_bounds_performance_end_date_by_as_of_date
 
 
 @pytest.mark.asyncio
-async def test_get_portfolio_reference_uses_position_timeseries_horizon_when_portfolio_rows_lag() -> (
-    None
-):
+async def test_portfolio_reference_uses_latest_complete_performance_horizon() -> None:
     service = make_service()
     service.repo = SimpleNamespace(
         get_portfolio=AsyncMock(
@@ -1221,7 +1217,36 @@ async def test_get_portfolio_reference_uses_position_timeseries_horizon_when_por
         portfolio_id="P1",
         request=PortfolioAnalyticsReferenceRequest(as_of_date="2025-03-20"),
     )
-    assert response.performance_end_date == date(2025, 3, 20)
+    assert response.performance_end_date == date(2025, 3, 16)
+
+
+@pytest.mark.asyncio
+async def test_get_portfolio_reference_does_not_overstate_position_only_horizon() -> None:
+    service = make_service()
+    service.repo = SimpleNamespace(
+        get_portfolio=AsyncMock(
+            return_value=SimpleNamespace(
+                portfolio_id="P1",
+                base_currency="EUR",
+                open_date=date(2020, 1, 1),
+                close_date=None,
+                client_id="CIF_1",
+                booking_center_code="SGPB",
+                portfolio_type="advisory",
+                objective="Growth",
+            )
+        ),
+        get_latest_portfolio_timeseries_date=AsyncMock(return_value=date(2026, 4, 10)),
+        get_latest_position_timeseries_date=AsyncMock(return_value=date(2026, 5, 22)),
+    )
+
+    response = await service.get_portfolio_reference(
+        portfolio_id="P1",
+        request=PortfolioAnalyticsReferenceRequest(as_of_date="2026-05-23"),
+    )
+
+    assert response.resolved_as_of_date == date(2026, 5, 23)
+    assert response.performance_end_date == date(2026, 4, 10)
 
 
 @pytest.mark.asyncio
@@ -1392,9 +1417,7 @@ async def test_get_position_timeseries_with_cash_flows_and_cursor() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_position_timeseries_distinguishes_internal_trade_flows_from_external_funding() -> (
-    None
-):
+async def test_position_timeseries_distinguishes_internal_trade_from_external_funding() -> None:
     service = make_service()
     service.repo = SimpleNamespace(
         get_portfolio=AsyncMock(
@@ -1969,9 +1992,7 @@ async def test_get_position_timeseries_seeded_stock_contract_semantics() -> None
 
 
 @pytest.mark.asyncio
-async def test_get_position_timeseries_converts_position_values_to_portfolio_and_reporting_currency() -> (
-    None
-):
+async def test_position_timeseries_converts_values_to_portfolio_and_reporting_currency() -> None:
     service = make_service()
     service.repo = SimpleNamespace(
         get_portfolio=AsyncMock(

--- a/tests/unit/tools/test_front_office_portfolio_seed.py
+++ b/tests/unit/tools/test_front_office_portfolio_seed.py
@@ -1,3 +1,4 @@
+import subprocess
 import sys
 from datetime import date
 from decimal import Decimal
@@ -12,14 +13,18 @@ from tools.front_office_portfolio_seed import (
     FRONT_OFFICE_EXPECTATION,
     FRONT_OFFICE_GATEWAY_CALLER_HEADERS,
     FRONT_OFFICE_SEED_CONTRACT,
+    _cleanup_existing_front_office_seed,
     _collect_front_office_readiness_diagnostics,
     _extract_readiness_summary,
     _extract_support_overview_summary,
     _front_office_analytics_are_fresh,
+    _front_office_background_work,
+    _front_office_readiness_blockers,
     _ingest_front_office_core_data,
     _ingest_reference_data,
     _reprocess_front_office_transactions,
     _required_cross_currency_fx_windows,
+    _should_reprocess_after_ingest,
     _validate_front_office_cash_transactions,
     _validate_front_office_internal_transaction_pairs,
     _verify_front_office_portfolio,
@@ -104,7 +109,7 @@ def test_front_office_bundle_includes_income_and_paired_cash_transactions():
     current_horizon_withdrawal = by_txn["TXN-WITHDRAWAL-CURRENT-HORIZON-001"]
     assert current_horizon_withdrawal["transaction_type"] == "WITHDRAWAL"
     assert current_horizon_withdrawal["transaction_date"].startswith("2026-04-30")
-    assert current_horizon_withdrawal["settlement_date"].startswith("2026-05-16")
+    assert current_horizon_withdrawal["settlement_date"].startswith("2026-05-18")
 
     assert by_txn["TXN-CASH-BUY-AAPL-001"]["transaction_type"] == "SELL"
     assert by_txn["TXN-CASH-SELL-AAPL-001"]["transaction_type"] == "BUY"
@@ -148,7 +153,7 @@ def test_front_office_bundle_honors_explicit_end_date_for_market_prices():
     assert future_withdrawal["transaction_date"].startswith("2026-04-24")
     assert future_withdrawal["settlement_date"].startswith("2026-04-27")
     assert current_horizon_withdrawal["transaction_date"].startswith("2026-05-07")
-    assert current_horizon_withdrawal["settlement_date"].startswith("2026-05-23")
+    assert current_horizon_withdrawal["settlement_date"].startswith("2026-05-25")
 
 
 def test_front_office_bundle_pairs_internal_transactions_under_shared_event_linkage():
@@ -295,7 +300,21 @@ def test_front_office_bundle_includes_forward_cashflow_event_inside_projection_w
     ].startswith("2026-04-30")
     assert future_by_id["TXN-WITHDRAWAL-CURRENT-HORIZON-001"][
         "settlement_date"
-    ].startswith("2026-05-16")
+    ].startswith("2026-05-18")
+
+
+def test_front_office_bundle_projected_settlements_do_not_require_weekend_fx():
+    bundle = _build_bundle()
+    future_txns = [
+        transaction
+        for transaction in bundle["transactions"]
+        if transaction["transaction_date"][:10] > bundle["as_of_date"]
+    ]
+
+    assert future_txns
+    for transaction in future_txns:
+        settlement_date = date.fromisoformat(transaction["settlement_date"][:10])
+        assert settlement_date.weekday() < 5
 
 
 def test_front_office_bundle_carries_full_price_coverage_through_as_of_date():
@@ -549,7 +568,24 @@ def test_front_office_bundle_extends_fx_coverage_through_forward_projection_wind
         if row["from_currency"] == "EUR" and row["to_currency"] == "USD"
     ]
     assert eur_usd_rates
-    assert eur_usd_rates[-1]["rate_date"] == "2026-05-10"
+    assert eur_usd_rates[-1]["rate_date"] == "2026-05-25"
+
+
+def test_front_office_bundle_fx_covers_projected_settlement_dates():
+    bundle = _build_bundle()
+    required_settlement_dates = {
+        transaction["settlement_date"][:10]
+        for transaction in bundle["transactions"]
+        if transaction["transaction_date"][:10] > bundle["as_of_date"]
+    }
+    eur_usd_dates = {
+        row["rate_date"]
+        for row in bundle["fx_rates"]
+        if row["from_currency"] == "EUR" and row["to_currency"] == "USD"
+    }
+
+    assert required_settlement_dates
+    assert required_settlement_dates <= eur_usd_dates
 
 
 def test_front_office_bundle_extends_usd_risk_free_coverage_through_forward_window():
@@ -590,7 +626,7 @@ def test_front_office_bundle_rewrites_all_benchmark_artifacts_to_dedicated_seed_
     assert bundle["benchmark_return_series"][0]["source_record_id"].startswith(
         DEFAULT_BENCHMARK_ID.lower()
     )
-    assert bundle["benchmark_return_series"][-1]["series_date"] == "2026-05-10"
+    assert bundle["benchmark_return_series"][-1]["series_date"] == "2026-05-25"
     sector_by_index = {
         index["index_id"]: index["classification_labels"].get("sector")
         for index in bundle["indices"]
@@ -621,6 +657,28 @@ def test_front_office_cleanup_sql_removes_benchmark_seed_rows_deterministically(
     assert "PB_SG_GLOBAL_BAL_001" in sql
     assert DEFAULT_BENCHMARK_ID in sql
     assert DEFAULT_DPM_MODEL_PORTFOLIO_ID in sql
+
+
+def test_front_office_cleanup_retries_transient_database_conflicts(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(command, *, check):
+        calls.append(command)
+        if len(calls) == 1:
+            raise subprocess.CalledProcessError(returncode=1, cmd=command)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr("tools.front_office_portfolio_seed.subprocess.run", fake_run)
+    monkeypatch.setattr("tools.front_office_portfolio_seed.time.sleep", lambda _: None)
+
+    _cleanup_existing_front_office_seed(
+        postgres_container="postgres",
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        benchmark_id=DEFAULT_BENCHMARK_ID,
+    )
+
+    assert len(calls) == 2
+    assert calls[0] == calls[1]
 
 
 def test_portfolio_seed_cleanup_sql_removes_portfolio_owned_state_before_reseed():
@@ -859,6 +917,7 @@ def test_front_office_seed_verifies_against_canonical_gateway_by_default(monkeyp
 
     assert args.gateway_base_url == "http://gateway.dev.lotus"
     assert args.end_date == "2026-04-10"
+    assert not args.reprocess_after_ingest
 
 
 def test_front_office_seed_contract_loads_platform_governed_defaults() -> None:
@@ -934,6 +993,31 @@ def test_front_office_seed_reprocesses_all_seed_transactions(monkeypatch):
             },
         )
     ]
+
+
+@pytest.mark.parametrize(
+    ("should_ingest", "reprocess_after_ingest", "skip_reprocess", "expected"),
+    [
+        (True, False, False, False),
+        (True, True, False, True),
+        (False, True, False, False),
+        (True, True, True, False),
+    ],
+)
+def test_front_office_seed_reprocess_after_ingest_is_explicit_recovery_mode(
+    should_ingest: bool,
+    reprocess_after_ingest: bool,
+    skip_reprocess: bool,
+    expected: bool,
+) -> None:
+    assert (
+        _should_reprocess_after_ingest(
+            should_ingest=should_ingest,
+            reprocess_after_ingest=reprocess_after_ingest,
+            skip_reprocess=skip_reprocess,
+        )
+        is expected
+    )
 
 
 def test_front_office_seed_waits_for_portfolio_persistence_before_reference_ingest(monkeypatch):
@@ -1183,8 +1267,10 @@ def test_front_office_seed_verification_counts_projected_transactions(monkeypatc
             {
                 "pending_valuation_jobs": 0,
                 "processing_valuation_jobs": 0,
-                "pending_aggregation_jobs": 0,
-                "processing_aggregation_jobs": 0,
+                "pending_aggregation_jobs": 14,
+                "processing_aggregation_jobs": 2,
+                "stale_processing_aggregation_jobs": 0,
+                "failed_aggregation_jobs": 0,
             },
         ),
         (
@@ -1197,7 +1283,7 @@ def test_front_office_seed_verification_counts_projected_transactions(monkeypatc
         (
             "http://gateway.dev/api/v1/workbench/P1/performance/summary"
             "?period=YTD&chart_frequency=monthly&contribution_dimension=asset_class"
-            "&attribution_dimension=asset_class&detail_basis=NET"
+            "&attribution_dimension=asset_class&detail_basis=NET&report_end_date=2026-04-10"
         ): (
             200,
             {
@@ -1241,8 +1327,56 @@ def test_front_office_seed_verification_counts_projected_transactions(monkeypatc
     assert verification["income_types"] == 2
     assert verification["activity_buckets"] == 3
     assert verification["positions_data_quality_status"] == "COMPLETE"
-    assert verification["pending_aggregation_jobs"] == 0
+    assert verification["pending_aggregation_jobs"] == 14
+    assert verification["processing_aggregation_jobs"] == 2
+    assert verification["failed_aggregation_jobs"] == 0
     assert any("include_projected=true" in url for url in requested_urls)
     assert all("income-summary/query" not in url for url in requested_urls)
     assert all("activity-summary/query" not in url for url in requested_urls)
+    assert any("report_end_date=2026-04-10" in url for url in requested_urls)
     assert gateway_header_calls == [FRONT_OFFICE_GATEWAY_CALLER_HEADERS]
+
+
+def test_front_office_readiness_blockers_surface_runtime_gaps() -> None:
+    blockers = _front_office_readiness_blockers(
+        {
+            "positions_data_quality_status": "COMPLETE",
+            "cash_data_quality_status": "STALE",
+            "pending_valuation_jobs": 3,
+            "processing_valuation_jobs": 0,
+            "pending_aggregation_jobs": 2,
+            "processing_aggregation_jobs": 1,
+            "stale_processing_aggregation_jobs": 1,
+            "failed_aggregation_jobs": 4,
+            "benchmark_code": None,
+            "analytics_performance_end_date": "2026-04-09",
+            "performance_report_end_date": "2026-04-10",
+            "return_path_latest_available_date": None,
+        },
+        expected_end_date="2026-04-10",
+    )
+
+    assert blockers == [
+        "cash_data_quality_not_complete",
+        "pending_valuation_jobs=3",
+        "stale_processing_aggregation_jobs=1",
+        "failed_aggregation_jobs=4",
+        "gateway_performance_benchmark_missing",
+        "core_analytics_reference_stale=2026-04-09",
+        "gateway_return_path_stale=missing",
+    ]
+
+
+def test_front_office_background_work_reports_non_blocking_aggregation_drain() -> None:
+    background = _front_office_background_work(
+        {
+            "pending_aggregation_jobs": 12,
+            "processing_aggregation_jobs": 3,
+            "failed_aggregation_jobs": 0,
+        }
+    )
+
+    assert background == [
+        "pending_aggregation_jobs=12",
+        "processing_aggregation_jobs=3",
+    ]

--- a/tools/front_office_portfolio_seed.py
+++ b/tools/front_office_portfolio_seed.py
@@ -258,6 +258,12 @@ def _calendar_dates(start: date, end: date) -> list[str]:
     return dates
 
 
+def _next_business_date(current: date) -> date:
+    while current.weekday() >= 5:
+        current += timedelta(days=1)
+    return current
+
+
 def _iso_utc_timestamp(day: date, hour: int = 21) -> str:
     return (
         datetime(day.year, day.month, day.day, hour=hour, tzinfo=UTC)
@@ -488,12 +494,18 @@ def build_front_office_portfolio_bundle(
     effective_benchmark_start = benchmark_start_date or start_date
     business_dates = _business_dates(start_date, end_date)
     calendar_dates = _calendar_dates(start_date, end_date)
-    fx_calendar_dates = _calendar_dates(start_date, end_date + timedelta(days=30))
     as_of_date = end_date.isoformat()
     forward_withdrawal_date = end_date + timedelta(days=7)
-    forward_withdrawal_settlement_date = end_date + timedelta(days=10)
+    forward_withdrawal_settlement_date = _next_business_date(end_date + timedelta(days=10))
     current_horizon_planned_withdrawal_date = end_date + timedelta(days=20)
-    current_horizon_planned_withdrawal_settlement_date = end_date + timedelta(days=36)
+    current_horizon_planned_withdrawal_settlement_date = _next_business_date(
+        end_date + timedelta(days=36)
+    )
+    forward_market_support_date = max(
+        end_date + timedelta(days=45),
+        current_horizon_planned_withdrawal_settlement_date,
+    )
+    fx_calendar_dates = _calendar_dates(start_date, forward_market_support_date)
 
     def tx_dt(day_offset: int, hour: int = 10) -> datetime:
         current = start_date + timedelta(days=day_offset)
@@ -1925,6 +1937,17 @@ def _reprocess_front_office_transactions(ingestion_base_url: str, bundle: dict[s
     )
 
 
+def _should_reprocess_after_ingest(
+    *,
+    should_ingest: bool,
+    reprocess_after_ingest: bool,
+    skip_reprocess: bool,
+) -> bool:
+    if skip_reprocess:
+        return False
+    return should_ingest and reprocess_after_ingest
+
+
 def _date_at_or_after(actual: str | None, expected: str) -> bool:
     if not actual:
         return False
@@ -1943,6 +1966,65 @@ def _front_office_analytics_are_fresh(
         and _date_at_or_after(performance_summary.get("report_end_date"), expected_end_date)
         and _date_at_or_after(return_path.get("latest_available_date"), expected_end_date)
     )
+
+
+def _front_office_readiness_blockers(
+    observation: dict[str, Any],
+    *,
+    expected_end_date: str,
+) -> list[str]:
+    blockers: list[str] = []
+    if observation.get("positions_data_quality_status") != "COMPLETE":
+        blockers.append("positions_data_quality_not_complete")
+    if observation.get("cash_data_quality_status") != "COMPLETE":
+        blockers.append("cash_data_quality_not_complete")
+
+    for field_name in (
+        "pending_valuation_jobs",
+        "processing_valuation_jobs",
+        "stale_processing_aggregation_jobs",
+        "failed_aggregation_jobs",
+    ):
+        job_count = int(observation.get(field_name) or 0)
+        if job_count:
+            blockers.append(f"{field_name}={job_count}")
+
+    if not observation.get("benchmark_code"):
+        blockers.append("gateway_performance_benchmark_missing")
+    if not _date_at_or_after(
+        observation.get("analytics_performance_end_date"), expected_end_date
+    ):
+        blockers.append(
+            "core_analytics_reference_stale="
+            f"{observation.get('analytics_performance_end_date') or 'missing'}"
+        )
+    if not _date_at_or_after(
+        observation.get("performance_report_end_date"), expected_end_date
+    ):
+        blockers.append(
+            "gateway_performance_report_stale="
+            f"{observation.get('performance_report_end_date') or 'missing'}"
+        )
+    if not _date_at_or_after(
+        observation.get("return_path_latest_available_date"), expected_end_date
+    ):
+        blockers.append(
+            "gateway_return_path_stale="
+            f"{observation.get('return_path_latest_available_date') or 'missing'}"
+        )
+    return blockers
+
+
+def _front_office_background_work(observation: dict[str, Any]) -> list[str]:
+    background: list[str] = []
+    for field_name in (
+        "pending_aggregation_jobs",
+        "processing_aggregation_jobs",
+    ):
+        job_count = int(observation.get(field_name) or 0)
+        if job_count:
+            background.append(f"{field_name}={job_count}")
+    return background
 
 
 def _extract_readiness_summary(readiness_payload: dict[str, Any]) -> dict[str, Any]:
@@ -2050,26 +2132,39 @@ def _cleanup_existing_front_office_seed(
     postgres_container: str,
     portfolio_id: str,
     benchmark_id: str,
+    max_attempts: int = 3,
 ) -> None:
     sql = build_front_office_seed_cleanup_sql(
         portfolio_id=portfolio_id,
         benchmark_id=benchmark_id,
     )
-    subprocess.run(
-        [
-            "docker",
-            "exec",
-            postgres_container,
-            "psql",
-            "-U",
-            "user",
-            "-d",
-            "portfolio_db",
-            "-c",
-            sql,
-        ],
-        check=True,
-    )
+    command = [
+        "docker",
+        "exec",
+        postgres_container,
+        "psql",
+        "-U",
+        "user",
+        "-d",
+        "portfolio_db",
+        "-c",
+        sql,
+    ]
+    for attempt in range(1, max_attempts + 1):
+        try:
+            subprocess.run(command, check=True)
+            return
+        except subprocess.CalledProcessError:
+            if attempt >= max_attempts:
+                raise
+            LOGGER.warning(
+                "Front-office seed cleanup hit a transient database conflict for %s; "
+                "retrying attempt %s of %s.",
+                portfolio_id,
+                attempt + 1,
+                max_attempts,
+            )
+            time.sleep(attempt * 2)
 
 
 def _verify_front_office_portfolio(
@@ -2085,6 +2180,8 @@ def _verify_front_office_portfolio(
 ) -> dict[str, Any]:
     deadline = datetime.now(tz=UTC) + timedelta(seconds=wait_seconds)
     last_observation: dict[str, Any] | None = None
+    last_logged_blockers: tuple[str, ...] | None = None
+    last_logged_at: datetime | None = None
     while datetime.now(tz=UTC) < deadline:
         try:
             _, positions_payload = _request_json(
@@ -2135,7 +2232,7 @@ def _verify_front_office_portfolio(
                 "GET",
                 f"{gateway_base_url}/api/v1/workbench/{expected.portfolio_id}/performance/summary"
                 f"?period=YTD&chart_frequency=monthly&contribution_dimension=asset_class"
-                f"&attribution_dimension=asset_class&detail_basis=NET",
+                f"&attribution_dimension=asset_class&detail_basis=NET&report_end_date={end_date}",
                 headers=FRONT_OFFICE_GATEWAY_CALLER_HEADERS,
             )
         except RuntimeError as exc:
@@ -2180,6 +2277,10 @@ def _verify_front_office_portfolio(
             "processing_valuation_jobs": support_overview.get("processing_valuation_jobs"),
             "pending_aggregation_jobs": support_overview.get("pending_aggregation_jobs"),
             "processing_aggregation_jobs": support_overview.get("processing_aggregation_jobs"),
+            "stale_processing_aggregation_jobs": support_overview.get(
+                "stale_processing_aggregation_jobs"
+            ),
+            "failed_aggregation_jobs": support_overview.get("failed_aggregation_jobs"),
             "benchmark_code": performance_summary.get("benchmark_code"),
             "analytics_performance_end_date": analytics_reference.get("performance_end_date"),
             "performance_report_end_date": performance_summary.get("report_end_date"),
@@ -2204,8 +2305,8 @@ def _verify_front_office_portfolio(
             and cash_payload.get("data_quality_status") == "COMPLETE"
             and int(support_overview.get("pending_valuation_jobs") or 0) == 0
             and int(support_overview.get("processing_valuation_jobs") or 0) == 0
-            and int(support_overview.get("pending_aggregation_jobs") or 0) == 0
-            and int(support_overview.get("processing_aggregation_jobs") or 0) == 0
+            and int(support_overview.get("stale_processing_aggregation_jobs") or 0) == 0
+            and int(support_overview.get("failed_aggregation_jobs") or 0) == 0
             and benchmark_assignment.get("benchmark_id")
             and performance_summary.get("benchmark_code")
             and _front_office_analytics_are_fresh(
@@ -2228,6 +2329,10 @@ def _verify_front_office_portfolio(
                 "processing_valuation_jobs": support_overview.get("processing_valuation_jobs"),
                 "pending_aggregation_jobs": support_overview.get("pending_aggregation_jobs"),
                 "processing_aggregation_jobs": support_overview.get("processing_aggregation_jobs"),
+                "stale_processing_aggregation_jobs": support_overview.get(
+                    "stale_processing_aggregation_jobs"
+                ),
+                "failed_aggregation_jobs": support_overview.get("failed_aggregation_jobs"),
                 "positions_data_quality_status": positions_payload.get("data_quality_status"),
                 "cash_data_quality_status": cash_payload.get("data_quality_status"),
                 "benchmark_code": performance_summary.get("benchmark_code"),
@@ -2240,11 +2345,33 @@ def _verify_front_office_portfolio(
                 ),
             }
 
-        LOGGER.info(
-            "Front-office verification waiting on readiness for %s: %s",
-            expected.portfolio_id,
+        blockers = _front_office_readiness_blockers(
             last_observation,
+            expected_end_date=end_date,
         )
+        background_work = _front_office_background_work(last_observation)
+        blocker_categories = tuple(blocker.split("=", maxsplit=1)[0] for blocker in blockers)
+        logged_blocker_categories = (
+            tuple(blocker.split("=", maxsplit=1)[0] for blocker in last_logged_blockers)
+            if last_logged_blockers is not None
+            else None
+        )
+        now = datetime.now(tz=UTC)
+        if (
+            blocker_categories != logged_blocker_categories
+            or last_logged_at is None
+            or (now - last_logged_at) >= timedelta(seconds=30)
+        ):
+            LOGGER.info(
+                "Front-office verification waiting on readiness for %s: blockers=%s "
+                "background_work=%s observation=%s",
+                expected.portfolio_id,
+                blockers,
+                background_work,
+                last_observation,
+            )
+            last_logged_blockers = tuple(blockers)
+            last_logged_at = now
 
     readiness_diagnostics = _collect_front_office_readiness_diagnostics(
         query_control_plane_base_url=query_control_plane_base_url,
@@ -2285,7 +2412,18 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--skip-reprocess",
         action="store_true",
-        help="Do not queue transaction reprocessing after bundle ingest.",
+        help=(
+            "Deprecated compatibility flag. Transaction reprocessing is no longer queued after "
+            "canonical clean ingest unless --reprocess-after-ingest is supplied."
+        ),
+    )
+    parser.add_argument(
+        "--reprocess-after-ingest",
+        action="store_true",
+        help=(
+            "Queue transaction reprocessing after ingest for deliberate recovery proof. "
+            "Do not use for normal clean canonical bootstrap because it replays late data."
+        ),
     )
     parser.add_argument("--log-level", default="INFO")
     return parser.parse_args()
@@ -2341,7 +2479,11 @@ def main() -> int:
                 poll_interval_seconds=args.poll_interval_seconds,
             )
         _ingest_reference_data(ingestion_base_url, bundle)
-        if should_ingest and not args.skip_reprocess:
+        if _should_reprocess_after_ingest(
+            should_ingest=should_ingest,
+            reprocess_after_ingest=args.reprocess_after_ingest,
+            skip_reprocess=args.skip_reprocess,
+        ):
             _reprocess_front_office_transactions(ingestion_base_url, bundle)
 
     if not args.ingest_only:

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -40,7 +40,9 @@ Current router groups inside `query_control_plane_service` are:
   requests
 - `analytics_inputs`
   portfolio and position analytics timeseries, analytics reference metadata, and durable export-job
-  lifecycle
+  lifecycle. The analytics reference `performance_end_date` is the latest complete performance
+  horizon across required portfolio and position analytics source families, bounded by the requested
+  as-of date.
 - `capabilities`
   tenant- and consumer-aware capability discovery, including the
   `core.observability.portfolio_supportability` feature flag for Gateway, Workbench, and downstream

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -88,6 +88,14 @@ and the current Workbench forward-liquidity horizon. After reseeding, `Portfolio
 should show at least one non-zero point for the canonical window and one non-zero current-horizon
 planned settlement point.
 
+Projected settlements in the canonical seed must land on business days and must be covered by the
+required FX pairs through the latest projected settlement date. Benchmark and FX reference coverage
+extends through at least 45 calendar days after the canonical as-of date, and through any later
+projected settlement date, so current-date Gateway and Workbench probes do not degrade on missing
+reference series. The current raw `market_prices` and `fx_rates` contracts are point-in-time
+series; when those contracts move to effective-date ranges, open-ended terminal price/rate validity
+should use `3999-12-31` explicitly.
+
 ## Startup checks
 
 When app-local runtime is unhealthy, check this order:

--- a/wiki/Query-Control-Plane.md
+++ b/wiki/Query-Control-Plane.md
@@ -144,6 +144,11 @@ Use this grouping when deciding where a new consumer should bind:
 - analytics inputs and export jobs
   portfolio timeseries, position timeseries, analytics reference, and
   `/integration/exports/analytics-timeseries/jobs...`
+
+`PortfolioAnalyticsReference.performance_end_date` is the latest complete performance horizon
+where required portfolio and position analytics source families overlap. It is bounded by the
+requested `as_of_date` and must not advertise a newer isolated source date that downstream
+performance analytics cannot calculate.
 - support and lineage
   `/support/...` and `/lineage/...`
 - simulation lifecycle


### PR DESCRIPTION
## Summary
- Extend canonical front-office seed/reference coverage so analytics readiness has complete overlap for portfolio and position analytics source families.
- Harden analytics reference `performance_end_date` selection to use the latest complete supported overlap.
- Update seed/runbook/wiki truth for forward market support dates and effective-ranged rate/price guidance.

## Evidence
- `python -m pytest tests\unit\tools\test_front_office_portfolio_seed.py -q` -> 53 passed
- `python -m ruff check tools\front_office_portfolio_seed.py tests\unit\tools\test_front_office_portfolio_seed.py` -> passed
- Broader targeted core seed/query tests earlier in the slice -> 147 passed
- Live seed completed for `PB_SG_GLOBAL_BAL_001`; benchmark/index coverage verified to 2026-05-25 with performance/report end 2026-04-10