### PR TITLE
ci: make institutional completion opt in

### DIFF
--- a/.github/workflows/main-releasability.yml
+++ b/.github/workflows/main-releasability.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: ["main"]
   workflow_dispatch:
+    inputs:
+      run_institutional_completion:
+        description: "Run the approval-grade 1000-portfolio institutional completion and sign-off jobs."
+        required: false
+        default: false
+        type: boolean
   schedule:
     - cron: "0 2 * * *"
 
@@ -420,10 +426,11 @@ jobs:
 
   institutional-completion-gate:
     name: Main Releasability / Institutional Completion Gate
-    # This approval-grade 100k-transaction bank-day run is intentionally kept
-    # off every main push. It remains available for scheduled and manual
-    # release-readiness validation without blocking routine post-merge health.
-    if: github.event_name != 'push'
+    # This approval-grade 1000-portfolio / 100k-transaction bank-day run is
+    # intentionally opt-in. The faster main releasability gates remain the
+    # routine post-merge signal; release candidates can enable this input when
+    # institutional sign-off evidence is explicitly required.
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_institutional_completion }}
     needs: [coverage-gate, failure-recovery-gate]
     runs-on: ubuntu-latest
     timeout-minutes: 180
@@ -465,7 +472,7 @@ jobs:
 
   institutional-signoff-pack:
     name: Main Releasability / Institutional Sign-Off Pack
-    if: github.event_name != 'push'
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_institutional_completion }}
     needs:
       [docker-smoke-contract, latency-gate, performance-load-gate, failure-recovery-gate, institutional-completion-gate]
     runs-on: ubuntu-latest

--- a/docs/operations/Institutional-Signoff-Runbook.md
+++ b/docs/operations/Institutional-Signoff-Runbook.md
@@ -34,18 +34,19 @@ reconciliation for the exact generated `run_id`, producing both:
 2. `output/task-runs/*-bank-day-load-reconciliation.json|md`
 
 ## CI Enforcement
-1. GitHub Actions job `Institutional Sign-Off Pack` runs on:
-   1. scheduled pipelines,
-   2. manual workflow dispatch.
+1. GitHub Actions job `Institutional Sign-Off Pack` runs only when the
+   `Main Releasability Gate` workflow is manually dispatched with
+   `run_institutional_completion=true`.
 2. The job is a required production-readiness gate and fails when:
    1. any required artifact is missing,
    2. any gate status is failed,
    3. any required artifact is older than 24 hours (`--max-age-hours 24`).
-3. The scheduled/manual main releasability workflow generates RFC-086 completion evidence through
+3. The opt-in manual main releasability workflow generates RFC-086 completion evidence through
    `Main Releasability / Institutional Completion Gate` before sign-off aggregation.
-4. Routine `main` push runs intentionally skip the approval-grade institutional completion and
-   sign-off jobs so post-merge health remains governed by the faster release gates. Use a scheduled
-   or manually dispatched run for institutional release evidence.
+4. Routine `main` push, scheduled, and default manual runs intentionally skip the approval-grade
+   1000-portfolio institutional completion and sign-off jobs so post-merge health remains governed
+   by the faster release gates. Use a manually dispatched run with
+   `run_institutional_completion=true` for institutional release evidence.
 
 ## Go-Live Checklist
 All items must be `yes`:

--- a/tests/unit/test_main_releasability_workflow.py
+++ b/tests/unit/test_main_releasability_workflow.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+WORKFLOW_PATH = Path(".github/workflows/main-releasability.yml")
+
+
+def test_institutional_completion_gate_is_manual_opt_in() -> None:
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "run_institutional_completion:" in workflow
+    assert (
+        'description: "Run the approval-grade 1000-portfolio institutional completion '
+        'and sign-off jobs."'
+    ) in workflow
+    assert "default: false" in workflow
+    assert "type: boolean" in workflow
+    assert (
+        "if: ${{ github.event_name == 'workflow_dispatch' "
+        "&& inputs.run_institutional_completion }}"
+    ) in workflow
+
+
+def test_institutional_completion_is_not_default_schedule_or_push_truth() -> None:
+    runbook = Path("docs/operations/Institutional-Signoff-Runbook.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "run_institutional_completion=true" in runbook
+    assert "Routine `main` push, scheduled, and default manual runs intentionally skip" in runbook
+    assert "1000-portfolio institutional completion" in runbook


### PR DESCRIPTION
## Summary
- make the approval-grade 1000-portfolio / 100k-transaction institutional completion gate opt-in for manual Main Releasability runs
- keep routine push, scheduled, and default manual Main Releasability runs on the faster release gates
- update the institutional sign-off runbook and add regression tests for the workflow/runbook truth

## Validation
- python -m pytest tests/unit/test_main_releasability_workflow.py tests/unit/scripts/test_institutional_completion_gate.py -q
- python -m ruff check tests/unit/test_main_releasability_workflow.py scripts/institutional_completion_gate.py
- make lint
- git diff --check

## Notes
- The 1000-portfolio institutional completion test is not deleted. It remains available when manually dispatching Main Releasability with `run_institutional_completion=true`.
- This avoids default manual/scheduled runs being blocked by the long RFC-086 approval-grade scenario while preserving explicit release evidence when required.