### PR TITLE
Fix main releasability integration regressions

### DIFF
--- a/tests/integration/services/calculators/cost_calculator_service/test_int_cost_consumer_persistence.py
+++ b/tests/integration/services/calculators/cost_calculator_service/test_int_cost_consumer_persistence.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from portfolio_common.database_models import (
+    Instrument,
     OutboxEvent,
     Portfolio,
     PositionLotState,
@@ -125,6 +126,16 @@ async def test_buy_then_sell_processing_reconciles_open_lot_quantity(
             client_id="CLIENT-COST-INT-LOT-01",
             is_leverage_allowed=False,
             status="ACTIVE",
+        )
+    )
+    async_db_session.add(
+        Instrument(
+            security_id="FO_EQ_AAPL_US",
+            name="Apple Inc.",
+            isin="US0378331005",
+            currency="USD",
+            product_type="EQUITY",
+            asset_class="Equity",
         )
     )
     async_db_session.add_all(

--- a/tests/integration/services/valuation_orchestrator_service/test_valuation_scheduler_integration.py
+++ b/tests/integration/services/valuation_orchestrator_service/test_valuation_scheduler_integration.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from typing import Any
 
 import pytest
 from portfolio_common.database_models import (
@@ -26,13 +26,30 @@ from src.services.valuation_orchestrator_service.app.core.valuation_scheduler im
 pytestmark = pytest.mark.asyncio
 
 
+class InMemoryValuationJobPublisher:
+    def __init__(self) -> None:
+        self.published_jobs: list[dict[str, Any]] = []
+
+    def publish_job_requested(
+        self,
+        *,
+        key: str,
+        value: dict[str, Any],
+        headers: list[tuple[str, bytes]],
+    ) -> None:
+        self.published_jobs.append({"key": key, "value": value, "headers": headers})
+
+    def confirm_delivery(self, *, timeout_seconds: int) -> int:
+        return 0
+
+
 @pytest.fixture
 def scheduler() -> ValuationScheduler:
-    with patch(
-        "src.services.valuation_orchestrator_service.app.core.valuation_scheduler.get_kafka_producer",
-        return_value=MagicMock(),
-    ):
-        yield ValuationScheduler(poll_interval=0.01, batch_size=2)
+    return ValuationScheduler(
+        poll_interval=0.01,
+        batch_size=2,
+        valuation_job_publisher=InMemoryValuationJobPublisher(),
+    )
 
 
 def _seed_backlog_state(


### PR DESCRIPTION
## Summary
- Fixes the post-merge Main Releasability / Integration Full failure from run 28461735551 on main SHA 6cf8e4ed856fa44d633a476b638db60168030f44.
- Seeds the cost-calculator lot integration scenario with the product instrument master row now required by the runtime reference-data guard.
- Updates valuation scheduler integration tests to inject the `ValuationJobPublisher` port instead of patching the removed scheduler-level Kafka helper.

## Objective and Expected Improvement
- Objective: restore mainline release evidence without weakening the instrument-reference guard or valuation publisher abstraction.
- Improvement: integration tests now model production prerequisites and depend on the scheduler application port, reducing stale mock coupling.

## Compatibility Impact
- Runtime/API behavior: no change.
- Downstream contracts: no change.
- Test/fixture behavior: updated to match the current production seams.

## Validation Evidence
- `python -m pytest tests/integration/services/calculators/cost_calculator_service/test_int_cost_consumer_persistence.py tests/integration/services/valuation_orchestrator_service/test_valuation_scheduler_integration.py -q` -> 5 passed in 59.88s
- `python -m ruff check tests/integration/services/calculators/cost_calculator_service/test_int_cost_consumer_persistence.py tests/integration/services/valuation_orchestrator_service/test_valuation_scheduler_integration.py` -> passed
- `python -m ruff format --check tests/integration/services/calculators/cost_calculator_service/test_int_cost_consumer_persistence.py tests/integration/services/valuation_orchestrator_service/test_valuation_scheduler_integration.py` -> passed
- `make test-integration-all` -> 699 passed in 473.06s

## Docs / Context / Wiki Decision
- No docs, context, or wiki change: this fixes stale integration test setup only; no public behavior, command, or operator truth changed.

## Main Releasability Follow-up
- After merge, rerun/monitor Main Releasability for the new main SHA and verify Integration Full is green.