### PR TITLE
fix(ci): bind API tool cache to lock

### DIFF
--- a/.github/workflows/quality-baseline.yml
+++ b/.github/workflows/quality-baseline.yml
@@ -75,6 +75,8 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: tools/api_governance/package-lock.json
       - name: Install repository
         run: |
           python -m pip install -U pip

--- a/tests/unit/test_ci_workflow_action_versions.py
+++ b/tests/unit/test_ci_workflow_action_versions.py
@@ -217,6 +217,21 @@ def test_workflows_opt_into_node24_action_runtime() -> None:
     assert missing_opt_in == []
 
 
+def test_api_governance_node_cache_is_bound_to_owned_lockfile() -> None:
+    workflow = (
+        yaml.safe_load(Path(".github/workflows/quality-baseline.yml").read_text(encoding="utf-8"))
+        or {}
+    )
+    steps = workflow["jobs"]["api-governance-gate"]["steps"]
+    setup_node = next(step for step in steps if step.get("uses") == "actions/setup-node@v6")
+
+    assert setup_node["with"] == {
+        "node-version": "${{ env.NODE_VERSION }}",
+        "cache": "npm",
+        "cache-dependency-path": "tools/api_governance/package-lock.json",
+    }
+
+
 def test_runtime_latency_gates_use_bounded_demo_seed_history() -> None:
     for workflow_path in GOVERNED_RUNTIME_WORKFLOWS:
         workflow_text = workflow_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Objective
Bind the API-governance Node cache to the committed lockfile so hosted CI restores deterministic dependency state from the same capability-owned manifest used by `npm ci`.

Closes #775

## Change
- configures `actions/setup-node` with the npm cache
- binds `cache-dependency-path` to `tools/api_governance/package-lock.json`
- adds workflow-governance regression coverage for the exact cache/lock relationship

## Compatibility
No API, OpenAPI, runtime service, database, event, calculation, or downstream contract changes. No deployable topology change.

## Repository organization
The lockfile remains capability-owned under `tools/api_governance`; validation remains in the existing workflow-governance test module. No flat package, generic helper, or issue-named implementation file was introduced.

## Validation
- `make quality-workflow-governance-gate` - 22 passed
- repository-wide setup-node scan - only the API-governance job uses this Node toolchain
- `git diff --check origin/main...HEAD` - passed
- commit signature status - good

## Documentation and wiki
No documentation or wiki truth changed: this is an implementation-level cache binding for the already documented lock-backed API-governance toolchain.