### PR TITLE
test: align index currency openapi contract

### DIFF
--- a/tests/integration/services/ingestion_service/test_ingestion_main_app_contract.py
+++ b/tests/integration/services/ingestion_service/test_ingestion_main_app_contract.py
@@ -391,7 +391,10 @@ async def test_openapi_describes_index_definition_shared_schema(async_test_clien
         "Index definition records to ingest or upsert."
     )
     assert record_schema["properties"]["index_id"]["description"] == ("Canonical index identifier.")
-    assert record_schema["properties"]["index_currency"]["description"] == "Index currency."
+    assert record_schema["properties"]["index_currency"]["description"] == (
+        "Canonical three-letter index currency used for benchmark construction, "
+        "performance comparison, and reporting alignment."
+    )
     assert record_schema["properties"]["classification_labels"]["description"] == (
         "Canonical classification labels for attribution."
     )


### PR DESCRIPTION
## Summary
- Align the ingestion OpenAPI integration contract assertion with the enriched IndexDefinitionRecord.index_currency description now emitted by the shared DTO schema.
- Keeps the contract test strict while preserving the canonical benchmark/performance/reporting currency meaning.

## Validation
- python -m pytest tests\\integration\\services\\ingestion_service\\test_ingestion_main_app_contract.py::test_openapi_describes_index_definition_shared_schema -q
- python -m ruff check tests\\integration\\services\\ingestion_service\\test_ingestion_main_app_contract.py
- python -m ruff format --check tests\\integration\\services\\ingestion_service\\test_ingestion_main_app_contract.py
- git diff --check

## Wiki
- No wiki source change required; this is a stale test expectation fix.