### PR TITLE
Preserve richer benchmark seed cleanup

### DIFF
--- a/src/libs/portfolio-common/portfolio_common/health.py
+++ b/src/libs/portfolio-common/portfolio_common/health.py
@@ -1,6 +1,7 @@
 # src/libs/portfolio-common/portfolio_common/health.py
 import asyncio
 import logging
+import time
 from typing import Awaitable, Callable
 
 from confluent_kafka.admin import AdminClient
@@ -65,13 +66,19 @@ async def check_kafka_health() -> bool:
         return False
 
 
-def create_health_router(*dependencies: str) -> APIRouter:
+def create_health_router(
+    *dependencies: str,
+    readiness_cache_ttl_seconds: float = 5.0,
+) -> APIRouter:
     """
     Creates a standardized health check router.
 
     Args:
         *dependencies: A list of strings ('db', 'kafka') specifying which
                        dependencies to check for the readiness probe.
+        readiness_cache_ttl_seconds: Per-process cache duration for dependency
+                       readiness results. Keeps probe storms from repeatedly
+                       forcing expensive dependency metadata checks.
 
     Returns:
         A FastAPI APIRouter with /live and /ready endpoints.
@@ -79,6 +86,10 @@ def create_health_router(*dependencies: str) -> APIRouter:
     router = APIRouter(tags=["Health"])
 
     dep_map = {"db": ("database", check_db_health), "kafka": ("kafka", check_kafka_health)}
+    readiness_cache_ttl_seconds = max(0.0, readiness_cache_ttl_seconds)
+    cached_until = 0.0
+    cached_all_ok = False
+    cached_dep_status: dict[str, str] | None = None
 
     @router.get(
         "/health/live",
@@ -127,17 +138,32 @@ def create_health_router(*dependencies: str) -> APIRouter:
         },
     )
     async def readiness_probe():
+        nonlocal cached_all_ok, cached_dep_status, cached_until
+
         resolved_dependencies = [
             (dep_map[dep][0], dep_map[dep][1]) for dep in dependencies if dep in dep_map
         ]
-        results = await asyncio.gather(*[check() for _, check in resolved_dependencies])
+        now = time.monotonic()
+        if (
+            readiness_cache_ttl_seconds > 0
+            and cached_dep_status is not None
+            and now < cached_until
+        ):
+            all_ok = cached_all_ok
+            dep_status = dict(cached_dep_status)
+        else:
+            results = await asyncio.gather(*[check() for _, check in resolved_dependencies])
 
-        all_ok = all(results)
+            all_ok = all(results)
 
-        dep_status = {
-            dependency_name: "ok" if results[i] else "unavailable"
-            for i, (dependency_name, _) in enumerate(resolved_dependencies)
-        }
+            dep_status = {
+                dependency_name: "ok" if results[i] else "unavailable"
+                for i, (dependency_name, _) in enumerate(resolved_dependencies)
+            }
+            if readiness_cache_ttl_seconds > 0:
+                cached_all_ok = all_ok
+                cached_dep_status = dict(dep_status)
+                cached_until = time.monotonic() + readiness_cache_ttl_seconds
 
         if all_ok:
             return {"status": "ready", "dependencies": dep_status}

--- a/src/services/query_service/app/services/integration_service.py
+++ b/src/services/query_service/app/services/integration_service.py
@@ -6,6 +6,7 @@ import logging
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
+from types import SimpleNamespace
 from typing import Any, Literal
 
 from portfolio_common.market_reference_quality import (
@@ -266,6 +267,81 @@ class IntegrationService:
     def _request_fingerprint(payload: dict[str, Any]) -> str:
         serialized = json.dumps(payload, sort_keys=True, separators=(",", ":"))
         return hashlib.md5(serialized.encode("utf-8")).hexdigest()  # nosec B324
+
+    @staticmethod
+    def _latest_effective_records(
+        rows: list[Any],
+        *,
+        key_fields: tuple[str, ...],
+        effective_from_field: str,
+    ) -> list[Any]:
+        latest_by_key: dict[tuple[Any, ...], Any] = {}
+        for row in sorted(
+            rows,
+            key=lambda item: (
+                *[getattr(item, field) for field in key_fields],
+                getattr(item, effective_from_field),
+            ),
+            reverse=True,
+        ):
+            record_key = tuple(getattr(row, field) for field in key_fields)
+            latest_by_key.setdefault(record_key, row)
+        return sorted(
+            latest_by_key.values(),
+            key=lambda item: tuple(getattr(item, field) for field in key_fields),
+        )
+
+    @staticmethod
+    def _resolve_component_window_rows(
+        rows: list[Any],
+        *,
+        start_date: date,
+        end_date: date,
+    ) -> list[Any]:
+        rows_by_index: dict[str, list[Any]] = {}
+        for row in rows:
+            rows_by_index.setdefault(row.index_id, []).append(row)
+
+        resolved_rows: list[Any] = []
+        for index_id, index_rows in rows_by_index.items():
+            sorted_rows = sorted(
+                index_rows,
+                key=lambda item: item.composition_effective_from,
+            )
+            for position, row in enumerate(sorted_rows):
+                next_start = (
+                    sorted_rows[position + 1].composition_effective_from
+                    if position + 1 < len(sorted_rows)
+                    else None
+                )
+                resolved_end = row.composition_effective_to
+                if next_start is not None:
+                    inferred_end = next_start - timedelta(days=1)
+                    if resolved_end is None or resolved_end >= next_start:
+                        resolved_end = inferred_end
+                    else:
+                        resolved_end = min(resolved_end, inferred_end)
+                if row.composition_effective_from > end_date:
+                    continue
+                if resolved_end is not None and resolved_end < start_date:
+                    continue
+                resolved_rows.append(
+                    SimpleNamespace(
+                        index_id=index_id,
+                        composition_weight=row.composition_weight,
+                        composition_effective_from=row.composition_effective_from,
+                        composition_effective_to=resolved_end,
+                        rebalance_event_id=getattr(row, "rebalance_event_id", None),
+                        quality_status=getattr(row, "quality_status", None),
+                        source_timestamp=getattr(row, "source_timestamp", None),
+                        observed_at=getattr(row, "observed_at", None),
+                        updated_at=getattr(row, "updated_at", None),
+                    )
+                )
+        return sorted(
+            resolved_rows,
+            key=lambda item: (item.composition_effective_from, item.index_id),
+        )
 
     @staticmethod
     def _series_request_fingerprint(
@@ -2942,9 +3018,13 @@ class IntegrationService:
         row = await self._reference_repository.get_benchmark_definition(benchmark_id, as_of_date)
         if row is None:
             return None
-        components = await self._reference_repository.list_benchmark_components(
-            benchmark_id,
-            as_of_date,
+        components = self._latest_effective_records(
+            await self._reference_repository.list_benchmark_components(
+                benchmark_id,
+                as_of_date,
+            ),
+            key_fields=("index_id",),
+            effective_from_field="composition_effective_from",
         )
         return BenchmarkDefinitionResponse(
             benchmark_id=row.benchmark_id,
@@ -2981,24 +3061,33 @@ class IntegrationService:
         benchmark_id: str,
         request: BenchmarkCompositionWindowRequest,
     ) -> BenchmarkCompositionWindowResponse | None:
-        definitions = (
+        definition_rows = (
             await self._reference_repository.list_benchmark_definitions_overlapping_window(
                 benchmark_id=benchmark_id,
                 start_date=request.window.start_date,
                 end_date=request.window.end_date,
             )
         )
-        if not definitions:
+        if not definition_rows:
             return None
 
-        benchmark_currencies = {row.benchmark_currency for row in definitions}
+        benchmark_currencies = {row.benchmark_currency for row in definition_rows}
         if len(benchmark_currencies) != 1:
             raise ValueError(
                 "Benchmark definition currency changed within requested composition window."
             )
+        definitions = self._latest_effective_records(
+            definition_rows,
+            key_fields=("benchmark_id",),
+            effective_from_field="effective_from",
+        )
 
-        components = await self._reference_repository.list_benchmark_components_overlapping_window(
-            benchmark_id=benchmark_id,
+        components = self._resolve_component_window_rows(
+            await self._reference_repository.list_benchmark_components_overlapping_window(
+                benchmark_id=benchmark_id,
+                start_date=request.window.start_date,
+                end_date=request.window.end_date,
+            ),
             start_date=request.window.start_date,
             end_date=request.window.end_date,
         )
@@ -3043,11 +3132,15 @@ class IntegrationService:
         benchmark_currency: str | None,
         benchmark_status: str | None,
     ) -> BenchmarkCatalogResponse:
-        rows = await self._reference_repository.list_benchmark_definitions(
-            as_of_date=as_of_date,
-            benchmark_type=benchmark_type,
-            benchmark_currency=benchmark_currency,
-            benchmark_status=benchmark_status,
+        rows = self._latest_effective_records(
+            await self._reference_repository.list_benchmark_definitions(
+                as_of_date=as_of_date,
+                benchmark_type=benchmark_type,
+                benchmark_currency=benchmark_currency,
+                benchmark_status=benchmark_status,
+            ),
+            key_fields=("benchmark_id",),
+            effective_from_field="effective_from",
         )
         components_by_benchmark = (
             await self._reference_repository.list_benchmark_components_for_benchmarks(
@@ -3057,7 +3150,11 @@ class IntegrationService:
         )
         records: list[BenchmarkDefinitionResponse] = []
         for row in rows:
-            components = components_by_benchmark.get(row.benchmark_id, [])
+            components = self._latest_effective_records(
+                components_by_benchmark.get(row.benchmark_id, []),
+                key_fields=("index_id",),
+                effective_from_field="composition_effective_from",
+            )
             records.append(
                 BenchmarkDefinitionResponse(
                     benchmark_id=row.benchmark_id,
@@ -3142,8 +3239,12 @@ class IntegrationService:
         benchmark_currency = (
             definition.benchmark_currency if definition else (request.target_currency or "UNKNOWN")
         )
-        components = await self._reference_repository.list_benchmark_components_overlapping_window(
-            benchmark_id=benchmark_id,
+        components = self._resolve_component_window_rows(
+            await self._reference_repository.list_benchmark_components_overlapping_window(
+                benchmark_id=benchmark_id,
+                start_date=request.window.start_date,
+                end_date=request.window.end_date,
+            ),
             start_date=request.window.start_date,
             end_date=request.window.end_date,
         )

--- a/tests/integration/tools/test_demo_data_pack.py
+++ b/tests/integration/tools/test_demo_data_pack.py
@@ -31,16 +31,24 @@ def test_build_demo_bundle_contains_benchmark_seed_data():
         bundle["benchmark_verification"]["portfolio_id"]
         == demo_data_pack.DEFAULT_DEMO_BENCHMARK_PORTFOLIO_ID
     )
+    assert bundle["benchmark_verification"]["catalog_benchmark_ids"] == [
+        demo_data_pack.DEFAULT_DEMO_BENCHMARK_ID,
+        demo_data_pack.SECONDARY_DEMO_BENCHMARK_ID,
+    ]
     assert len(bundle["benchmark_assignments"]) == 1
-    assert len(bundle["benchmark_definitions"]) == 1
-    assert len(bundle["benchmark_compositions"]) == 2
+    assert len(bundle["benchmark_definitions"]) == 2
+    assert len(bundle["benchmark_compositions"]) == 4
     assert len(bundle["indices"]) == 2
     assert len(bundle["index_price_series"]) > len(bundle["business_dates"]) * 2
     assert len(bundle["index_return_series"]) > len(bundle["business_dates"]) * 2
-    assert len(bundle["benchmark_return_series"]) > len(bundle["business_dates"])
+    assert len(bundle["benchmark_return_series"]) > len(bundle["business_dates"]) * 2
+    assert {definition["benchmark_id"] for definition in bundle["benchmark_definitions"]} == {
+        demo_data_pack.DEFAULT_DEMO_BENCHMARK_ID,
+        demo_data_pack.SECONDARY_DEMO_BENCHMARK_ID,
+    }
     assert {
         composition["composition_weight"] for composition in bundle["benchmark_compositions"]
-    } == {"0.6000000000", "0.4000000000"}
+    } == {"0.6000000000", "0.4000000000", "0.8000000000", "0.2000000000"}
     sector_by_index = {
         index["index_id"]: index["classification_labels"].get("sector")
         for index in bundle["indices"]

--- a/tests/unit/libs/portfolio-common/test_health.py
+++ b/tests/unit/libs/portfolio-common/test_health.py
@@ -43,3 +43,53 @@ async def test_readiness_probe_returns_ready_for_known_dependencies_only():
     response = await readiness_probe()
 
     assert response == {"status": "ready", "dependencies": {}}
+
+
+async def test_readiness_probe_caches_dependency_results_within_ttl(monkeypatch):
+    calls = 0
+    now = 100.0
+
+    async def _db_ok():
+        nonlocal calls
+        calls += 1
+        return True
+
+    monkeypatch.setattr(health_module, "check_db_health", _db_ok)
+    monkeypatch.setattr(health_module.time, "monotonic", lambda: now)
+
+    router = health_module.create_health_router("db", readiness_cache_ttl_seconds=5.0)
+    readiness_probe = next(
+        route.endpoint for route in router.routes if route.path == "/health/ready"
+    )
+
+    assert await readiness_probe() == {"status": "ready", "dependencies": {"database": "ok"}}
+    assert await readiness_probe() == {"status": "ready", "dependencies": {"database": "ok"}}
+
+    assert calls == 1
+
+
+async def test_readiness_probe_rechecks_dependencies_after_ttl(monkeypatch):
+    calls = 0
+    now = 100.0
+
+    async def _db_ok():
+        nonlocal calls
+        calls += 1
+        return True
+
+    def _monotonic():
+        return now
+
+    monkeypatch.setattr(health_module, "check_db_health", _db_ok)
+    monkeypatch.setattr(health_module.time, "monotonic", _monotonic)
+
+    router = health_module.create_health_router("db", readiness_cache_ttl_seconds=5.0)
+    readiness_probe = next(
+        route.endpoint for route in router.routes if route.path == "/health/ready"
+    )
+
+    await readiness_probe()
+    now = 106.0
+    await readiness_probe()
+
+    assert calls == 2

--- a/tests/unit/services/query_service/services/test_integration_service.py
+++ b/tests/unit/services/query_service/services/test_integration_service.py
@@ -8,6 +8,7 @@ from portfolio_common.reconciliation_quality import BLOCKED, COMPLETE, PARTIAL, 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.services.query_service.app.dtos.reference_integration_dto import (
+    BenchmarkCompositionWindowRequest,
     CioModelChangeAffectedCohortRequest,
     ClientIncomeNeedsScheduleRequest,
     ClientRestrictionProfileRequest,
@@ -2730,8 +2731,16 @@ async def test_benchmark_composition_window_rejects_currency_changes_within_wind
     service._reference_repository = SimpleNamespace(  # type: ignore[assignment]
         list_benchmark_definitions_overlapping_window=AsyncMock(
             return_value=[
-                SimpleNamespace(benchmark_currency="USD"),
-                SimpleNamespace(benchmark_currency="EUR"),
+                SimpleNamespace(
+                    benchmark_id="B1",
+                    benchmark_currency="USD",
+                    effective_from=date(2026, 1, 1),
+                ),
+                SimpleNamespace(
+                    benchmark_id="B1",
+                    benchmark_currency="EUR",
+                    effective_from=date(2026, 1, 2),
+                ),
             ]
         ),
         list_benchmark_components_overlapping_window=AsyncMock(return_value=[]),
@@ -2744,6 +2753,167 @@ async def test_benchmark_composition_window_rejects_currency_changes_within_wind
                 window=SimpleNamespace(start_date=date(2026, 1, 1), end_date=date(2026, 1, 31))
             ),
         )
+
+
+@pytest.mark.asyncio
+async def test_benchmark_catalog_collapses_superseded_effective_rows() -> None:
+    service = make_service()
+    service._reference_repository = SimpleNamespace(  # type: ignore[assignment]
+        list_benchmark_definitions=AsyncMock(
+            return_value=[
+                SimpleNamespace(
+                    benchmark_id="B1",
+                    benchmark_name="Benchmark New",
+                    benchmark_type="composite",
+                    benchmark_currency="USD",
+                    return_convention="total_return_index",
+                    benchmark_status="active",
+                    benchmark_family="family",
+                    benchmark_provider="provider",
+                    rebalance_frequency="monthly",
+                    classification_set_id="set1",
+                    classification_labels={"asset_class": "multi_asset"},
+                    effective_from=date(2025, 3, 27),
+                    effective_to=None,
+                    quality_status="accepted",
+                    source_timestamp=None,
+                    source_vendor="vendor",
+                    source_record_id="src-new",
+                ),
+                SimpleNamespace(
+                    benchmark_id="B1",
+                    benchmark_name="Benchmark Old",
+                    benchmark_type="composite",
+                    benchmark_currency="USD",
+                    return_convention="total_return_index",
+                    benchmark_status="active",
+                    benchmark_family="family",
+                    benchmark_provider="provider",
+                    rebalance_frequency="monthly",
+                    classification_set_id="set1",
+                    classification_labels={"asset_class": "multi_asset"},
+                    effective_from=date(2023, 3, 28),
+                    effective_to=None,
+                    quality_status="accepted",
+                    source_timestamp=None,
+                    source_vendor="vendor",
+                    source_record_id="src-old",
+                ),
+            ]
+        ),
+        list_benchmark_components_for_benchmarks=AsyncMock(
+            return_value={
+                "B1": [
+                    SimpleNamespace(
+                        index_id="IDX_BOND",
+                        composition_weight=Decimal("0.4"),
+                        composition_effective_from=date(2023, 3, 28),
+                        composition_effective_to=None,
+                        rebalance_event_id="old",
+                    ),
+                    SimpleNamespace(
+                        index_id="IDX_BOND",
+                        composition_weight=Decimal("0.4"),
+                        composition_effective_from=date(2025, 3, 27),
+                        composition_effective_to=None,
+                        rebalance_event_id="new",
+                    ),
+                    SimpleNamespace(
+                        index_id="IDX_EQ",
+                        composition_weight=Decimal("0.6"),
+                        composition_effective_from=date(2025, 3, 27),
+                        composition_effective_to=None,
+                        rebalance_event_id="new",
+                    ),
+                ]
+            }
+        ),
+    )
+
+    response = await service.list_benchmark_catalog(date(2026, 3, 27), None, None, None)
+
+    assert len(response.records) == 1
+    assert response.records[0].benchmark_name == "Benchmark New"
+    assert [component.index_id for component in response.records[0].components] == [
+        "IDX_BOND",
+        "IDX_EQ",
+    ]
+    assert response.records[0].components[0].composition_effective_from == date(2025, 3, 27)
+
+
+@pytest.mark.asyncio
+async def test_benchmark_composition_window_resolves_superseded_component_rows() -> None:
+    service = make_service()
+    service._reference_repository = SimpleNamespace(  # type: ignore[assignment]
+        list_benchmark_definitions_overlapping_window=AsyncMock(
+            return_value=[
+                SimpleNamespace(
+                    benchmark_id="B1",
+                    benchmark_currency="USD",
+                    effective_from=date(2025, 3, 27),
+                    effective_to=None,
+                    quality_status="accepted",
+                ),
+                SimpleNamespace(
+                    benchmark_id="B1",
+                    benchmark_currency="USD",
+                    effective_from=date(2023, 3, 28),
+                    effective_to=None,
+                    quality_status="accepted",
+                ),
+            ]
+        ),
+        list_benchmark_components_overlapping_window=AsyncMock(
+            return_value=[
+                SimpleNamespace(
+                    index_id="IDX_BOND",
+                    composition_weight=Decimal("0.4"),
+                    composition_effective_from=date(2023, 3, 28),
+                    composition_effective_to=None,
+                    rebalance_event_id="old",
+                    quality_status="accepted",
+                ),
+                SimpleNamespace(
+                    index_id="IDX_BOND",
+                    composition_weight=Decimal("0.4"),
+                    composition_effective_from=date(2025, 3, 27),
+                    composition_effective_to=None,
+                    rebalance_event_id="new",
+                    quality_status="accepted",
+                ),
+                SimpleNamespace(
+                    index_id="IDX_EQ",
+                    composition_weight=Decimal("0.6"),
+                    composition_effective_from=date(2023, 3, 28),
+                    composition_effective_to=None,
+                    rebalance_event_id="old",
+                    quality_status="accepted",
+                ),
+                SimpleNamespace(
+                    index_id="IDX_EQ",
+                    composition_weight=Decimal("0.6"),
+                    composition_effective_from=date(2025, 3, 27),
+                    composition_effective_to=None,
+                    rebalance_event_id="new",
+                    quality_status="accepted",
+                ),
+            ]
+        ),
+    )
+
+    response = await service.get_benchmark_composition_window(
+        "B1",
+        BenchmarkCompositionWindowRequest(
+            window={"start_date": date(2026, 1, 1), "end_date": date(2026, 3, 27)}
+        ),
+    )
+
+    assert response is not None
+    assert [
+        (segment.index_id, segment.composition_effective_from)
+        for segment in response.segments
+    ] == [("IDX_BOND", date(2025, 3, 27)), ("IDX_EQ", date(2025, 3, 27))]
+    assert response.data_quality_status == "COMPLETE"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tools/test_front_office_portfolio_seed.py
+++ b/tests/unit/tools/test_front_office_portfolio_seed.py
@@ -631,6 +631,8 @@ def test_front_office_bundle_extends_usd_risk_free_coverage_through_forward_wind
 def test_front_office_bundle_rewrites_all_benchmark_artifacts_to_dedicated_seed_identity():
     bundle = _build_bundle()
 
+    assert len(bundle["benchmark_definitions"]) == 1
+    assert len(bundle["benchmark_compositions"]) == 2
     assert {row["benchmark_id"] for row in bundle["benchmark_definitions"]} == {
         DEFAULT_BENCHMARK_ID
     }
@@ -656,6 +658,28 @@ def test_front_office_bundle_rewrites_all_benchmark_artifacts_to_dedicated_seed_
         DEFAULT_BENCHMARK_ID.lower()
     )
     assert bundle["benchmark_return_series"][-1]["series_date"] == "2026-05-25"
+    assert len(
+        {
+            (row["benchmark_id"], row["effective_from"])
+            for row in bundle["benchmark_definitions"]
+        }
+    ) == len(bundle["benchmark_definitions"])
+    assert len(
+        {
+            (
+                row["benchmark_id"],
+                row["index_id"],
+                row["composition_effective_from"],
+            )
+            for row in bundle["benchmark_compositions"]
+        }
+    ) == len(bundle["benchmark_compositions"])
+    assert len(
+        {
+            (row["benchmark_id"], row["series_date"], row["return_period"])
+            for row in bundle["benchmark_return_series"]
+        }
+    ) == len(bundle["benchmark_return_series"])
     sector_by_index = {
         index["index_id"]: index["classification_labels"].get("sector")
         for index in bundle["indices"]

--- a/tools/demo_data_pack.py
+++ b/tools/demo_data_pack.py
@@ -17,6 +17,7 @@ from urllib import error, parse, request
 LOGGER = logging.getLogger("demo_data_pack")
 
 DEFAULT_DEMO_BENCHMARK_ID = "BMK_GLOBAL_BALANCED_60_40"
+SECONDARY_DEMO_BENCHMARK_ID = "BMK_GLOBAL_GROWTH_80_20"
 DEFAULT_DEMO_BENCHMARK_PORTFOLIO_ID = "DEMO_ADV_USD_001"
 
 
@@ -34,8 +35,13 @@ DEMO_EXPECTATIONS: tuple[PortfolioExpectation, ...] = (
         "DEMO_ADV_USD_001",
         1,
         1,
-        8,
-        (("CASH_USD", 235350.0), ("SEC_AAPL_US", 800.0), ("SEC_UST_5Y", 120.0)),
+        15,
+        (
+            ("CASH_USD", 398905.0),
+            ("SEC_AAPL_US", 1420.0),
+            ("SEC_UST_5Y", 150.0),
+            ("SEC_ETF_WORLD_USD", 530.0),
+        ),
     ),
     PortfolioExpectation(
         "DEMO_DPM_EUR_001",
@@ -220,22 +226,37 @@ def _build_benchmark_reference_data(*, dates: list[str], start_date: date) -> di
     for current_date, equity_return, bond_return in zip(
         series_dates, equity_daily_returns, bond_daily_returns, strict=True
     ):
-        benchmark_return = (equity_return * Decimal("0.6")) + (bond_return * Decimal("0.4"))
-        benchmark_return_series.append(
-            {
-                "series_id": "bmk_global_balanced_60_40_return",
-                "benchmark_id": DEFAULT_DEMO_BENCHMARK_ID,
-                "series_date": current_date,
-                "benchmark_return": f"{benchmark_return:.10f}",
-                "return_period": "1d",
-                "return_convention": "total_return_index",
-                "series_currency": "USD",
-                "source_timestamp": _iso_utc_timestamp(date.fromisoformat(current_date)),
-                "source_vendor": "LOTUS_DEMO",
-                "source_record_id": f"bmk_global_balanced_60_40_return_{current_date}",
-                "quality_status": "accepted",
-            }
+        benchmark_series_specs = (
+            (
+                DEFAULT_DEMO_BENCHMARK_ID,
+                "bmk_global_balanced_60_40_return",
+                Decimal("0.6"),
+                Decimal("0.4"),
+            ),
+            (
+                SECONDARY_DEMO_BENCHMARK_ID,
+                "bmk_global_growth_80_20_return",
+                Decimal("0.8"),
+                Decimal("0.2"),
+            ),
         )
+        for benchmark_id, series_id, equity_weight, bond_weight in benchmark_series_specs:
+            benchmark_return = (equity_return * equity_weight) + (bond_return * bond_weight)
+            benchmark_return_series.append(
+                {
+                    "series_id": series_id,
+                    "benchmark_id": benchmark_id,
+                    "series_date": current_date,
+                    "benchmark_return": f"{benchmark_return:.10f}",
+                    "return_period": "1d",
+                    "return_convention": "total_return_index",
+                    "series_currency": "USD",
+                    "source_timestamp": _iso_utc_timestamp(date.fromisoformat(current_date)),
+                    "source_vendor": "LOTUS_DEMO",
+                    "source_record_id": f"{series_id}_{current_date}",
+                    "quality_status": "accepted",
+                }
+            )
 
     return {
         "benchmark_assignments": [
@@ -272,7 +293,28 @@ def _build_benchmark_reference_data(*, dates: list[str], start_date: date) -> di
                 "source_timestamp": _iso_utc_timestamp(start_date),
                 "source_vendor": "LOTUS_DEMO",
                 "source_record_id": "bmk_global_balanced_60_40_definition",
-            }
+            },
+            {
+                "benchmark_id": SECONDARY_DEMO_BENCHMARK_ID,
+                "benchmark_name": "Global Growth 80/20",
+                "benchmark_type": "composite",
+                "benchmark_currency": "USD",
+                "return_convention": "total_return_index",
+                "benchmark_status": "active",
+                "benchmark_family": "multi_asset_growth",
+                "benchmark_provider": "LOTUS_DEMO",
+                "rebalance_frequency": "monthly",
+                "classification_set_id": "wm_global_taxonomy_v1",
+                "classification_labels": {
+                    "asset_class": "multi_asset",
+                    "strategy": "growth",
+                    "region": "global",
+                },
+                "effective_from": effective_from,
+                "source_timestamp": _iso_utc_timestamp(start_date),
+                "source_vendor": "LOTUS_DEMO",
+                "source_record_id": "bmk_global_growth_80_20_definition",
+            },
         ],
         "benchmark_compositions": [
             {
@@ -295,6 +337,28 @@ def _build_benchmark_reference_data(*, dates: list[str], start_date: date) -> di
                 "source_timestamp": _iso_utc_timestamp(start_date),
                 "source_vendor": "LOTUS_DEMO",
                 "source_record_id": "bmk_global_balanced_60_40_bond",
+                "quality_status": "accepted",
+            },
+            {
+                "benchmark_id": SECONDARY_DEMO_BENCHMARK_ID,
+                "index_id": "IDX_GLOBAL_EQUITY_TR",
+                "composition_effective_from": effective_from,
+                "composition_weight": "0.8000000000",
+                "rebalance_event_id": "bmk_global_growth_80_20_initial",
+                "source_timestamp": _iso_utc_timestamp(start_date),
+                "source_vendor": "LOTUS_DEMO",
+                "source_record_id": "bmk_global_growth_80_20_equity",
+                "quality_status": "accepted",
+            },
+            {
+                "benchmark_id": SECONDARY_DEMO_BENCHMARK_ID,
+                "index_id": "IDX_GLOBAL_BOND_TR",
+                "composition_effective_from": effective_from,
+                "composition_weight": "0.2000000000",
+                "rebalance_event_id": "bmk_global_growth_80_20_initial",
+                "source_timestamp": _iso_utc_timestamp(start_date),
+                "source_vendor": "LOTUS_DEMO",
+                "source_record_id": "bmk_global_growth_80_20_bond",
                 "quality_status": "accepted",
             },
         ],
@@ -344,6 +408,10 @@ def _build_benchmark_reference_data(*, dates: list[str], start_date: date) -> di
         "benchmark_verification": {
             "portfolio_id": DEFAULT_DEMO_BENCHMARK_PORTFOLIO_ID,
             "benchmark_id": DEFAULT_DEMO_BENCHMARK_ID,
+            "catalog_benchmark_ids": [
+                DEFAULT_DEMO_BENCHMARK_ID,
+                SECONDARY_DEMO_BENCHMARK_ID,
+            ],
             "start_date": effective_from,
             "end_date": latest_date,
         },
@@ -384,7 +452,7 @@ def build_risk_free_reference_data(
 
 
 def build_demo_bundle() -> dict[str, Any]:
-    start_date = date.today() - timedelta(days=365)
+    start_date = date.today() - timedelta(days=365 * 3)
     end_date = date.today()
     dates = _business_dates(start_date, end_date)
     as_of = end_date.isoformat()
@@ -406,7 +474,7 @@ def build_demo_bundle() -> dict[str, Any]:
         {
             "portfolio_id": "DEMO_ADV_USD_001",
             "base_currency": "USD",
-            "open_date": "2024-01-02",
+            "open_date": "2023-01-03",
             "risk_exposure": "Moderate",
             "investment_time_horizon": "Long",
             "portfolio_type": "Advisory",
@@ -590,9 +658,9 @@ def build_demo_bundle() -> dict[str, Any]:
             "CASH_USD",
             tx_ts(1, 9),
             "DEPOSIT",
-            500000,
+            750000,
             1,
-            500000,
+            750000,
             "USD",
         ),
         _tx(
@@ -602,9 +670,9 @@ def build_demo_bundle() -> dict[str, Any]:
             "SEC_AAPL_US",
             tx_ts(2),
             "BUY",
-            800,
-            185,
-            148000,
+            1200,
+            182,
+            218400,
             "USD",
         ),
         _tx(
@@ -614,9 +682,9 @@ def build_demo_bundle() -> dict[str, Any]:
             "CASH_USD",
             tx_ts(2),
             "SELL",
-            148000,
+            218400,
             1,
-            148000,
+            218400,
             "USD",
         ),
         _tx(
@@ -626,9 +694,9 @@ def build_demo_bundle() -> dict[str, Any]:
             "SEC_UST_5Y",
             tx_ts(5),
             "BUY",
-            120,
-            980,
-            117600,
+            180,
+            975,
+            175500,
             "USD",
         ),
         _tx(
@@ -638,9 +706,33 @@ def build_demo_bundle() -> dict[str, Any]:
             "CASH_USD",
             tx_ts(5),
             "SELL",
-            117600,
+            175500,
             1,
-            117600,
+            175500,
+            "USD",
+        ),
+        _tx(
+            "DEMO_ADV_BUY_ETF_01",
+            "DEMO_ADV_USD_001",
+            "WORLD_ETF",
+            "SEC_ETF_WORLD_USD",
+            tx_ts(35),
+            "BUY",
+            650,
+            128,
+            83200,
+            "USD",
+        ),
+        _tx(
+            "DEMO_ADV_CASH_OUT_03",
+            "DEMO_ADV_USD_001",
+            "CASH",
+            "CASH_USD",
+            tx_ts(35),
+            "SELL",
+            83200,
+            1,
+            83200,
             "USD",
         ),
         _tx(
@@ -652,7 +744,7 @@ def build_demo_bundle() -> dict[str, Any]:
             "DIVIDEND",
             0,
             0,
-            1200,
+            1800,
             "USD",
         ),
         _tx(
@@ -662,9 +754,117 @@ def build_demo_bundle() -> dict[str, Any]:
             "CASH_USD",
             tx_ts(160),
             "BUY",
-            1200,
+            1800,
             1,
-            1200,
+            1800,
+            "USD",
+        ),
+        _tx(
+            "DEMO_ADV_COUPON_01",
+            "DEMO_ADV_USD_001",
+            "UST5Y",
+            "SEC_UST_5Y",
+            tx_ts(340),
+            "DIVIDEND",
+            0,
+            0,
+            950,
+            "USD",
+        ),
+        _tx(
+            "DEMO_ADV_CASH_IN_02",
+            "DEMO_ADV_USD_001",
+            "CASH",
+            "CASH_USD",
+            tx_ts(340),
+            "BUY",
+            950,
+            1,
+            950,
+            "USD",
+        ),
+        _tx(
+            "DEMO_ADV_DEP_02",
+            "DEMO_ADV_USD_001",
+            "CASH",
+            "CASH_USD",
+            tx_ts(420, 9),
+            "DEPOSIT",
+            120000,
+            1,
+            120000,
+            "USD",
+        ),
+        _tx(
+            "DEMO_ADV_BUY_AAPL_02",
+            "DEMO_ADV_USD_001",
+            "AAPL",
+            "SEC_AAPL_US",
+            tx_ts(510),
+            "BUY",
+            220,
+            196,
+            43120,
+            "USD",
+        ),
+        _tx(
+            "DEMO_ADV_CASH_OUT_04",
+            "DEMO_ADV_USD_001",
+            "CASH",
+            "CASH_USD",
+            tx_ts(510),
+            "SELL",
+            43120,
+            1,
+            43120,
+            "USD",
+        ),
+        _tx(
+            "DEMO_ADV_SELL_UST_01",
+            "DEMO_ADV_USD_001",
+            "UST5Y",
+            "SEC_UST_5Y",
+            tx_ts(675),
+            "SELL",
+            30,
+            992,
+            29760,
+            "USD",
+        ),
+        _tx(
+            "DEMO_ADV_CASH_IN_03",
+            "DEMO_ADV_USD_001",
+            "CASH",
+            "CASH_USD",
+            tx_ts(675),
+            "BUY",
+            29760,
+            1,
+            29760,
+            "USD",
+        ),
+        _tx(
+            "DEMO_ADV_SELL_ETF_01",
+            "DEMO_ADV_USD_001",
+            "WORLD_ETF",
+            "SEC_ETF_WORLD_USD",
+            tx_ts(780),
+            "SELL",
+            120,
+            142,
+            17040,
+            "USD",
+        ),
+        _tx(
+            "DEMO_ADV_CASH_IN_04",
+            "DEMO_ADV_USD_001",
+            "CASH",
+            "CASH_USD",
+            tx_ts(780),
+            "BUY",
+            17040,
+            1,
+            17040,
             "USD",
         ),
         _tx(
@@ -672,11 +872,11 @@ def build_demo_bundle() -> dict[str, Any]:
             "DEMO_ADV_USD_001",
             "CASH",
             "CASH_USD",
-            tx_ts(330),
+            tx_ts(900),
             "FEE",
             1,
-            250,
-            250,
+            425,
+            425,
             "USD",
         ),
         _tx(
@@ -1250,6 +1450,7 @@ def _verify_benchmark_reference(
     *,
     portfolio_id: str,
     benchmark_id: str,
+    catalog_benchmark_ids: list[str],
     start_date: str,
     end_date: str,
     wait_seconds: int,
@@ -1283,7 +1484,10 @@ def _verify_benchmark_reference(
         )
         if (
             isinstance(records, list)
-            and any(record.get("benchmark_id") == benchmark_id for record in records)
+            and all(
+                any(record.get("benchmark_id") == expected_id for record in records)
+                for expected_id in catalog_benchmark_ids
+            )
             and isinstance(assignment_payload, dict)
             and assignment_payload.get("benchmark_id") == benchmark_id
             and isinstance(segments, list)
@@ -1292,6 +1496,7 @@ def _verify_benchmark_reference(
             return {
                 "portfolio_id": portfolio_id,
                 "benchmark_id": benchmark_id,
+                "catalog_benchmark_ids": catalog_benchmark_ids,
                 "catalog_records": len(records),
                 "composition_segments": len(segments),
             }
@@ -1379,6 +1584,7 @@ def main() -> int:
             query_control_plane_base_url,
             portfolio_id=demo_bundle["benchmark_verification"]["portfolio_id"],
             benchmark_id=demo_bundle["benchmark_verification"]["benchmark_id"],
+            catalog_benchmark_ids=demo_bundle["benchmark_verification"]["catalog_benchmark_ids"],
             start_date=demo_bundle["benchmark_verification"]["start_date"],
             end_date=demo_bundle["benchmark_verification"]["end_date"],
             wait_seconds=args.wait_seconds,

--- a/tools/front_office_portfolio_seed.py
+++ b/tools/front_office_portfolio_seed.py
@@ -1376,6 +1376,7 @@ def build_front_office_portfolio_bundle(
             "source_record_id": f"{benchmark_id.lower()}_definition",
         }
         for definition in benchmark_reference["benchmark_definitions"]
+        if definition["benchmark_id"] == DEFAULT_DEMO_BENCHMARK_ID
     ]
     benchmark_reference["benchmark_compositions"] = [
         {
@@ -1392,6 +1393,7 @@ def build_front_office_portfolio_bundle(
             ),
         }
         for composition in benchmark_reference["benchmark_compositions"]
+        if composition["benchmark_id"] == DEFAULT_DEMO_BENCHMARK_ID
     ]
     benchmark_reference["benchmark_return_series"] = [
         {
@@ -1408,6 +1410,7 @@ def build_front_office_portfolio_bundle(
             ),
         }
         for series_row in benchmark_reference["benchmark_return_series"]
+        if series_row["benchmark_id"] == DEFAULT_DEMO_BENCHMARK_ID
     ]
     benchmark_reference["benchmark_assignments"] = [
         {


### PR DESCRIPTION
## Summary
- Preserve useful work from stale `feat/richer-demo-performance-seeding` without merging its old tree state.
- Collapse superseded benchmark definition/component records in query-service benchmark catalog, definition, composition-window, and market-series flows.
- Enrich the demo data pack with a secondary 80/20 growth benchmark, longer benchmark history, and richer advisory USD activity.

## Branch cleanup evidence
- Deleted remote branches already merged or superseded by merged PRs: `codex/rfc-0075-canonical-demo-validation-20260411`, `codex/rfc-0076-slice-2-contract-enforcement-20260411`, `docs/sync-agent-dod-contract`, `feature/rfc0033-front-office-seed-quiescence`, `fix/holdings-stale-snapshot-reconciliation`, `fix/issue-279-and-latency-followup`, `fix/latency-profile-dynamic-runtime-context`, `wtbd-rfc40-transaction-cost-source-core`.
- Kept and ported the only branch with unmerged useful implementation content: `feat/richer-demo-performance-seeding`.

## Local validation
- `python -m pytest tests/unit/services/query_service/services/test_integration_service.py -k "benchmark_catalog_collapses or benchmark_composition_window or benchmark_market_series_supports_paging_tokens" tests/integration/tools/test_demo_data_pack.py`
- `python -m pytest tests/unit/services/query_service/services/test_integration_service.py tests/integration/tools/test_demo_data_pack.py`
- `make lint`
- `make test-unit`