### PR TITLE
Normalize DPM universe booking-center scope

### DIFF
--- a/src/services/query_service/app/services/integration_service.py
+++ b/src/services/query_service/app/services/integration_service.py
@@ -756,6 +756,11 @@ class IntegrationService:
         self,
         request: DpmPortfolioUniverseCandidateRequest,
     ) -> DpmPortfolioUniverseCandidateResponse:
+        booking_center_code = (
+            request.booking_center_code.strip() if request.booking_center_code else None
+        )
+        if booking_center_code == "":
+            booking_center_code = None
         model_portfolio_ids = sorted(
             {
                 model_portfolio_id.strip()
@@ -767,7 +772,7 @@ class IntegrationService:
             {
                 "product_name": "DpmPortfolioUniverseCandidate",
                 "as_of_date": request.as_of_date.isoformat(),
-                "booking_center_code": request.booking_center_code,
+                "booking_center_code": booking_center_code,
                 "model_portfolio_ids": model_portfolio_ids,
                 "include_inactive_mandates": request.include_inactive_mandates,
                 "tenant_id": request.tenant_id,
@@ -784,7 +789,7 @@ class IntegrationService:
 
         rows = await self._reference_repository.list_dpm_portfolio_universe_candidates(
             as_of_date=request.as_of_date,
-            booking_center_code=request.booking_center_code,
+            booking_center_code=booking_center_code,
             model_portfolio_ids=model_portfolio_ids,
             include_inactive_mandates=request.include_inactive_mandates,
             after_sort_key=after_sort_key,
@@ -825,7 +830,7 @@ class IntegrationService:
             )
 
         filters_applied = ["as_of_date"]
-        if request.booking_center_code:
+        if booking_center_code:
             filters_applied.append("booking_center_code")
         if model_portfolio_ids:
             filters_applied.append("model_portfolio_ids")

--- a/tests/unit/services/query_service/services/test_integration_service.py
+++ b/tests/unit/services/query_service/services/test_integration_service.py
@@ -435,6 +435,56 @@ async def test_resolve_dpm_portfolio_universe_candidates_returns_paged_degraded_
 
 
 @pytest.mark.asyncio
+async def test_resolve_dpm_portfolio_universe_candidates_normalizes_booking_center_scope():
+    service = make_service()
+    service._reference_repository = AsyncMock()  # pylint: disable=protected-access
+    service._reference_repository.list_dpm_portfolio_universe_candidates.return_value = []  # type: ignore[attr-defined] # pylint: disable=line-too-long
+    request = DpmPortfolioUniverseCandidateRequest(
+        as_of_date=date(2026, 5, 3),
+        tenant_id="default",
+        booking_center_code="  Singapore  ",
+    )
+
+    await service.resolve_dpm_portfolio_universe_candidates(request)
+
+    service._reference_repository.list_dpm_portfolio_universe_candidates.assert_awaited_once_with(  # type: ignore[attr-defined] # pylint: disable=protected-access
+        as_of_date=date(2026, 5, 3),
+        booking_center_code="Singapore",
+        model_portfolio_ids=[],
+        include_inactive_mandates=False,
+        after_sort_key=None,
+        limit=251,
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_dpm_portfolio_universe_candidates_ignores_blank_booking_center_scope():
+    service = make_service()
+    service._reference_repository = AsyncMock()  # pylint: disable=protected-access
+    service._reference_repository.list_dpm_portfolio_universe_candidates.return_value = []  # type: ignore[attr-defined] # pylint: disable=line-too-long
+    request = DpmPortfolioUniverseCandidateRequest(
+        as_of_date=date(2026, 5, 3),
+        tenant_id="default",
+        booking_center_code="   ",
+    )
+
+    response = await service.resolve_dpm_portfolio_universe_candidates(request)
+
+    service._reference_repository.list_dpm_portfolio_universe_candidates.assert_awaited_once_with(  # type: ignore[attr-defined] # pylint: disable=protected-access
+        as_of_date=date(2026, 5, 3),
+        booking_center_code=None,
+        model_portfolio_ids=[],
+        include_inactive_mandates=False,
+        after_sort_key=None,
+        limit=251,
+    )
+    assert response.supportability.filters_applied == [
+        "as_of_date",
+        "active_discretionary_authority",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_resolve_dpm_portfolio_universe_candidates_accepts_scoped_page_token():
     service = make_service()
     service._reference_repository = AsyncMock()  # pylint: disable=protected-access


### PR DESCRIPTION
## Summary
- normalize DPM portfolio-universe booking-center filters before request fingerprinting and repository lookup
- treat blank booking-center filters as absent so source-owned candidate discovery does not fail closed on whitespace-only input
- add focused service tests for trimmed and blank booking-center scope

## Boundaries
- no global portfolio-universe ownership claim
- no relationship householding, suitability, PM ranking, execution, client-contact, or OMS claim

## Validation
- python -m pytest tests/unit/services/query_service/services/test_integration_service.py -q
- git diff --check
- make lint