### PR TITLE
test: make compose diagnostic proof semantic

### DIFF
--- a/tests/integration/test_runtime_port_isolation.py
+++ b/tests/integration/test_runtime_port_isolation.py
@@ -128,9 +128,10 @@ def test_managed_compose_run_preserves_diagnostics_after_controlled_failure(
             raise RuntimeError("controlled validation failure")
 
     diagnostic_text = log_path.read_text(encoding="utf-8")
-    assert log_path.stat().st_size > 1024
+    assert diagnostic_text.startswith("--- lotus compose diagnostics ---\n")
     assert f"compose_project={project_name}" in diagnostic_text
     assert f"compose_file={compose_file.resolve()}" in diagnostic_text
+    assert "--- service logs ---" in diagnostic_text
     assert "postgres" in diagnostic_text.lower()
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
         probe.settimeout(1)

--- a/tests/integration/test_runtime_port_isolation.py
+++ b/tests/integration/test_runtime_port_isolation.py
@@ -128,11 +128,15 @@ def test_managed_compose_run_preserves_diagnostics_after_controlled_failure(
             raise RuntimeError("controlled validation failure")
 
     diagnostic_text = log_path.read_text(encoding="utf-8")
-    assert diagnostic_text.startswith("--- lotus compose diagnostics ---\n")
-    assert f"compose_project={project_name}" in diagnostic_text
-    assert f"compose_file={compose_file.resolve()}" in diagnostic_text
-    assert "--- service logs ---" in diagnostic_text
-    assert "postgres" in diagnostic_text.lower()
+    diagnostic_header, service_logs = diagnostic_text.split(
+        "--- service logs ---\n",
+        maxsplit=1,
+    )
+    assert diagnostic_header.startswith("--- lotus compose diagnostics ---\n")
+    assert f"compose_project={project_name}" in diagnostic_header
+    assert f"compose_file={compose_file.resolve()}" in diagnostic_header
+    assert service_logs.strip()
+    assert "postgres" in service_logs.lower()
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
         probe.settimeout(1)
         assert probe.connect_ex(("127.0.0.1", postgres_port)) != 0


### PR DESCRIPTION
## Objective
Fix the exact-main diagnostic contract exposed by Main Releasability run `29226940497` under #730.

## Measured improvement
- removes one platform/version-dependent `>1024` byte assertion;
- verifies the authored diagnostic envelope, exact Compose project, resolved Compose file, a non-empty service-log section, and PostgreSQL evidence;
- preserves the controlled-failure and teardown proof.

## Compatibility
CI/test evidence only. No application API, OpenAPI, persistence, event, image, financial-calculation, or downstream contract change.

## Validation
- live controlled-failure Compose test: 1 passed;
- managed-runtime unit plus live port-isolation cohort: 14 passed;
- Ruff check/format and `git diff --check`: passed;
- same-pattern scan found no other diagnostic size/length thresholds.

## Documentation
No README, context, API inventory, migration, or wiki change: this corrects a brittle assertion without changing the governed runtime or operator contract.

Related to #730.