### PR TITLE
test: reuse deadlock-safe reprocessing cleanup

### DIFF
--- a/tests/integration/services/calculators/position_calculator/test_int_reprocessing_atomicity.py
+++ b/tests/integration/services/calculators/position_calculator/test_int_reprocessing_atomicity.py
@@ -30,26 +30,8 @@ SECURITY_ID = "SEC_REPRO_ATOM_01"
 
 
 @pytest_asyncio.fixture(scope="function")
-async def setup_repro_atomicity_data(async_db_session: AsyncSession):
+async def setup_repro_atomicity_data(clean_db, async_db_session: AsyncSession):
     """Sets up the initial state for the atomicity test."""
-    # Clean up before test
-    await async_db_session.execute(
-        text(
-            """
-            TRUNCATE TABLE
-                outbox_events,
-                daily_position_snapshots,
-                position_history,
-                position_timeseries,
-                portfolio_timeseries,
-                position_state,
-                transactions,
-                portfolios
-            RESTART IDENTITY CASCADE
-            """
-        )
-    )
-
     # ARRANGE: Create initial state
     async_db_session.add(
         Portfolio(


### PR DESCRIPTION
## Summary
- Replace hand-rolled async TRUNCATE cleanup in the reprocessing atomicity integration fixture with the repository shared clean_db fixture.
- Reuses the existing deadlock-retry and connection-termination cleanup path used by DB integration tests, avoiding full integration suite deadlocks during main releasability.

## Validation
- python -m pytest tests\\integration\\services\\calculators\\position_calculator\\test_int_reprocessing_atomicity.py -q
- python -m ruff check tests\\integration\\services\\calculators\\position_calculator\\test_int_reprocessing_atomicity.py
- python -m ruff format --check tests\\integration\\services\\calculators\\position_calculator\\test_int_reprocessing_atomicity.py
- git diff --check

## Wiki
- No wiki source change required; test cleanup reliability only.