### PR TITLE
Harden canonical seed HTTP retries

### DIFF
--- a/tests/integration/tools/test_demo_data_pack.py
+++ b/tests/integration/tools/test_demo_data_pack.py
@@ -1,3 +1,7 @@
+import http.client
+
+import pytest
+
 from tools import demo_data_pack
 
 
@@ -85,3 +89,13 @@ def test_all_demo_portfolios_exist_checks_every_expected_portfolio(monkeypatch):
 
     assert demo_data_pack._all_demo_portfolios_exist("http://query") is True
     assert set(seen) == {item.portfolio_id for item in demo_data_pack.DEMO_EXPECTATIONS}
+
+
+def test_request_json_treats_remote_disconnect_as_retryable_connection_error(monkeypatch):
+    def disconnecting_urlopen(*_args, **_kwargs):
+        raise http.client.RemoteDisconnected("closed without response")
+
+    monkeypatch.setattr(demo_data_pack.request, "urlopen", disconnecting_urlopen)
+
+    with pytest.raises(RuntimeError, match="GET http://query.dev/health connection error"):
+        demo_data_pack._request_json("GET", "http://query.dev/health")

--- a/tools/demo_data_pack.py
+++ b/tools/demo_data_pack.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import http.client
 import json
 import logging
 import math
@@ -1159,7 +1160,7 @@ def _request_json(
     except error.HTTPError as exc:
         detail = exc.read().decode("utf-8", errors="replace")
         raise RuntimeError(f"{method} {url} failed ({exc.code}): {detail}") from exc
-    except error.URLError as exc:
+    except (error.URLError, http.client.RemoteDisconnected, TimeoutError, ConnectionError) as exc:
         raise RuntimeError(f"{method} {url} connection error: {exc}") from exc
 
 


### PR DESCRIPTION
## Summary
- Treat transient remote disconnects and connection close/timeout errors from the demo seed HTTP helper as retryable connection errors.
- Add regression coverage proving a remote disconnect is normalized to the verifier retry path.

## Evidence
- Static: `make lint` passed.
- Tests: `python -m pytest tests/integration/tools/test_demo_data_pack.py tests/unit/tools/test_front_office_portfolio_seed.py -q` passed (`60 passed`).

## Runtime context
- Discovered while continuing RFC-0024 canonical front-office validation for `PB_SG_GLOBAL_BAL_001`.
- The live run still has separate Core readiness/backlog blockers; this PR only prevents transient HTTP disconnects from aborting the governed seed verifier before it can keep polling and report readiness evidence.

## Docs / wiki
- No wiki source update required: this is a seed-tool reliability hardening change and does not change product contracts, operator runbooks, or durable repository truth.

## Tiering
- Repository profile: Domain API / source-data platform.
- PR-blocking scope: static quality and targeted seed-tool tests; no API/schema/contract changes.