### PR TITLE
fix: restore unified runtime recovery and correction workflows

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -1909,10 +1909,13 @@ Most relevant current governance:
      external cash identifiers and generated-shaped identifiers in upstream-provided mode remain
      material conflict inputs.
      Canonical booked-transaction replay is the only path that may continue after an identical
-     semantic claim. It must carry the exact internal `lotus-transaction-processing-intent=repair`
-     delivery header, claim a separate physical repair-delivery fence inside the combined unit of
-     work, and retain semantic-conflict and epoch rejection. Missing or unknown intent remains
-     standard duplicate behavior; malformed or repeated intent headers fail closed. Cashflow repair
+     semantic claim or an explicit canonical correction. It must carry the exact internal
+     `lotus-transaction-processing-intent=repair` delivery header. Identical repair payloads claim
+     a separate physical repair-delivery fence; materially corrected payloads claim an immutable
+     `transaction-correction:v1` semantic identity containing the canonical SHA-256 fingerprint,
+     preserving the original semantic row and every distinct correction row. A standard changed
+     delivery, correction-identity conflict, missing or unknown intent remains fail-closed;
+     malformed or repeated intent headers fail closed too. Cashflow repair
      restores the canonical transaction/epoch row through an atomic PostgreSQL conflict-update
      keyed by the existing unique constraint instead of allowing its semantic fence to turn repair
      into a no-op or using a check-then-insert race for a missing row. Prove missing, corrupted, and
@@ -1952,7 +1955,8 @@ Most relevant current governance:
      epoch advancement. Record `coalesced/already_materialized`, do not read full history, advance
      epoch, delete/reinsert positions, or publish replay events, and keep normal ordered processing
      free of this extra query. This is safe because combined semantic idempotency rejects materially
-     changed content for the same transaction identity and the cost-basis key lock serializes the
+     changed content outside the explicit correction workflow; an accepted correction has its own
+     immutable identity and executes the governed rebuild. The cost-basis key lock serializes the
      caller-owned units of work. Any change requires concurrent committed backdated-trigger proof,
      exact current-epoch quantities/cost, one-winner epoch evidence, zero active-runtime replay
      fan-out, bounded recalculation work-volume metrics, and migration/index validation.

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -1865,7 +1865,11 @@ Most relevant current governance:
      identities. Static event guards must resolve dependency-injected consumer factory defaults so
      target DLQ wiring cannot disappear from certification. Full-stack tests must allocate the
      target's `LOTUS_TRANSACTION_PROCESSING_HOST_PORT`; never reintroduce deleted calculator ports
-     or rely on the app-local default when parallel stacks may run.
+     or rely on the app-local default when parallel stacks may run. Compose-backed recovery restart
+     sets and health checks must derive from `scripts/quality/ci_service_sets.py`, not duplicate a
+     local service list. Any operational driver that calls `build_test_runtime_env(...)` must use
+     the returned PostgreSQL, Kafka, and HTTP endpoints by default; fixed local endpoints are valid
+     only as explicit operator overrides after dynamic runtime allocation.
 140. Active target cost composition imports
      `cost_calculator_service.app.cost_calculation_workflow`, never the compatibility
      `app.consumer` module. Keep cost policy, financial staging, AVCO/FIFO state, corporate-action

--- a/docs/architecture/codebase-reviews/CR-1491-SEMANTIC-TRANSACTION-IDEMPOTENCY.md
+++ b/docs/architecture/codebase-reviews/CR-1491-SEMANTIC-TRANSACTION-IDEMPOTENCY.md
@@ -23,15 +23,25 @@ recalculating it.
 - The combined unit of work classifies claims as `claimed`, `physical_duplicate`,
   `semantic_duplicate`, or `semantic_conflict` before any financial module executes.
 - Identical duplicates return the existing `DUPLICATE` processing status. Material conflicts raise
-  terminal `transaction_semantic_conflict` for shared DLQ handling.
+  terminal `transaction_semantic_conflict` for shared DLQ handling unless they arrive through the
+  explicit canonical repair workflow.
+- A material repair payload claims an immutable `transaction-correction:v1` semantic key containing
+  its canonical SHA-256 fingerprint. The original semantic fence and every distinct correction
+  remain separate auditable rows; identical correction replay retains the physical repair-delivery
+  fence.
 - Metrics use the bounded claim outcomes and contain no portfolio or transaction labels.
 
 ## Compatibility
 
-The event schema, topic, public API, and ordinary successful result are unchanged. The intentional
-behavior change is that a second identical replay no longer emits another
+The event schema, topic, public API, and ordinary successful result are unchanged. Intentional
+behavior changes are that a second identical replay no longer emits another
 `ProcessedTransactionPersisted` compatibility event or reruns position processing. Pre-migration
 physical fences have null semantic fields and remain valid physical duplicates after deployment.
+
+Standard materially changed deliveries still fail terminally. The existing operational
+reprocessing API remains the explicit correction path: its internal repair header permits a new
+canonical payload to execute under a payload-specific immutable correction fence instead of being
+silently skipped or mutating the original claim.
 
 This supersedes CR-1455's expectation of one compatibility processed event per distinct replay
 offset. Replay publication remains auditable at its control boundary; repeated financial-state
@@ -50,6 +60,9 @@ schema rollback because the new worker reads and writes those fields.
 - Unified use case, adapter, consumer, and observability cohort: `21` tests.
 - Repository-native transaction-processing contract: `27 passed` in `113.76s` against PostgreSQL
   after rebuilding the migration-runner image.
+- Correction extension: `72` focused domain/use-case/position tests, `2` PostgreSQL correction
+  tests, repository-native transaction-processing contract `39 passed`, and the correction-to-
+  current-valuation E2E scenario passed in `66.59s` after rebuilding the combined runtime image.
 - Ruff, MyPy, Alembic single-head, migration contract, architecture boundary, in-process modularity,
   and in-process boundary checks passed.
 

--- a/scripts/operations/failure_recovery_gate.py
+++ b/scripts/operations/failure_recovery_gate.py
@@ -17,7 +17,7 @@ from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Protocol, cast
 
 import requests  # type: ignore[import-untyped]
 from portfolio_common.config import (
@@ -39,9 +39,13 @@ try:
         transaction_processing_counts,
         wait_for_database_count,
     )
-    from scripts.quality.ci_service_sets import FAILURE_RECOVERY_GATE_SERVICES
+    from scripts.quality.ci_service_sets import (
+        FAILURE_RECOVERY_GATE_SERVICES as _FAILURE_RECOVERY_GATE_SERVICES,
+    )
 except ModuleNotFoundError:  # pragma: no cover - direct script execution
-    from ci_service_sets import FAILURE_RECOVERY_GATE_SERVICES
+    from ci_service_sets import (  # type: ignore[no-redef]
+        FAILURE_RECOVERY_GATE_SERVICES as _FAILURE_RECOVERY_GATE_SERVICES,
+    )
     from transaction_processing_cutover_offsets import KafkaOffsetStore
     from transaction_processing_load_support import (
         TransactionProcessingCounts,
@@ -53,6 +57,27 @@ except ModuleNotFoundError:  # pragma: no cover - direct script execution
 
 TRANSACTION_PROCESSING_GROUP = "portfolio_transaction_processing_group"
 TRANSACTION_REPLAY_GROUP = "portfolio_transaction_replay_request_group"
+
+
+class RuntimeConnectionEndpoints(Protocol):
+    """Generated host endpoints required by the failure-recovery driver."""
+
+    host_database_url: str
+    kafka_bootstrap_servers: str
+
+
+def _resolve_runtime_connections(
+    *,
+    requested_host_database_url: str | None,
+    requested_kafka_bootstrap_servers: str | None,
+    endpoints: RuntimeConnectionEndpoints,
+) -> tuple[str, str]:
+    """Prefer explicit operator endpoints and otherwise use the isolated test runtime."""
+
+    return (
+        requested_host_database_url or endpoints.host_database_url,
+        requested_kafka_bootstrap_servers or endpoints.kafka_bootstrap_servers,
+    )
 
 
 class RecoveryMode(StrEnum):
@@ -398,9 +423,9 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--event-replay-base-url", default=None)
     parser.add_argument(
         "--host-database-url",
-        default="postgresql://user:password@localhost:55432/portfolio_db",
+        default=None,
     )
-    parser.add_argument("--kafka-bootstrap-servers", default="localhost:9092")
+    parser.add_argument("--kafka-bootstrap-servers", default=None)
     parser.add_argument("--transaction-topic", default=KAFKA_TRANSACTIONS_PERSISTED_TOPIC)
     parser.add_argument("--consumer-group", default=TRANSACTION_PROCESSING_GROUP)
     parser.add_argument(
@@ -458,9 +483,14 @@ def main() -> int:
     ingestion_base_url = args.ingestion_base_url or endpoints.e2e_ingestion_url
     query_base_url = args.query_base_url or endpoints.e2e_query_url
     event_replay_base_url = args.event_replay_base_url or endpoints.e2e_event_replay_url
-    engine = create_engine(args.host_database_url, pool_pre_ping=True)
+    host_database_url, kafka_bootstrap_servers = _resolve_runtime_connections(
+        requested_host_database_url=args.host_database_url,
+        requested_kafka_bootstrap_servers=args.kafka_bootstrap_servers,
+        endpoints=endpoints,
+    )
+    engine = create_engine(host_database_url, pool_pre_ping=True)
     offset_store = KafkaOffsetStore(
-        bootstrap_servers=args.kafka_bootstrap_servers,
+        bootstrap_servers=kafka_bootstrap_servers,
         timeout_seconds=10,
     )
 
@@ -469,7 +499,7 @@ def main() -> int:
             compose_up(
                 args.compose_file,
                 build=args.build,
-                services=list(FAILURE_RECOVERY_GATE_SERVICES),
+                services=list(_FAILURE_RECOVERY_GATE_SERVICES),
             )
             wait_for_migration_runner(
                 args.compose_file,

--- a/scripts/quality/ci_service_sets.py
+++ b/scripts/quality/ci_service_sets.py
@@ -66,6 +66,27 @@ INSTITUTIONAL_COMPLETION_GATE_SERVICES: tuple[str, ...] = (
     "financial_reconciliation_service",
 )
 
+E2E_RECOVERY_SERVICES: tuple[str, ...] = tuple(
+    service
+    for service in INSTITUTIONAL_COMPLETION_GATE_SERVICES
+    if service not in RUNTIME_BOOTSTRAP_SERVICES
+)
+
+E2E_RECOVERY_HEALTH_PORT_ENV: dict[str, str] = {
+    "ingestion_service": "LOTUS_INGESTION_HOST_PORT",
+    "event_replay_service": "LOTUS_EVENT_REPLAY_HOST_PORT",
+    "financial_reconciliation_service": "LOTUS_FINANCIAL_RECONCILIATION_HOST_PORT",
+    "query_service": "LOTUS_QUERY_HOST_PORT",
+    "query_control_plane_service": "LOTUS_QUERY_CONTROL_PLANE_HOST_PORT",
+    "persistence_service": "LOTUS_PERSISTENCE_HOST_PORT",
+    "portfolio_transaction_processing_service": "LOTUS_TRANSACTION_PROCESSING_HOST_PORT",
+    "pipeline_orchestrator_service": "LOTUS_PIPELINE_ORCHESTRATOR_HOST_PORT",
+    "position_valuation_calculator": "LOTUS_POSITION_VALUATION_HOST_PORT",
+    "timeseries_generator_service": "LOTUS_TIMESERIES_GENERATOR_HOST_PORT",
+    "valuation_orchestrator_service": "LOTUS_VALUATION_ORCHESTRATOR_HOST_PORT",
+    "portfolio_aggregation_service": "LOTUS_PORTFOLIO_AGGREGATION_HOST_PORT",
+}
+
 PREBUILD_GROUPS: dict[str, tuple[str, ...]] = {
     "query-only": QUERY_BUILD_SERVICES,
     "docker-smoke": DOCKER_SMOKE_SERVICES,

--- a/src/services/calculators/position_calculator/app/core/position_logic.py
+++ b/src/services/calculators/position_calculator/app/core/position_logic.py
@@ -45,6 +45,8 @@ class PositionCalculator:
         db_session: AsyncSession,
         repo: PositionRepository,
         position_state_repo: PositionStateRepository,
+        *,
+        rebuild_existing: bool = False,
     ) -> PositionCalculationResult:
         """
         Orchestrates recalculation and reprocessing triggers for a single transaction event.
@@ -74,11 +76,8 @@ class PositionCalculator:
         if replay_decision.should_queue_replay:
             if replay_decision.replay_watermark_date is None:
                 raise RuntimeError("Backdated replay decision did not include a replay watermark.")
-            if await repo.is_transaction_materialized(
-                portfolio_id,
-                security_id,
-                event.transaction_id,
-                current_state.epoch,
+            if not rebuild_existing and await repo.is_transaction_materialized(
+                portfolio_id, security_id, event.transaction_id, current_state.epoch
             ):
                 POSITION_RECALCULATION_COORDINATION_TOTAL.labels(
                     outcome="coalesced",

--- a/src/services/portfolio_transaction_processing_service/app/application/process_transaction.py
+++ b/src/services/portfolio_transaction_processing_service/app/application/process_transaction.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from ..domain import BookedTransaction, build_transaction_semantic_identity
+from ..domain import (
+    BookedTransaction,
+    build_transaction_correction_identity,
+    build_transaction_semantic_identity,
+)
 from ..ports import (
     PositionProcessingResult,
     TransactionIdempotencyOutcome,
@@ -97,6 +101,22 @@ class ProcessTransactionUseCase:
                     payload_fingerprint=identity.payload_fingerprint,
                     correlation_id=metadata.correlation_id,
                 )
+                correction_claimed = False
+                if (
+                    idempotency_outcome is TransactionIdempotencyOutcome.SEMANTIC_CONFLICT
+                    and metadata.processing_intent is TransactionProcessingIntent.REPAIR
+                ):
+                    identity = build_transaction_correction_identity(transaction)
+                    idempotency_outcome = await unit_of_work.idempotency.claim(
+                        event_id=metadata.event_id,
+                        portfolio_id=transaction.portfolio_id,
+                        semantic_key=identity.semantic_key,
+                        payload_fingerprint=identity.payload_fingerprint,
+                        correlation_id=metadata.correlation_id,
+                    )
+                    correction_claimed = (
+                        idempotency_outcome is TransactionIdempotencyOutcome.CLAIMED
+                    )
                 repair_delivery_claimed = (
                     idempotency_outcome is TransactionIdempotencyOutcome.SEMANTIC_DUPLICATE
                     and metadata.processing_intent is TransactionProcessingIntent.REPAIR
@@ -106,7 +126,7 @@ class ProcessTransactionUseCase:
                         correlation_id=metadata.correlation_id,
                     )
                 )
-                if repair_delivery_claimed:
+                if correction_claimed or repair_delivery_claimed:
                     idempotency_observation.set_outcome(TransactionProcessingOutcome.REPLAYED)
                 elif idempotency_outcome is not TransactionIdempotencyOutcome.CLAIMED:
                     idempotency_observation.set_outcome(
@@ -149,6 +169,7 @@ class ProcessTransactionUseCase:
                             processed_transaction,
                             correlation_id=metadata.correlation_id,
                             traceparent=metadata.traceparent,
+                            rebuild_existing=correction_claimed,
                         )
                     )
             rebuilt_transactions = _rebuilt_position_transactions(position_results)

--- a/src/services/portfolio_transaction_processing_service/app/domain/__init__.py
+++ b/src/services/portfolio_transaction_processing_service/app/domain/__init__.py
@@ -7,8 +7,10 @@ from .average_cost_pool_reconciliation import (
 )
 from .booked_transaction import BookedTransaction
 from .transaction_semantic_identity import (
+    TRANSACTION_CORRECTION_IDENTITY_VERSION,
     TRANSACTION_SEMANTIC_IDENTITY_VERSION,
     TransactionSemanticIdentity,
+    build_transaction_correction_identity,
     build_transaction_semantic_identity,
 )
 
@@ -17,7 +19,9 @@ __all__ = [
     "AverageCostPoolReconciliationAssessment",
     "AverageCostPoolReconciliationStatus",
     "BookedTransaction",
+    "TRANSACTION_CORRECTION_IDENTITY_VERSION",
     "TRANSACTION_SEMANTIC_IDENTITY_VERSION",
     "TransactionSemanticIdentity",
+    "build_transaction_correction_identity",
     "build_transaction_semantic_identity",
 ]

--- a/src/services/portfolio_transaction_processing_service/app/domain/transaction_semantic_identity.py
+++ b/src/services/portfolio_transaction_processing_service/app/domain/transaction_semantic_identity.py
@@ -10,6 +10,7 @@ from typing import Any
 from .booked_transaction import BookedTransaction
 
 TRANSACTION_SEMANTIC_IDENTITY_VERSION = "v1"
+TRANSACTION_CORRECTION_IDENTITY_VERSION = "v1"
 _PROCESSOR_OWNED_OUTPUT_FIELDS = frozenset(
     {
         "allocated_cost_basis_base",
@@ -72,6 +73,28 @@ def build_transaction_semantic_identity(
     return TransactionSemanticIdentity(
         semantic_key=semantic_key,
         payload_fingerprint=payload_fingerprint,
+    )
+
+
+def build_transaction_correction_identity(
+    transaction: BookedTransaction,
+) -> TransactionSemanticIdentity:
+    """Build an immutable identity for one explicit canonical correction payload."""
+
+    base_identity = build_transaction_semantic_identity(transaction)
+    semantic_key = ":".join(
+        (
+            "transaction-correction",
+            TRANSACTION_CORRECTION_IDENTITY_VERSION,
+            transaction.portfolio_id.strip(),
+            transaction.transaction_id.strip(),
+            str(transaction.epoch or 0),
+            base_identity.payload_fingerprint,
+        )
+    )
+    return TransactionSemanticIdentity(
+        semantic_key=semantic_key,
+        payload_fingerprint=base_identity.payload_fingerprint,
     )
 
 

--- a/src/services/portfolio_transaction_processing_service/app/infrastructure/position_processing_adapter.py
+++ b/src/services/portfolio_transaction_processing_service/app/infrastructure/position_processing_adapter.py
@@ -21,6 +21,7 @@ class PositionStagingWorkflow(Protocol):
         db_session: AsyncSession,
         repo: position_repository.PositionRepository,
         position_state_repo: PositionStateRepository,
+        rebuild_existing: bool = False,
     ) -> position_logic.PositionCalculationResult: ...
 
 
@@ -33,12 +34,14 @@ class CombinedPositionCalculationWorkflow:
         db_session: AsyncSession,
         repo: position_repository.PositionRepository,
         position_state_repo: PositionStateRepository,
+        rebuild_existing: bool = False,
     ) -> position_logic.PositionCalculationResult:
         return await position_logic.PositionCalculator.calculate(
             event=event,
             db_session=db_session,
             repo=repo,
             position_state_repo=position_state_repo,
+            rebuild_existing=rebuild_existing,
         )
 
 
@@ -64,6 +67,7 @@ class PositionProcessingCompatibilityAdapter:
         *,
         correlation_id: str | None,
         traceparent: str | None,
+        rebuild_existing: bool = False,
     ) -> PositionProcessingResult:
         stage_result = await self._workflow.calculate(
             event=to_transaction_event(
@@ -74,6 +78,7 @@ class PositionProcessingCompatibilityAdapter:
             db_session=self._db_session,
             repo=self._repository,
             position_state_repo=self._position_state_repository,
+            rebuild_existing=rebuild_existing,
         )
         return PositionProcessingResult(
             position_record_count=stage_result.position_record_count,

--- a/src/services/portfolio_transaction_processing_service/app/ports/transaction_processing.py
+++ b/src/services/portfolio_transaction_processing_service/app/ports/transaction_processing.py
@@ -83,6 +83,7 @@ class PositionProcessingPort(Protocol):
         *,
         correlation_id: str | None,
         traceparent: str | None,
+        rebuild_existing: bool = False,
     ) -> PositionProcessingResult: ...
 
 

--- a/tests/e2e/test_failure_scenarios.py
+++ b/tests/e2e/test_failure_scenarios.py
@@ -11,6 +11,10 @@ from confluent_kafka import Consumer
 from portfolio_common.config import KAFKA_BOOTSTRAP_SERVERS, KAFKA_PERSISTENCE_SERVICE_DLQ_TOPIC
 from sqlalchemy import exc, text
 
+from scripts.quality.ci_service_sets import (
+    E2E_RECOVERY_HEALTH_PORT_ENV,
+    E2E_RECOVERY_SERVICES,
+)
 from tests.test_support.output_control import emit_test_output
 
 from .api_client import E2EApiClient
@@ -23,14 +27,8 @@ def _compose_args(*compose_args: str) -> list[str]:
 
 def _core_service_health_urls() -> list[str]:
     return [
-        f"http://localhost:{os.environ['LOTUS_PERSISTENCE_HOST_PORT']}/health/ready",
-        f"http://localhost:{os.environ['LOTUS_POSITION_CALCULATOR_HOST_PORT']}/health/ready",
-        f"http://localhost:{os.environ['LOTUS_CASHFLOW_CALCULATOR_HOST_PORT']}/health/ready",
-        f"http://localhost:{os.environ['LOTUS_COST_CALCULATOR_HOST_PORT']}/health/ready",
-        f"http://localhost:{os.environ['LOTUS_POSITION_VALUATION_HOST_PORT']}/health/ready",
-        f"http://localhost:{os.environ['LOTUS_TIMESERIES_GENERATOR_HOST_PORT']}/health/ready",
-        f"http://localhost:{os.environ['LOTUS_INGESTION_HOST_PORT']}/health/ready",
-        f"http://localhost:{os.environ['LOTUS_QUERY_HOST_PORT']}/health/ready",
+        f"http://localhost:{os.environ[E2E_RECOVERY_HEALTH_PORT_ENV[service]]}/health/ready"
+        for service in E2E_RECOVERY_SERVICES
     ]
 
 
@@ -241,17 +239,7 @@ def test_db_outage_recovery(
     # 9. RECOVERY BARRIER: restart all core services and wait for end-to-end readiness
     emit_test_output("\n--- Restarting all core services after DB outage scenario ---")
     subprocess.run(
-        _compose_args(
-            "restart",
-            "ingestion_service",
-            "query_service",
-            "persistence_service",
-            "position_calculator_service",
-            "cashflow_calculator_service",
-            "cost_calculator_service",
-            "position_valuation_calculator",
-            "timeseries_generator_service",
-        ),
+        _compose_args("restart", *E2E_RECOVERY_SERVICES),
         check=True,
         capture_output=True,
     )

--- a/tests/e2e/test_transaction_type_coverage_matrix.py
+++ b/tests/e2e/test_transaction_type_coverage_matrix.py
@@ -73,6 +73,25 @@ def test_transaction_type_coverage_fixture_is_deduplicated_and_comprehensive():
     tax_payload = next(item for item in tx_payloads if item["transaction_type"] == "TAX")
     assert tax_payload["security_id"] == "CASH_USD_COVER_DRYRUN"
     assert tax_payload["instrument_id"] == "CASH_USD_COVER_DRYRUN"
+    cash_consideration = next(
+        item for item in tx_payloads if item["transaction_type"] == "CASH_CONSIDERATION"
+    )
+    assert cash_consideration["quantity"] == "0"
+    assert cash_consideration["price"] == "0"
+    assert cash_consideration["allocated_cost_basis_local"] == "50"
+    assert cash_consideration["allocated_cost_basis_base"] == "50"
+    cash_in_lieu = next(item for item in tx_payloads if item["transaction_type"] == "CASH_IN_LIEU")
+    assert cash_in_lieu["allocated_cost_basis_local"] == "101.50"
+    assert cash_in_lieu["allocated_cost_basis_base"] == "101.50"
+    for fx_type in ("FX_FORWARD", "FX_SPOT", "FX_SWAP"):
+        fx_payload = next(item for item in tx_payloads if item["transaction_type"] == fx_type)
+        assert fx_payload["quantity"] == "0"
+        assert fx_payload["price"] == "0"
+        assert fx_payload["pair_base_currency"] == "EUR"
+        assert fx_payload["pair_quote_currency"] == "USD"
+        assert fx_payload["buy_currency"] == "USD"
+        assert fx_payload["sell_currency"] == "EUR"
+        assert Decimal(fx_payload["contract_rate"]) > 0
 
 
 def test_cashflow_rules_cover_every_supported_transaction_type(db_engine):
@@ -113,7 +132,8 @@ def test_all_supported_transaction_types_are_ingestable_queryable_and_cashflowed
 
     poll_db_until(
         query="""
-            SELECT count(DISTINCT t.transaction_type)
+            SELECT count(DISTINCT t.transaction_type),
+                   array_agg(DISTINCT t.transaction_type ORDER BY t.transaction_type)
             FROM transactions t
             JOIN cashflows c ON c.transaction_id = t.transaction_id
             WHERE t.portfolio_id = :portfolio_id

--- a/tests/e2e/timeseries_support.py
+++ b/tests/e2e/timeseries_support.py
@@ -44,12 +44,12 @@ EXPECTED_PORTFOLIO_TIMESERIES = {
     "2025-08-28": {
         "beginning_market_value": Decimal("0"),
         "ending_market_value": Decimal("5720"),
-        "valuation_status": "restated",
+        "valuation_status": "final",
     },
     "2025-08-29": {
         "beginning_market_value": Decimal("6240"),
         "ending_market_value": Decimal("6575"),
-        "valuation_status": "restated",
+        "valuation_status": "final",
     },
 }
 

--- a/tests/e2e/transaction_type_coverage_support.py
+++ b/tests/e2e/transaction_type_coverage_support.py
@@ -81,7 +81,10 @@ def build_transaction_payloads(
         gross = Decimal("100")
         trade_fee = Decimal("0")
 
-        if tx_type in {"DIVIDEND", "INTEREST"}:
+        if tx_type == "CASH_CONSIDERATION":
+            quantity = Decimal("0")
+            price = Decimal("0")
+        elif tx_type in {"DIVIDEND", "INTEREST"}:
             quantity = Decimal("0")
             price = Decimal("0")
         elif tx_type == "ADJUSTMENT":
@@ -108,6 +111,41 @@ def build_transaction_payloads(
             "linked_transaction_group_id": f"LTG-{portfolio_id}",
             "trade_fee": str(trade_fee),
         }
+        if tx_type in {"FX_FORWARD", "FX_SPOT", "FX_SWAP"}:
+            event.update(
+                {
+                    "settlement_date": iso_z(ts),
+                    "component_type": (
+                        "FX_CASH_SETTLEMENT_BUY" if tx_type == "FX_SPOT" else "FX_CONTRACT_OPEN"
+                    ),
+                    "component_id": f"{tx_id}-COMPONENT",
+                    "calculation_policy_id": "FX_DEFAULT_POLICY",
+                    "calculation_policy_version": "1.0.0",
+                    "quantity": "0",
+                    "price": "0",
+                    "pair_base_currency": "EUR",
+                    "pair_quote_currency": "USD",
+                    "fx_rate_quote_convention": "QUOTE_PER_BASE",
+                    "buy_currency": "USD",
+                    "sell_currency": "EUR",
+                    "buy_amount": "110",
+                    "sell_amount": "100",
+                    "contract_rate": "1.10",
+                    "spot_exposure_model": "NONE",
+                    "fx_realized_pnl_mode": "NONE",
+                }
+            )
+            if tx_type == "FX_SPOT":
+                event["fx_cash_leg_role"] = "BUY"
+                event["linked_fx_cash_leg_id"] = f"{tx_id}-SELL"
+                event["settlement_status"] = "SETTLED"
+            else:
+                event["fx_contract_id"] = f"{tx_id}-CONTRACT"
+                event["fx_contract_open_transaction_id"] = tx_id
+            if tx_type == "FX_SWAP":
+                event["swap_event_id"] = f"{tx_id}-SWAP"
+                event["near_leg_group_id"] = f"{tx_id}-NEAR"
+                event["far_leg_group_id"] = f"{tx_id}-FAR"
         if tx_type == "ADJUSTMENT":
             event["movement_direction"] = "INFLOW"
             event["adjustment_reason"] = "TEST_COVERAGE"
@@ -121,6 +159,11 @@ def build_transaction_payloads(
             link_ref = f"{portfolio_id}_ADJ_LINK_00"
             event["linked_cash_transaction_id"] = link_ref
             event["external_cash_transaction_id"] = link_ref
+            event["allocated_cost_basis_local"] = "50"
+            event["allocated_cost_basis_base"] = "50"
+        elif tx_type == "CASH_IN_LIEU":
+            event["allocated_cost_basis_local"] = "101.50"
+            event["allocated_cost_basis_base"] = "101.50"
 
         payloads.append(event)
 

--- a/tests/integration/services/calculators/cost_calculator_service/test_int_cost_consumer_persistence.py
+++ b/tests/integration/services/calculators/cost_calculator_service/test_int_cost_consumer_persistence.py
@@ -121,9 +121,7 @@ async def test_adjustment_message_persists_outbox_and_idempotency(
     persisted_transaction = (
         (
             await async_db_session.execute(
-                select(DBTransaction).where(
-                    DBTransaction.transaction_id == "ADJ-COST-INT-01"
-                )
+                select(DBTransaction).where(DBTransaction.transaction_id == "ADJ-COST-INT-01")
             )
         )
         .scalars()

--- a/tests/integration/services/calculators/cost_calculator_service/test_int_cost_consumer_persistence.py
+++ b/tests/integration/services/calculators/cost_calculator_service/test_int_cost_consumer_persistence.py
@@ -41,6 +41,21 @@ async def test_adjustment_message_persists_outbox_and_idempotency(
             status="ACTIVE",
         )
     )
+    async_db_session.add(
+        DBTransaction(
+            transaction_id="ADJ-COST-INT-01",
+            portfolio_id="PORT-COST-INT-01",
+            instrument_id="CASH",
+            security_id="CASH",
+            transaction_date=datetime(2026, 1, 5, 10, 0, 0),
+            transaction_type="ADJUSTMENT",
+            quantity=Decimal("0"),
+            price=Decimal("0"),
+            gross_transaction_amount=Decimal("125.50"),
+            trade_currency="USD",
+            currency="USD",
+        )
+    )
     await async_db_session.commit()
 
     event = TransactionEvent(
@@ -103,12 +118,25 @@ async def test_adjustment_message_persists_outbox_and_idempotency(
         .scalars()
         .all()
     )
+    persisted_transaction = (
+        (
+            await async_db_session.execute(
+                select(DBTransaction).where(
+                    DBTransaction.transaction_id == "ADJ-COST-INT-01"
+                )
+            )
+        )
+        .scalars()
+        .one()
+    )
 
     assert len(outbox_rows) == 1
     assert outbox_rows[0].correlation_id == "corr-cost-int-01"
     assert outbox_rows[0].payload["transaction_id"] == "ADJ-COST-INT-01"
     assert len(processed_rows) == 1
     assert processed_rows[0].correlation_id == "corr-cost-int-01"
+    assert persisted_transaction.net_cost_local == Decimal("125.50")
+    assert persisted_transaction.net_cost == Decimal("125.50")
 
 
 async def test_buy_then_sell_processing_reconciles_open_lot_quantity(

--- a/tests/integration/services/portfolio_transaction_processing_service/test_int_atomic_unit_of_work.py
+++ b/tests/integration/services/portfolio_transaction_processing_service/test_int_atomic_unit_of_work.py
@@ -13,10 +13,15 @@ from src.services.portfolio_transaction_processing_service.app.application impor
     ProcessTransactionCommand,
     ProcessTransactionUseCase,
     TransactionEventMetadata,
+    TransactionProcessingIntent,
     TransactionProcessingRejected,
     TransactionProcessingStatus,
 )
-from src.services.portfolio_transaction_processing_service.app.domain import BookedTransaction
+from src.services.portfolio_transaction_processing_service.app.domain import (
+    BookedTransaction,
+    build_transaction_correction_identity,
+    build_transaction_semantic_identity,
+)
 from src.services.portfolio_transaction_processing_service.app.infrastructure import (
     PROMETHEUS_TRANSACTION_PROCESSING_OBSERVER,
     TRANSACTION_PROCESSING_SERVICE_NAME,
@@ -209,6 +214,59 @@ async def test_semantic_fence_suppresses_republication_and_rejects_changed_paylo
             )
         )
     assert semantic_fence_count == 1
+
+
+async def test_explicit_repair_claims_immutable_payload_specific_correction_identity(
+    clean_db,
+    async_db_session: AsyncSession,
+) -> None:
+    session_factory = async_sessionmaker(async_db_session.bind, expire_on_commit=False)
+    original = _command("CORRECTION")
+    corrected = replace(
+        original,
+        transaction=replace(
+            original.transaction,
+            quantity=Decimal("12"),
+            gross_transaction_amount=Decimal("306.00"),
+        ),
+        metadata=replace(
+            original.metadata,
+            event_id="transactions.corrected-1-902",
+            processing_intent=TransactionProcessingIntent.REPAIR,
+        ),
+    )
+    use_case = ProcessTransactionUseCase(
+        _unit_of_work_factory(session_factory, fail_at=None),
+        observer=PROMETHEUS_TRANSACTION_PROCESSING_OBSERVER,
+    )
+
+    original_result = await use_case.execute(original)
+    corrected_result = await use_case.execute(corrected)
+
+    assert original_result.status is TransactionProcessingStatus.PROCESSED
+    assert corrected_result.status is TransactionProcessingStatus.PROCESSED
+    original_identity = build_transaction_semantic_identity(original.transaction)
+    correction_identity = build_transaction_correction_identity(corrected.transaction)
+    async with session_factory() as session:
+        semantic_rows = (
+            (
+                await session.execute(
+                    select(ProcessedEvent.semantic_key, ProcessedEvent.payload_fingerprint)
+                    .where(
+                        ProcessedEvent.service_name == TRANSACTION_PROCESSING_SERVICE_NAME,
+                        ProcessedEvent.semantic_key.isnot(None),
+                    )
+                    .order_by(ProcessedEvent.id)
+                )
+            )
+            .tuples()
+            .all()
+        )
+
+    assert semantic_rows == [
+        (original_identity.semantic_key, original_identity.payload_fingerprint),
+        (correction_identity.semantic_key, correction_identity.payload_fingerprint),
+    ]
 
 
 @pytest.mark.parametrize("fail_at", ["cost", "cashflow", "position"])

--- a/tests/integration/services/portfolio_transaction_processing_service/test_int_combined_backdated_processing.py
+++ b/tests/integration/services/portfolio_transaction_processing_service/test_int_combined_backdated_processing.py
@@ -12,12 +12,14 @@ from portfolio_common.database_models import (
     PositionHistory,
     PositionLotState,
     PositionState,
+    ProcessedEvent,
 )
 from portfolio_common.database_models import Transaction as DBTransaction
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.services.portfolio_transaction_processing_service.app.application import (
+    TransactionProcessingIntent,
     TransactionProcessingStatus,
 )
 from tests.test_support.transaction_processing import (
@@ -25,6 +27,7 @@ from tests.test_support.transaction_processing import (
     instrument_record,
     persist_and_process_booked_transaction,
     portfolio_record,
+    process_booked_transaction,
     transaction_processing_test_context,
 )
 
@@ -208,6 +211,128 @@ async def test_backdated_transaction_rebuilds_current_epoch_without_legacy_repla
         stage.transaction_id for stage in current_pipeline_stages
     }
     assert legacy_replay_event_count == 0
+
+
+async def test_explicit_correction_rebuilds_already_materialized_position_history(
+    clean_db,
+    async_db_session: AsyncSession,
+) -> None:
+    portfolio_id = "PORT-COMBINED-CORRECTION-01"
+    security_id = "SEC-COMBINED-CORRECTION-01"
+    first_buy = booked_transaction_event(
+        transaction_id="BUY-COMBINED-CORRECTION-DAY1",
+        portfolio_id=portfolio_id,
+        security_id=security_id,
+        transaction_date=datetime(2026, 1, 5, 10, 0, tzinfo=timezone.utc),
+        transaction_type="BUY",
+        quantity="100",
+        price="100",
+        gross_amount="10000",
+    )
+    later_buy = booked_transaction_event(
+        transaction_id="BUY-COMBINED-CORRECTION-DAY3",
+        portfolio_id=portfolio_id,
+        security_id=security_id,
+        transaction_date=datetime(2026, 1, 7, 10, 0, tzinfo=timezone.utc),
+        transaction_type="BUY",
+        quantity="50",
+        price="120",
+        gross_amount="6000",
+    )
+    async_db_session.add_all(
+        [
+            portfolio_record(portfolio_id),
+            instrument_record(
+                security_id,
+                name="Combined Correction Equity",
+                isin="SG0000000299",
+                currency="USD",
+            ),
+        ]
+    )
+    await async_db_session.commit()
+    context = transaction_processing_test_context(async_db_session)
+    await persist_and_process_booked_transaction(
+        session=async_db_session,
+        context=context,
+        event=first_buy,
+        event_id="transactions.persisted-0-9291",
+        correlation_id="corr-combined-correction-01",
+    )
+    await persist_and_process_booked_transaction(
+        session=async_db_session,
+        context=context,
+        event=later_buy,
+        event_id="transactions.persisted-0-9292",
+        correlation_id="corr-combined-correction-01",
+    )
+
+    await async_db_session.execute(
+        update(DBTransaction)
+        .where(DBTransaction.transaction_id == first_buy.transaction_id)
+        .values(quantity=Decimal("120"), gross_transaction_amount=Decimal("12000"))
+    )
+    await async_db_session.commit()
+    corrected_first_buy = first_buy.model_copy(
+        update={
+            "quantity": Decimal("120"),
+            "gross_transaction_amount": Decimal("12000"),
+        }
+    )
+
+    correction_result = await process_booked_transaction(
+        context=context,
+        event=corrected_first_buy,
+        event_id="transactions.persisted-0-9293",
+        correlation_id="corr-combined-correction-01",
+        processing_intent=TransactionProcessingIntent.REPAIR,
+    )
+
+    assert correction_result.status is TransactionProcessingStatus.PROCESSED
+    assert correction_result.position_record_count == 2
+    async with context.session_factory() as verification_session:
+        state = (
+            await verification_session.execute(
+                select(PositionState).where(
+                    PositionState.portfolio_id == portfolio_id,
+                    PositionState.security_id == security_id,
+                )
+            )
+        ).scalar_one()
+        positions = (
+            (
+                await verification_session.execute(
+                    select(PositionHistory)
+                    .where(
+                        PositionHistory.portfolio_id == portfolio_id,
+                        PositionHistory.security_id == security_id,
+                        PositionHistory.epoch == state.epoch,
+                    )
+                    .order_by(PositionHistory.position_date)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        correction_fence_count = int(
+            await verification_session.scalar(
+                select(func.count())
+                .select_from(ProcessedEvent)
+                .where(
+                    ProcessedEvent.service_name == "portfolio-transaction-processing",
+                    ProcessedEvent.semantic_key.like("transaction-correction:v1:%"),
+                )
+            )
+            or 0
+        )
+
+    assert state.epoch == 1
+    assert [position.quantity for position in positions] == [Decimal("120"), Decimal("170")]
+    assert [position.cost_basis for position in positions] == [
+        Decimal("12000"),
+        Decimal("18000"),
+    ]
+    assert correction_fence_count == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/scripts/test_ci_service_sets.py
+++ b/tests/unit/scripts/test_ci_service_sets.py
@@ -1,11 +1,15 @@
 from scripts.quality.ci_service_sets import (
     DOCKER_SMOKE_SERVICES,
+    E2E_RECOVERY_HEALTH_PORT_ENV,
+    E2E_RECOVERY_SERVICES,
     E2E_SMOKE_SERVICES,
     FAILURE_RECOVERY_GATE_SERVICES,
+    INSTITUTIONAL_COMPLETION_GATE_SERVICES,
     LATENCY_GATE_SERVICES,
     PERFORMANCE_GATE_SERVICES,
     RUNTIME_BOOTSTRAP_SERVICES,
 )
+from tests.e2e.test_failure_scenarios import _core_service_health_urls
 
 
 def test_docker_smoke_services_use_the_combined_transaction_processor() -> None:
@@ -43,6 +47,26 @@ def test_compose_runtime_sets_use_only_the_combined_transaction_processor() -> N
         LATENCY_GATE_SERVICES,
         PERFORMANCE_GATE_SERVICES,
         FAILURE_RECOVERY_GATE_SERVICES,
+        E2E_RECOVERY_SERVICES,
     ):
         assert target in group
         assert not legacy_workers.intersection(group)
+
+
+def test_e2e_recovery_restarts_only_long_running_application_services() -> None:
+    assert not set(RUNTIME_BOOTSTRAP_SERVICES).intersection(E2E_RECOVERY_SERVICES)
+    assert set(E2E_RECOVERY_SERVICES) == set(INSTITUTIONAL_COMPLETION_GATE_SERVICES).difference(
+        RUNTIME_BOOTSTRAP_SERVICES
+    )
+    assert set(E2E_RECOVERY_HEALTH_PORT_ENV) == set(E2E_RECOVERY_SERVICES)
+
+
+def test_e2e_recovery_health_checks_use_combined_transaction_runtime(monkeypatch) -> None:
+    for index, name in enumerate(E2E_RECOVERY_HEALTH_PORT_ENV.values(), start=8100):
+        monkeypatch.setenv(name, str(index))
+    monkeypatch.setenv("LOTUS_TRANSACTION_PROCESSING_HOST_PORT", "8190")
+
+    health_urls = _core_service_health_urls()
+
+    assert "http://localhost:8190/health/ready" in health_urls
+    assert len(health_urls) == len(E2E_RECOVERY_SERVICES)

--- a/tests/unit/scripts/test_failure_recovery_gate.py
+++ b/tests/unit/scripts/test_failure_recovery_gate.py
@@ -9,6 +9,7 @@ from scripts.operations.failure_recovery_gate import (
     _consumer_lag,
     _evaluate_recovery_result,
     _resolve_interruption_container,
+    _resolve_runtime_connections,
     _set_container_pause,
 )
 from scripts.operations.transaction_processing_load_support import TransactionProcessingCounts
@@ -21,6 +22,42 @@ def _complete_counts(records: int) -> TransactionProcessingCounts:
         cashflow_count=records,
         position_count=records,
         processing_claim_count=records,
+    )
+
+
+def test_runtime_connections_default_to_generated_isolated_endpoints() -> None:
+    endpoints = SimpleNamespace(
+        host_database_url="postgresql://localhost:62362/portfolio_db",
+        kafka_bootstrap_servers="localhost:62360",
+    )
+
+    resolved = _resolve_runtime_connections(
+        requested_host_database_url=None,
+        requested_kafka_bootstrap_servers=None,
+        endpoints=endpoints,
+    )
+
+    assert resolved == (
+        "postgresql://localhost:62362/portfolio_db",
+        "localhost:62360",
+    )
+
+
+def test_runtime_connections_preserve_explicit_operator_overrides() -> None:
+    endpoints = SimpleNamespace(
+        host_database_url="postgresql://localhost:62362/portfolio_db",
+        kafka_bootstrap_servers="localhost:62360",
+    )
+
+    resolved = _resolve_runtime_connections(
+        requested_host_database_url="postgresql://db.example/core",
+        requested_kafka_bootstrap_servers="kafka.example:9092",
+        endpoints=endpoints,
+    )
+
+    assert resolved == (
+        "postgresql://db.example/core",
+        "kafka.example:9092",
     )
 
 

--- a/tests/unit/services/calculators/position_calculator/core/test_position_logic.py
+++ b/tests/unit/services/calculators/position_calculator/core/test_position_logic.py
@@ -10,7 +10,10 @@ from portfolio_common.database_models import Transaction as DBTransaction
 from portfolio_common.events import TransactionEvent
 from portfolio_common.position_state_repository import PositionStateRepository
 
-from src.services.calculators.position_calculator.app.core.position_logic import PositionCalculator
+from src.services.calculators.position_calculator.app.core.position_logic import (
+    PositionCalculationResult,
+    PositionCalculator,
+)
 from src.services.calculators.position_calculator.app.core.position_models import (
     PositionState as PositionStateDTO,
 )
@@ -410,6 +413,37 @@ async def test_calculate_coalesces_backdated_event_already_materialized_in_curre
     mock_coordination_metric.labels.return_value.inc.assert_called_once_with()
     mock_work_metric.labels.assert_called_once_with(mode="coalesced")
     mock_work_metric.labels.return_value.observe.assert_called_once_with(0)
+
+
+@pytest.mark.asyncio
+@patch.object(PositionCalculator, "_rebuild_backdated_position_history", new_callable=AsyncMock)
+@patch("src.services.calculators.position_calculator.app.core.position_logic.EpochFencer")
+async def test_calculate_rebuilds_materialized_backdated_event_for_explicit_correction(
+    mock_fencer_class: MagicMock,
+    mock_rebuild: AsyncMock,
+    mock_repo: AsyncMock,
+    mock_state_repo: AsyncMock,
+    sample_event: TransactionEvent,
+) -> None:
+    mock_fencer_class.return_value.check = AsyncMock(return_value=True)
+    mock_rebuild.return_value = PositionCalculationResult(position_record_count=2)
+    sample_event.epoch = None
+    current_state = PositionState(watermark_date=date(2025, 8, 25), epoch=3)
+    mock_state_repo.get_or_create_state.return_value = current_state
+    mock_repo.get_latest_position_history_date.return_value = date(2025, 8, 25)
+    mock_repo.is_transaction_materialized.return_value = True
+
+    result = await PositionCalculator.calculate(
+        sample_event,
+        AsyncMock(),
+        mock_repo,
+        mock_state_repo,
+        rebuild_existing=True,
+    )
+
+    assert result.position_record_count == 2
+    mock_repo.is_transaction_materialized.assert_not_awaited()
+    mock_rebuild.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/portfolio_transaction_processing_service/test_position_processing_adapter.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/test_position_processing_adapter.py
@@ -60,6 +60,7 @@ async def test_position_adapter_returns_position_and_replay_outcome() -> None:
         transaction,
         correlation_id="corr-001",
         traceparent="trace-001",
+        rebuild_existing=True,
     )
 
     assert result.position_record_count == 2
@@ -69,4 +70,5 @@ async def test_position_adapter_returns_position_and_replay_outcome() -> None:
     assert event.transaction_id == "TX-001"
     assert event.correlation_id == "corr-001"
     assert event.traceparent == "trace-001"
+    assert workflow.calculate.await_args.kwargs["rebuild_existing"] is True
     assert "outbox_repo" not in workflow.calculate.await_args.kwargs

--- a/tests/unit/services/portfolio_transaction_processing_service/test_process_transaction_use_case.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/test_process_transaction_use_case.py
@@ -91,14 +91,16 @@ class _Idempotency:
         outcome: TransactionIdempotencyOutcome = TransactionIdempotencyOutcome.CLAIMED,
     ) -> None:
         self.calls = calls
-        self.outcome = outcome
+        self.outcomes = [outcome]
         self.claim_kwargs: dict = {}
         self.repair_claimed = True
 
     async def claim(self, **kwargs) -> TransactionIdempotencyOutcome:
         self.calls.append("idempotency")
         self.claim_kwargs = kwargs
-        return self.outcome
+        if len(self.outcomes) > 1:
+            return self.outcomes.pop(0)
+        return self.outcomes[0]
 
     async def claim_repair_delivery(self, **_kwargs) -> bool:
         self.calls.append("repair-idempotency")
@@ -147,9 +149,11 @@ class _Position:
         self.calls = calls
         self.error_on = error_on
         self.cashflow_rebuild_transactions_by_id = cashflow_rebuild_transactions_by_id or {}
+        self.rebuild_existing_calls: list[bool] = []
 
-    async def process(self, transaction: BookedTransaction, **_kwargs) -> PositionProcessingResult:
+    async def process(self, transaction: BookedTransaction, **kwargs) -> PositionProcessingResult:
         self.calls.append(f"position:{transaction.transaction_id}")
+        self.rebuild_existing_calls.append(bool(kwargs.get("rebuild_existing", False)))
         if transaction.transaction_id == self.error_on:
             raise RuntimeError("position failed")
         return PositionProcessingResult(
@@ -460,7 +464,49 @@ async def test_use_case_rejects_material_semantic_conflict_before_financial_work
 
 
 @pytest.mark.asyncio
-async def test_repair_intent_does_not_bypass_material_semantic_conflict() -> None:
+async def test_repair_intent_claims_payload_specific_correction_identity() -> None:
+    calls: list[str] = []
+    unit_of_work = _UnitOfWork(
+        calls=calls,
+        idempotency_outcome=TransactionIdempotencyOutcome.SEMANTIC_CONFLICT,
+    )
+    unit_of_work.idempotency.outcomes.append(TransactionIdempotencyOutcome.CLAIMED)
+    command = replace(
+        _command(),
+        transaction=replace(
+            _command().transaction,
+            quantity=Decimal("12"),
+            gross_transaction_amount=Decimal("306"),
+        ),
+        metadata=replace(
+            _command().metadata,
+            processing_intent=TransactionProcessingIntent.REPAIR,
+        ),
+    )
+
+    result = await ProcessTransactionUseCase(
+        lambda: unit_of_work,
+        observer=_RecordingObserver(),
+    ).execute(command)
+
+    assert result.status is TransactionProcessingStatus.PROCESSED
+    assert calls == [
+        "enter",
+        "idempotency",
+        "idempotency",
+        "cost:TX-001",
+        "position:TX-001",
+        "cashflow:TX-001:0",
+        "commit",
+    ]
+    assert unit_of_work.idempotency.claim_kwargs["semantic_key"].startswith(
+        "transaction-correction:v1:PB-001:TX-001:0:sha256:"
+    )
+    assert unit_of_work.position.rebuild_existing_calls == [True]
+
+
+@pytest.mark.asyncio
+async def test_repair_intent_fails_closed_when_correction_identity_conflicts() -> None:
     calls: list[str] = []
     unit_of_work = _UnitOfWork(
         calls=calls,
@@ -481,7 +527,7 @@ async def test_repair_intent_does_not_bypass_material_semantic_conflict() -> Non
         ).execute(command)
 
     assert exc_info.value.reason_code == "transaction_semantic_conflict"
-    assert calls == ["enter", "idempotency", "rollback"]
+    assert calls == ["enter", "idempotency", "idempotency", "rollback"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/portfolio_transaction_processing_service/test_transaction_semantic_identity.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/test_transaction_semantic_identity.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 
 from src.services.portfolio_transaction_processing_service.app.domain import (
     BookedTransaction,
+    build_transaction_correction_identity,
     build_transaction_semantic_identity,
 )
 
@@ -159,3 +160,26 @@ def test_semantic_identity_separates_processing_epochs() -> None:
     original = build_transaction_semantic_identity(transaction)
 
     assert next_epoch.semantic_key != original.semantic_key
+
+
+def test_correction_identity_is_payload_specific_and_preserves_base_fingerprint() -> None:
+    transaction = _transaction()
+    corrected = replace(
+        transaction, quantity=Decimal("12"), gross_transaction_amount=Decimal("306")
+    )
+
+    original_correction = build_transaction_correction_identity(transaction)
+    corrected_correction = build_transaction_correction_identity(corrected)
+
+    assert (
+        original_correction.payload_fingerprint
+        == build_transaction_semantic_identity(transaction).payload_fingerprint
+    )
+    assert (
+        corrected_correction.payload_fingerprint
+        == build_transaction_semantic_identity(corrected).payload_fingerprint
+    )
+    assert original_correction.semantic_key != corrected_correction.semantic_key
+    assert corrected_correction.semantic_key.startswith(
+        "transaction-correction:v1:PB-001:TX-SEMANTIC-001:3:sha256:"
+    )


### PR DESCRIPTION
## Objective
Restore exact-main releasability after the unified transaction-processing cutover by correcting stale fixtures, operational runtime assumptions, and the explicit transaction-correction path exposed by run `29181785623`.

## Changes
- persist the canonical adjustment transaction before an integration fixture emits `transactions.persisted`
- derive the E2E database-outage recovery restart and health sets from the governed application topology
- replace deleted calculator runtime references with `portfolio_transaction_processing_service`
- make the failure-recovery gate use generated isolated PostgreSQL and Kafka endpoints unless explicitly overridden
- retain terminal semantic conflicts for ordinary changed deliveries
- let the governed `REPAIR` path claim immutable payload-specific correction identities while preserving the original semantic fence
- force only a newly claimed material correction to rebuild already-materialized position history and advance the governed epoch

## Compatibility
No API shape, event schema, topic, or database schema changes. Ordinary materially changed deliveries remain fail-closed as `transaction_semantic_conflict`. Intentional behavior restoration: the existing operational reprocessing API can process corrected canonical economics under an auditable correction identity, regenerate cost/cashflow/position state, and rearm current valuation.

## Validation
- focused canonical adjustment PostgreSQL integration: `1 passed`
- cost-consumer unit suite: `50 passed`
- recovery topology and failure-gate unit cohort: `15 passed`
- focused E2E database-outage recovery: `1 passed in 99.54s`
- repository-native failure-recovery gate: 100/100 cost, cashflow, position, and claims; lag 0 -> 100 -> 0; 9.177s recovery; 0 added DLQ
- correction domain/use-case/position cohort: `72 passed`
- PostgreSQL immutable correction fence: `1 passed`
- PostgreSQL materialized-position correction rebuild: `1 passed`
- repository-native transaction-processing contract: `39 passed in 146.00s`
- corrected transaction through current valuation E2E: `1 passed in 66.59s`
- targeted Ruff, MyPy, architecture, docs/wiki, and diff gates: passed
- full feature-SHA Main Releasability run `29184181907`: in progress at final signed head `287af707`

## Documentation
Repository engineering context now governs recovery topology, generated test-runtime endpoints, immutable correction identities, and correction rebuild behavior. CR-1491 records the intentional correction contract and validation. No OpenAPI or migration changed. No repo-local wiki source changed because operator/runtime topology and the reprocessing API surface remain unchanged; no wiki publication is required.

Tracks #468 and #485. Related concurrency validation informs #482 and #486.
