### PR TITLE
fix: harden front-office reseed cleanup retries

### DIFF
--- a/tests/unit/tools/test_front_office_portfolio_seed.py
+++ b/tests/unit/tools/test_front_office_portfolio_seed.py
@@ -26,6 +26,7 @@ from tools.front_office_portfolio_seed import (
     _reprocess_front_office_transactions,
     _required_cross_currency_fx_windows,
     _should_reprocess_after_ingest,
+    _terminate_front_office_seed_cleanup_blockers,
     _validate_front_office_cash_transactions,
     _validate_front_office_internal_transaction_pairs,
     _verify_front_office_portfolio,
@@ -714,9 +715,13 @@ def test_front_office_cleanup_sql_removes_benchmark_seed_rows_deterministically(
 def test_front_office_cleanup_retries_transient_database_conflicts(monkeypatch) -> None:
     calls: list[list[str]] = []
 
-    def fake_run(command, *, check):
+    def fake_run(command, *, check, capture_output=False, text=False):
         calls.append(command)
-        if len(calls) == 1:
+        if "pg_stat_activity" in command[-1]:
+            assert capture_output is True
+            assert text is True
+            return subprocess.CompletedProcess(command, 0, stdout="2\nt\nt\n", stderr="")
+        if len([call for call in calls if "pg_stat_activity" not in call[-1]]) == 1:
             raise subprocess.CalledProcessError(returncode=1, cmd=command)
         return subprocess.CompletedProcess(command, 0)
 
@@ -730,9 +735,46 @@ def test_front_office_cleanup_retries_transient_database_conflicts(monkeypatch) 
         max_business_date=date(2026, 4, 10),
     )
 
-    assert len(calls) == 2
-    assert calls[0] == calls[1]
+    cleanup_calls = [call for call in calls if "pg_stat_activity" not in call[-1]]
+    blocker_cleanup_calls = [call for call in calls if "pg_stat_activity" in call[-1]]
+    assert len(cleanup_calls) == 2
+    assert len(blocker_cleanup_calls) == 1
+    assert cleanup_calls[0] == cleanup_calls[1]
     assert "date > '2026-04-10'" in calls[0][-1]
+    assert "portfolio_aggregation_jobs" in blocker_cleanup_calls[0][-1]
+    assert "portfolio_valuation_jobs" in blocker_cleanup_calls[0][-1]
+
+
+def test_front_office_cleanup_blocker_termination_counts_matching_sessions(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(command, *, check, capture_output, text):
+        calls.append(command)
+        assert check is False
+        assert capture_output is True
+        assert text is True
+        return subprocess.CompletedProcess(command, 0, stdout="3\nt\nt\nt\n", stderr="")
+
+    monkeypatch.setattr("tools.front_office_portfolio_seed.subprocess.run", fake_run)
+
+    terminated_count = _terminate_front_office_seed_cleanup_blockers(postgres_container="postgres")
+
+    assert terminated_count == 3
+    assert len(calls) == 1
+    assert calls[0][:8] == [
+        "docker",
+        "exec",
+        "postgres",
+        "psql",
+        "-U",
+        "user",
+        "-d",
+        "portfolio_db",
+    ]
+    assert "pg_terminate_backend(pid)" in calls[0][-1]
+    assert "state in ('active', 'idle in transaction')" in calls[0][-1]
+    assert "portfolio_aggregation_jobs" in calls[0][-1]
+    assert "portfolio_valuation_jobs" in calls[0][-1]
 
 
 def test_portfolio_seed_cleanup_sql_removes_portfolio_owned_state_before_reseed():

--- a/tools/front_office_portfolio_seed.py
+++ b/tools/front_office_portfolio_seed.py
@@ -2263,14 +2263,91 @@ def _cleanup_existing_front_office_seed(
         except subprocess.CalledProcessError:
             if attempt >= max_attempts:
                 raise
+            terminated_sessions = _terminate_front_office_seed_cleanup_blockers(
+                postgres_container=postgres_container
+            )
             LOGGER.warning(
                 "Front-office seed cleanup hit a transient database conflict for %s; "
-                "retrying attempt %s of %s.",
+                "terminated %s conflicting Core database session(s); retrying attempt %s of %s.",
                 portfolio_id,
+                terminated_sessions,
                 attempt + 1,
                 max_attempts,
             )
             time.sleep(attempt * 2)
+
+
+def _terminate_front_office_seed_cleanup_blockers(*, postgres_container: str) -> int:
+    """
+    Best-effort local reseed recovery for workers touching queue tables during cleanup.
+
+    The canonical front-office reseed is a local/operator workflow. If background Core workers are
+    concurrently claiming valuation or aggregation jobs, PostgreSQL can deadlock against the
+    cleanup delete order. Terminate only active sessions whose current query is touching the seed
+    cleanup hot tables, then let the bounded cleanup retry recreate deterministic seed state.
+    """
+
+    sql = """
+select count(*)::int
+from pg_stat_activity
+where datname = current_database()
+  and pid <> pg_backend_pid()
+  and state in ('active', 'idle in transaction')
+  and (
+    query ilike '%portfolio_aggregation_jobs%'
+    or query ilike '%portfolio_valuation_jobs%'
+    or query ilike '%daily_position_snapshots%'
+    or query ilike '%portfolio_timeseries%'
+    or query ilike '%position_timeseries%'
+  );
+
+select pg_terminate_backend(pid)
+from pg_stat_activity
+where datname = current_database()
+  and pid <> pg_backend_pid()
+  and state in ('active', 'idle in transaction')
+  and (
+    query ilike '%portfolio_aggregation_jobs%'
+    or query ilike '%portfolio_valuation_jobs%'
+    or query ilike '%daily_position_snapshots%'
+    or query ilike '%portfolio_timeseries%'
+    or query ilike '%position_timeseries%'
+  );
+"""
+    command = [
+        "docker",
+        "exec",
+        postgres_container,
+        "psql",
+        "-U",
+        "user",
+        "-d",
+        "portfolio_db",
+        "-At",
+        "-c",
+        sql,
+    ]
+    result = subprocess.run(command, check=False, capture_output=True, text=True)
+    if result.returncode != 0:
+        LOGGER.warning(
+            "Unable to terminate possible front-office seed cleanup blockers before retry: %s",
+            result.stderr.strip() or f"psql exited {result.returncode}",
+        )
+        return 0
+    output_lines = (result.stdout or "0").strip().splitlines()
+    terminated_count = sum(1 for line in output_lines[1:] if line.strip().lower() == "t")
+    if terminated_count:
+        return terminated_count
+    first_line = output_lines[0]
+    try:
+        return int(first_line)
+    except ValueError:
+        LOGGER.warning(
+            "Unable to parse terminated front-office seed cleanup blocker count from psql "
+            "output: %s",
+            result.stdout.strip(),
+        )
+        return 0
 
 
 def _verify_front_office_portfolio(


### PR DESCRIPTION
## Summary
- Add a bounded cleanup retry hardening path for canonical front-office reseeds when Core workers are concurrently touching valuation or aggregation queue tables.
- Terminate only active PostgreSQL sessions whose current query references the seed cleanup hot tables, then retry deterministic cleanup.

## Evidence
- Static: `python -m ruff check tools/front_office_portfolio_seed.py tests/unit/tools/test_front_office_portfolio_seed.py` -> passed.
- Format: `python -m ruff format --check tools/front_office_portfolio_seed.py tests/unit/tools/test_front_office_portfolio_seed.py` -> passed.
- Unit: `python -m pytest tests/unit/tools/test_front_office_portfolio_seed.py -q` -> 56 passed.
- Runtime: platform canonical QA reseed passed after this change; `PB_SG_GLOBAL_BAL_001` verified with 11 positions, 31 transactions, cash/positions quality COMPLETE, benchmark `BMK_PB_GLOBAL_BALANCED_60_40`, analytics/performance/return path at `2026-04-10`.
- Wiki/docs: no durable user-facing docs or repo-local wiki source changed; no wiki publish required.
- Non-degradation: retry remains bounded, table-scoped, and local-operator focused; no broad database session termination is introduced.