### PR TITLE
Fix canonical demo seed portfolio identifiers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -597,6 +597,10 @@ services:
         echo 'Demo data pack disabled via DEMO_DATA_PACK_ENABLED=false';
         exit 0;
       fi;
+      portfolio_args='';
+      if [ -n \"$$DEMO_DATA_PACK_PORTFOLIO_IDS\" ]; then
+        portfolio_args=\"--portfolio-ids $$DEMO_DATA_PACK_PORTFOLIO_IDS\";
+      fi;
       python -m tools.demo_data_pack
       --ingestion-base-url http://ingestion_service:8000
       --query-base-url http://query_service:8001
@@ -605,7 +609,7 @@ services:
       --wait-seconds $$DEMO_DATA_PACK_WAIT_SECONDS
       --poll-interval-seconds $$DEMO_DATA_PACK_POLL_INTERVAL_SECONDS
       --history-days $$DEMO_DATA_PACK_HISTORY_DAYS
-      --portfolio-ids "$$DEMO_DATA_PACK_PORTFOLIO_IDS"
+      $$portfolio_args
       "
     restart: "no"
     networks:

--- a/tests/unit/test_app_local_stack_contract.py
+++ b/tests/unit/test_app_local_stack_contract.py
@@ -60,7 +60,10 @@ def test_demo_data_loader_uses_internal_service_urls() -> None:
     assert "--wait-seconds $$DEMO_DATA_PACK_WAIT_SECONDS" in command
     assert "--poll-interval-seconds $$DEMO_DATA_PACK_POLL_INTERVAL_SECONDS" in command
     assert "--history-days $$DEMO_DATA_PACK_HISTORY_DAYS" in command
-    assert '--portfolio-ids "$$DEMO_DATA_PACK_PORTFOLIO_IDS"' in command
+    assert "portfolio_args='';" in command
+    assert 'if [ -n \\"$$DEMO_DATA_PACK_PORTFOLIO_IDS\\" ]; then' in command
+    assert 'portfolio_args=\\"--portfolio-ids $$DEMO_DATA_PACK_PORTFOLIO_IDS\\";' in command
+    assert "$$portfolio_args" in command
     assert "depends_on" not in demo_loader["environment"]
     assert demo_loader["environment"]["DEMO_DATA_PACK_WAIT_SECONDS"] == (
         "${DEMO_DATA_PACK_WAIT_SECONDS:-900}"


### PR DESCRIPTION
## Summary
- preserve canonical demo seed portfolio identifiers for the governed front-office runtime

## Evidence
- Remote Feature Lane: https://github.com/sgajbi/lotus-core/actions/runs/27684585269
- Live canonical Workbench validation passed for PB_SG_GLOBAL_BAL_001 after the platform demo stack fixes

## Risk
- Scoped to canonical demo seed identity alignment.