### PR TITLE
Fix canonical front-office business-date horizon

### DIFF
--- a/src/libs/portfolio-common/portfolio_common/valuation_repository_base.py
+++ b/src/libs/portfolio-common/portfolio_common/valuation_repository_base.py
@@ -299,10 +299,13 @@ class ValuationRepositoryBase:
         business_date_stmt = select(func.max(BusinessDate.date)).where(
             BusinessDate.calendar_code == DEFAULT_BUSINESS_CALENDAR_CODE
         )
+        business_date = (await self.db.execute(business_date_stmt)).scalar_one_or_none()
+        if business_date is not None:
+            return business_date
+
         snapshot_date_stmt = select(func.max(DailyPositionSnapshot.date))
         valuation_job_date_stmt = select(func.max(PortfolioValuationJob.valuation_date))
 
-        business_date = (await self.db.execute(business_date_stmt)).scalar_one_or_none()
         snapshot_date = (await self.db.execute(snapshot_date_stmt)).scalar_one_or_none()
         valuation_job_date = (await self.db.execute(valuation_job_date_stmt)).scalar_one_or_none()
 

--- a/tests/integration/services/calculators/position_valuation_calculator/test_int_valuation_repo.py
+++ b/tests/integration/services/calculators/position_valuation_calculator/test_int_valuation_repo.py
@@ -1539,6 +1539,54 @@ async def test_get_latest_business_date_falls_back_to_processing_dates_when_cale
     assert latest_date == date(2025, 8, 10)
 
 
+async def test_get_latest_business_date_prefers_calendar_over_future_processing_residue(
+    clean_db, async_db_session: AsyncSession
+):
+    repo = ValuationRepository(async_db_session)
+
+    async_db_session.add_all(
+        [
+            BusinessDate(calendar_code="GLOBAL", date=date(2026, 4, 10)),
+            Portfolio(
+                portfolio_id="P-CALENDAR-BOUND-1",
+                base_currency="USD",
+                open_date=date(2024, 1, 1),
+                risk_exposure="a",
+                investment_time_horizon="b",
+                portfolio_type="c",
+                booking_center_code="d",
+                client_id="e",
+                status="ACTIVE",
+            ),
+        ]
+    )
+    await async_db_session.commit()
+
+    async_db_session.add_all(
+        [
+            PortfolioValuationJob(
+                portfolio_id="P-CALENDAR-BOUND-1",
+                security_id="S-CALENDAR-BOUND-1",
+                valuation_date=date(2026, 6, 17),
+                epoch=0,
+                status="PROCESSING",
+            ),
+            DailyPositionSnapshot(
+                portfolio_id="P-CALENDAR-BOUND-1",
+                security_id="S-CALENDAR-BOUND-1",
+                date=date(2026, 6, 17),
+                quantity=Decimal("1"),
+                cost_basis=Decimal("1"),
+            ),
+        ]
+    )
+    await async_db_session.commit()
+
+    latest_date = await repo.get_latest_business_date()
+
+    assert latest_date == date(2026, 4, 10)
+
+
 async def test_get_states_needing_backfill_skips_keys_without_instrument(
     clean_db, async_db_session: AsyncSession
 ):

--- a/tests/unit/tools/test_front_office_portfolio_seed.py
+++ b/tests/unit/tools/test_front_office_portfolio_seed.py
@@ -770,8 +770,17 @@ def test_front_office_seed_cleanup_sql_bounds_demo_business_dates():
     assert (
         "delete from business_dates where calendar_code = 'GLOBAL' and date > '2026-04-10';"
     ) in sql
+    assert (
+        sql.count(
+            "delete from business_dates where calendar_code = 'GLOBAL' and date > '2026-04-10';"
+        )
+        == 2
+    )
     assert sql.index("delete from business_dates") < sql.index(
         "delete from financial_reconciliation_findings"
+    )
+    assert sql.rindex("delete from business_dates") > sql.rindex(
+        "delete from processed_events where service_name in"
     )
 
 

--- a/tests/unit/tools/test_front_office_portfolio_seed.py
+++ b/tests/unit/tools/test_front_office_portfolio_seed.py
@@ -727,10 +727,12 @@ def test_front_office_cleanup_retries_transient_database_conflicts(monkeypatch) 
         postgres_container="postgres",
         portfolio_id="PB_SG_GLOBAL_BAL_001",
         benchmark_id=DEFAULT_BENCHMARK_ID,
+        max_business_date=date(2026, 4, 10),
     )
 
     assert len(calls) == 2
     assert calls[0] == calls[1]
+    assert "date > '2026-04-10'" in calls[0][-1]
 
 
 def test_portfolio_seed_cleanup_sql_removes_portfolio_owned_state_before_reseed():
@@ -756,6 +758,22 @@ def test_portfolio_seed_cleanup_sql_removes_portfolio_owned_state_before_reseed(
     assert "delete from reprocessing_jobs;" not in sql
     assert "delete from processed_events where service_name in" in sql
     assert "delete from processed_events where portfolio_id = 'PB_SG_GLOBAL_BAL_001';" in sql
+
+
+def test_front_office_seed_cleanup_sql_bounds_demo_business_dates():
+    sql = build_front_office_seed_cleanup_sql(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        benchmark_id=DEFAULT_BENCHMARK_ID,
+        max_business_date=date(2026, 4, 10),
+    )
+
+    assert (
+        "delete from business_dates where calendar_code = 'GLOBAL' "
+        "and date > '2026-04-10';"
+    ) in sql
+    assert sql.index("delete from business_dates") < sql.index(
+        "delete from financial_reconciliation_findings"
+    )
 
 
 def test_portfolio_seed_cleanup_sql_resets_only_volatile_replay_fences():

--- a/tests/unit/tools/test_front_office_portfolio_seed.py
+++ b/tests/unit/tools/test_front_office_portfolio_seed.py
@@ -768,8 +768,7 @@ def test_front_office_seed_cleanup_sql_bounds_demo_business_dates():
     )
 
     assert (
-        "delete from business_dates where calendar_code = 'GLOBAL' "
-        "and date > '2026-04-10';"
+        "delete from business_dates where calendar_code = 'GLOBAL' and date > '2026-04-10';"
     ) in sql
     assert sql.index("delete from business_dates") < sql.index(
         "delete from financial_reconciliation_findings"

--- a/tools/front_office_portfolio_seed.py
+++ b/tools/front_office_portfolio_seed.py
@@ -242,7 +242,12 @@ def build_portfolio_seed_cleanup_sql(*, portfolio_id: str) -> str:
     )
 
 
-def build_front_office_seed_cleanup_sql(*, portfolio_id: str, benchmark_id: str) -> str:
+def build_front_office_seed_cleanup_sql(
+    *,
+    portfolio_id: str,
+    benchmark_id: str,
+    max_business_date: date | None = None,
+) -> str:
     benchmark_index_id_list = ", ".join(
         f"'{index_id}'" for index_id in DEFAULT_BENCHMARK_COMPONENT_INDEX_IDS
     )
@@ -250,8 +255,20 @@ def build_front_office_seed_cleanup_sql(*, portfolio_id: str, benchmark_id: str)
         build_portfolio_seed_cleanup_sql(portfolio_id=row["portfolio_id"])
         for row in DPM_SOURCE_ONLY_CANDIDATE_PORTFOLIOS
     ]
+    business_date_bound_sql = (
+        [
+            (
+                "delete from business_dates "
+                "where calendar_code = 'GLOBAL' "
+                f"and date > '{max_business_date.isoformat()}';"
+            )
+        ]
+        if max_business_date is not None
+        else []
+    )
     return "\n".join(
         [
+            *business_date_bound_sql,
             build_portfolio_seed_cleanup_sql(portfolio_id=portfolio_id),
             *source_only_candidate_cleanup,
             (
@@ -2218,11 +2235,13 @@ def _cleanup_existing_front_office_seed(
     postgres_container: str,
     portfolio_id: str,
     benchmark_id: str,
+    max_business_date: date | None = None,
     max_attempts: int = 3,
 ) -> None:
     sql = build_front_office_seed_cleanup_sql(
         portfolio_id=portfolio_id,
         benchmark_id=benchmark_id,
+        max_business_date=max_business_date,
     )
     command = [
         "docker",
@@ -2551,6 +2570,7 @@ def main() -> int:
                 postgres_container=args.postgres_container,
                 portfolio_id=args.portfolio_id,
                 benchmark_id=args.benchmark_id,
+                max_business_date=end_date,
             )
         should_ingest = args.force_ingest or not args.skip_cleanup
         if not should_ingest:

--- a/tools/front_office_portfolio_seed.py
+++ b/tools/front_office_portfolio_seed.py
@@ -271,6 +271,7 @@ def build_front_office_seed_cleanup_sql(
             *business_date_bound_sql,
             build_portfolio_seed_cleanup_sql(portfolio_id=portfolio_id),
             *source_only_candidate_cleanup,
+            *business_date_bound_sql,
             (
                 "delete from model_portfolio_targets "
                 f"where model_portfolio_id = '{DEFAULT_DPM_MODEL_PORTFOLIO_ID}' "


### PR DESCRIPTION
## Summary
- caps the canonical front-office seed business-date horizon at the governed contract end date
- makes latest-business-date lookup prefer calendar business dates over stale future processing residue
- adds regression coverage for calendar preference and seed cleanup

## Evidence
- `python -m ruff check tools\front_office_portfolio_seed.py src\libs\portfolio-common\portfolio_common\valuation_repository_base.py tests\unit\tools\test_front_office_portfolio_seed.py tests\integration\services\calculators\position_valuation_calculator\test_int_valuation_repo.py`
- `python -m pytest tests\unit\tools\test_front_office_portfolio_seed.py tests\integration\services\calculators\position_valuation_calculator\test_int_valuation_repo.py::test_get_latest_business_date_falls_back_to_processing_dates_when_calendar_is_empty tests\integration\services\calculators\position_valuation_calculator\test_int_valuation_repo.py::test_get_latest_business_date_prefers_calendar_over_future_processing_residue -q` -> 57 passed
- canonical seed verified `PB_SG_GLOBAL_BAL_001` through `2026-04-10`

## Risk
- behavior-preserving for normal processing; changes only stale future date residue selection and canonical seed cleanup