### PR TITLE
fix: restore exact-main valuation convergence

### DIFF
--- a/src/services/calculators/position_valuation_calculator/app/valuation_processor.py
+++ b/src/services/calculators/position_valuation_calculator/app/valuation_processor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
+from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Protocol
 
 from portfolio_common.config import KAFKA_VALUATION_SNAPSHOT_PERSISTED_TOPIC
@@ -76,6 +77,7 @@ VALUATION_VALUED_CURRENT = "VALUED_CURRENT"
 VALUATION_VALUED_STALE = "VALUED_STALE"
 VALUATION_JOB_COMPLETE = "COMPLETE"
 VALUATION_JOB_SKIPPED_NO_POSITION = "SKIPPED_NO_POSITION"
+ZERO = Decimal("0")
 
 
 def _normalize_currency_code(value: object) -> str:
@@ -408,6 +410,15 @@ class ValuationJobProcessor:
         price: MarketPrice | None,
     ) -> ValuationSnapshotResult:
         if not price:
+            if self._is_flat_position(snapshot):
+                self._apply_flat_position_valuation(snapshot)
+                return ValuationSnapshotResult(
+                    snapshot=snapshot,
+                    job_failure_reason=None,
+                    receipt=build_legacy_valuation_receipt(
+                        snapshot_identity=_snapshot_identity(snapshot)
+                    ),
+                )
             snapshot.valuation_status = VALUATION_UNVALUED
             return ValuationSnapshotResult(snapshot=snapshot, job_failure_reason=None)
 
@@ -459,6 +470,28 @@ class ValuationJobProcessor:
             reason="valuation_logic_failed",
         ).inc()
         return ValuationSnapshotResult(snapshot=snapshot, job_failure_reason=failure_reason)
+
+    @staticmethod
+    def _is_flat_position(snapshot: DailyPositionSnapshot) -> bool:
+        """Return whether a quote-independent zero valuation is fully supported."""
+
+        return (
+            snapshot.quantity == ZERO
+            and snapshot.cost_basis == ZERO
+            and snapshot.cost_basis_local == ZERO
+        )
+
+    @staticmethod
+    def _apply_flat_position_valuation(snapshot: DailyPositionSnapshot) -> None:
+        """Persist an exact zero valuation without fabricating price authority."""
+
+        snapshot.market_value = ZERO
+        snapshot.market_value_local = ZERO
+        snapshot.unrealized_gain_loss = ZERO
+        snapshot.unrealized_gain_loss_local = ZERO
+        snapshot.unrealized_price_gain_loss = ZERO
+        snapshot.unrealized_fx_gain_loss = ZERO
+        snapshot.valuation_status = VALUATION_VALUED_CURRENT
 
     async def _value_authoritative_snapshot(
         self,

--- a/src/services/calculators/position_valuation_calculator/app/valuation_processor.py
+++ b/src/services/calculators/position_valuation_calculator/app/valuation_processor.py
@@ -409,16 +409,16 @@ class ValuationJobProcessor:
         portfolio: Portfolio,
         price: MarketPrice | None,
     ) -> ValuationSnapshotResult:
+        if self._is_flat_position(snapshot):
+            self._apply_flat_position_valuation(snapshot)
+            return ValuationSnapshotResult(
+                snapshot=snapshot,
+                job_failure_reason=None,
+                receipt=build_legacy_valuation_receipt(
+                    snapshot_identity=_snapshot_identity(snapshot)
+                ),
+            )
         if not price:
-            if self._is_flat_position(snapshot):
-                self._apply_flat_position_valuation(snapshot)
-                return ValuationSnapshotResult(
-                    snapshot=snapshot,
-                    job_failure_reason=None,
-                    receipt=build_legacy_valuation_receipt(
-                        snapshot_identity=_snapshot_identity(snapshot)
-                    ),
-                )
             snapshot.valuation_status = VALUATION_UNVALUED
             return ValuationSnapshotResult(snapshot=snapshot, job_failure_reason=None)
 

--- a/tests/integration/services/portfolio_derived_state_service/test_timeseries_repository_integration.py
+++ b/tests/integration/services/portfolio_derived_state_service/test_timeseries_repository_integration.py
@@ -84,7 +84,7 @@ def _snapshot(
         market_value_local=Decimal("100"),
         unrealized_gain_loss=Decimal("0"),
         unrealized_gain_loss_local=Decimal("0"),
-        valuation_status="VALUED",
+        valuation_status="VALUED_CURRENT",
     )
 
 

--- a/tests/unit/services/calculators/position_valuation_calculator/consumers/test_valuation_consumer.py
+++ b/tests/unit/services/calculators/position_valuation_calculator/consumers/test_valuation_consumer.py
@@ -513,9 +513,27 @@ async def test_valuation_processor_marks_snapshot_unvalued_when_price_is_missing
     mock_dependencies["outbox_repo"].create_outbox_event.assert_awaited_once()
 
 
-async def test_valuation_processor_values_flat_position_without_market_price(
+@pytest.mark.parametrize(
+    ("market_price", "instrument_currency", "portfolio_currency"),
+    [
+        (None, "USD", "USD"),
+        (
+            MarketPrice(
+                price=Decimal("99"),
+                currency="EUR",
+                price_date=date(2025, 7, 31),
+            ),
+            "EUR",
+            "USD",
+        ),
+    ],
+)
+async def test_valuation_processor_values_flat_position_without_quote_dependencies(
     mock_event: PortfolioValuationRequiredEvent,
     mock_dependencies: dict,
+    market_price: MarketPrice | None,
+    instrument_currency: str,
+    portfolio_currency: str,
 ) -> None:
     mock_valuation_repo = mock_dependencies["valuation_repo"]
     mock_dependencies["idempotency_repo"].claim_event_processing.return_value = True
@@ -525,14 +543,14 @@ async def test_valuation_processor_values_flat_position_without_market_price(
         cost_basis_local=Decimal("0"),
     )
     mock_valuation_repo.get_instrument.return_value = Instrument(
-        currency="USD",
+        currency=instrument_currency,
         security_id=mock_event.security_id,
     )
     mock_valuation_repo.get_portfolio.return_value = Portfolio(
-        base_currency="USD",
+        base_currency=portfolio_currency,
         portfolio_id=mock_event.portfolio_id,
     )
-    mock_valuation_repo.get_latest_price_for_position.return_value = None
+    mock_valuation_repo.get_latest_price_for_position.return_value = market_price
 
     def persist_snapshot(snapshot):
         snapshot.id = 94
@@ -558,6 +576,7 @@ async def test_valuation_processor_values_flat_position_without_market_price(
     receipt = mock_dependencies["valuation_receipt_repo"].upsert.await_args.kwargs["receipt"]
     assert receipt.snapshot_identity.security_id == mock_event.security_id
     assert receipt.supportability.value == "LEGACY_UNSCOPED"
+    mock_valuation_repo.get_fx_rate.assert_not_awaited()
     mock_dependencies["valuation_receipt_repo"].delete.assert_not_awaited()
     mock_dependencies["outbox_repo"].create_outbox_event.assert_awaited_once()
 

--- a/tests/unit/services/calculators/position_valuation_calculator/consumers/test_valuation_consumer.py
+++ b/tests/unit/services/calculators/position_valuation_calculator/consumers/test_valuation_consumer.py
@@ -505,8 +505,102 @@ async def test_valuation_processor_marks_snapshot_unvalued_when_price_is_missing
 
     persisted_snapshot = mock_valuation_repo.upsert_daily_snapshot.call_args.args[0]
     assert persisted_snapshot.valuation_status == "UNVALUED"
+    assert persisted_snapshot.market_value is None
+    assert persisted_snapshot.market_value_local is None
     mock_valuation_repo.update_job_status.assert_awaited_once()
+    mock_dependencies["valuation_receipt_repo"].delete.assert_awaited_once_with(snapshot_id=93)
+    mock_dependencies["valuation_receipt_repo"].upsert.assert_not_awaited()
     mock_dependencies["outbox_repo"].create_outbox_event.assert_awaited_once()
+
+
+async def test_valuation_processor_values_flat_position_without_market_price(
+    mock_event: PortfolioValuationRequiredEvent,
+    mock_dependencies: dict,
+) -> None:
+    mock_valuation_repo = mock_dependencies["valuation_repo"]
+    mock_dependencies["idempotency_repo"].claim_event_processing.return_value = True
+    mock_valuation_repo.get_last_position_history_before_date.return_value = PositionHistory(
+        quantity=Decimal("0"),
+        cost_basis=Decimal("0"),
+        cost_basis_local=Decimal("0"),
+    )
+    mock_valuation_repo.get_instrument.return_value = Instrument(
+        currency="USD",
+        security_id=mock_event.security_id,
+    )
+    mock_valuation_repo.get_portfolio.return_value = Portfolio(
+        base_currency="USD",
+        portfolio_id=mock_event.portfolio_id,
+    )
+    mock_valuation_repo.get_latest_price_for_position.return_value = None
+
+    def persist_snapshot(snapshot):
+        snapshot.id = 94
+        return snapshot
+
+    mock_valuation_repo.upsert_daily_snapshot.side_effect = persist_snapshot
+
+    await mock_dependencies["processor"].process_valid_event(
+        mock_event,
+        "valuation.job.requested-0-94",
+        "processor-corr-id",
+    )
+
+    persisted_snapshot = mock_valuation_repo.upsert_daily_snapshot.call_args.args[0]
+    assert persisted_snapshot.market_price is None
+    assert persisted_snapshot.market_value == Decimal("0")
+    assert persisted_snapshot.market_value_local == Decimal("0")
+    assert persisted_snapshot.unrealized_gain_loss == Decimal("0")
+    assert persisted_snapshot.unrealized_gain_loss_local == Decimal("0")
+    assert persisted_snapshot.unrealized_price_gain_loss == Decimal("0")
+    assert persisted_snapshot.unrealized_fx_gain_loss == Decimal("0")
+    assert persisted_snapshot.valuation_status == "VALUED_CURRENT"
+    receipt = mock_dependencies["valuation_receipt_repo"].upsert.await_args.kwargs["receipt"]
+    assert receipt.snapshot_identity.security_id == mock_event.security_id
+    assert receipt.supportability.value == "LEGACY_UNSCOPED"
+    mock_dependencies["valuation_receipt_repo"].delete.assert_not_awaited()
+    mock_dependencies["outbox_repo"].create_outbox_event.assert_awaited_once()
+
+
+async def test_valuation_processor_does_not_zero_value_residual_cost_without_price(
+    mock_event: PortfolioValuationRequiredEvent,
+    mock_dependencies: dict,
+) -> None:
+    mock_valuation_repo = mock_dependencies["valuation_repo"]
+    mock_dependencies["idempotency_repo"].claim_event_processing.return_value = True
+    mock_valuation_repo.get_last_position_history_before_date.return_value = PositionHistory(
+        quantity=Decimal("0"),
+        cost_basis=Decimal("1"),
+        cost_basis_local=Decimal("1"),
+    )
+    mock_valuation_repo.get_instrument.return_value = Instrument(
+        currency="USD",
+        security_id=mock_event.security_id,
+    )
+    mock_valuation_repo.get_portfolio.return_value = Portfolio(
+        base_currency="USD",
+        portfolio_id=mock_event.portfolio_id,
+    )
+    mock_valuation_repo.get_latest_price_for_position.return_value = None
+
+    def persist_snapshot(snapshot):
+        snapshot.id = 95
+        return snapshot
+
+    mock_valuation_repo.upsert_daily_snapshot.side_effect = persist_snapshot
+
+    await mock_dependencies["processor"].process_valid_event(
+        mock_event,
+        "valuation.job.requested-0-95",
+        "processor-corr-id",
+    )
+
+    persisted_snapshot = mock_valuation_repo.upsert_daily_snapshot.call_args.args[0]
+    assert persisted_snapshot.valuation_status == "UNVALUED"
+    assert persisted_snapshot.market_value is None
+    assert persisted_snapshot.market_value_local is None
+    mock_dependencies["valuation_receipt_repo"].delete.assert_awaited_once_with(snapshot_id=95)
+    mock_dependencies["valuation_receipt_repo"].upsert.assert_not_awaited()
 
 
 async def test_valuation_processor_marks_snapshot_stale_when_price_date_precedes_valuation_date(


### PR DESCRIPTION
## Summary
- align the PostgreSQL position-timeseries refresh fixture with canonical `VALUED_CURRENT`
- value an exactly flat unscoped position at zero without fabricating market-price authority
- retain fail-closed `UNVALUED` behavior for non-zero quantity or residual cost when a quote is absent

## Why
- Main Releasability run 30474448233 attempt 2 exposed two exact-main defects after #849:
  - full integration used a legacy `VALUED` fixture rejected by the canonical state contract
  - full E2E repeatedly sent day-two cash materialization to DLQ because the prior day was exactly flat but unpriced and therefore lacked an authoritative local market value
- zero quantity plus zero reporting/local cost basis has an exact, quote-independent value of zero; non-flat positions still require price authority

## Scope
- [x] Single #788 exact-main fix-forward slice
- [x] No unrelated refactors mixed in

## Validation (local)
- [x] exact failing PostgreSQL integration test: 1 passed in 57.05s
- [x] exact live `test_timeseries_contracts.py`: 4 passed in 66.29s at `4b7902a55`; final-head rerun confirmed both position rows then exposed separate reopened #490 portfolio-epoch convergence (4 setup errors after 237.21s)
- [x] valuation + derived-state focused unit suite: 139 passed with warnings as errors
- [x] MyPy: 240 source files, zero errors
- [x] changed-file Ruff/format and `git diff --check`

## CI Expectations
- [ ] Fast PR gates are green at final head
- [ ] Exact-main Main Releasability is green after merge
- failing main evidence: https://github.com/sgajbi/lotus-core/actions/runs/30474448233
- integration artifact: https://github.com/sgajbi/lotus-core/actions/runs/30474448233/artifacts/8734472730
- E2E artifact: https://github.com/sgajbi/lotus-core/actions/runs/30474448233/artifacts/8734692708

## Governance/Docs
- [x] Documentation impact reviewed across README, architecture docs, API/OpenAPI, RFCs, runbooks, supported features, wiki, repository context, and platform context
- [x] No docs/wiki/API/migration change: the existing valuation status and payload contracts are preserved; this makes a mathematically exact flat-position case truthful and corrects test data
- [x] No runtime split: no deployable or service-boundary changes

## Post-Merge Hygiene
- [ ] Delete remote feature branch
- [ ] Delete local feature branch
- [ ] Sync local main with origin/main (`local = remote = main`)

Issue: #788 (exact-main fix-forward evidence; does not close its broader product-aware valuation acceptance criteria)