### PR TITLE
fix(valuation): revalue nonzero positions

### DIFF
--- a/src/libs/portfolio-common/portfolio_common/valuation_repository_base.py
+++ b/src/libs/portfolio-common/portfolio_common/valuation_repository_base.py
@@ -118,7 +118,7 @@ class ValuationRepositoryBase:
             )
             .where(
                 latest_history_subquery.c.rn == 1,
-                latest_history_subquery.c.quantity > 0,
+                latest_history_subquery.c.quantity != 0,
                 or_(
                     DailyPositionSnapshot.id.is_(None),
                     DailyPositionSnapshot.updated_at < MarketPrice.updated_at,
@@ -162,7 +162,7 @@ class ValuationRepositoryBase:
         )
 
         stmt = select(latest_history_subquery.c.portfolio_id).where(
-            latest_history_subquery.c.rn == 1, latest_history_subquery.c.quantity > 0
+            latest_history_subquery.c.rn == 1, latest_history_subquery.c.quantity != 0
         )
 
         result = await self.db.execute(stmt)
@@ -194,7 +194,7 @@ class ValuationRepositoryBase:
             .where(
                 PositionHistory.security_id == security_id,
                 PositionHistory.position_date > a_date,
-                PositionHistory.quantity > 0,
+                PositionHistory.quantity != 0,
             )
             .order_by(PositionHistory.portfolio_id.asc())
         )
@@ -756,7 +756,7 @@ class ValuationRepositoryBase:
 
         stmt = select(
             ranked_snapshots_subq.c.portfolio_id, ranked_snapshots_subq.c.security_id
-        ).where(ranked_snapshots_subq.c.rn == 1, ranked_snapshots_subq.c.quantity > 0)
+        ).where(ranked_snapshots_subq.c.rn == 1, ranked_snapshots_subq.c.quantity != 0)
 
         result = await self.db.execute(stmt)
         open_positions = result.mappings().all()

--- a/src/services/persistence_service/app/repositories/market_price_repository.py
+++ b/src/services/persistence_service/app/repositories/market_price_repository.py
@@ -45,7 +45,7 @@ class MarketPriceRepository:
         )
 
         stmt = select(latest_snapshot_subquery.c.portfolio_id).where(
-            latest_snapshot_subquery.c.rn == 1, latest_snapshot_subquery.c.quantity > 0
+            latest_snapshot_subquery.c.rn == 1, latest_snapshot_subquery.c.quantity != 0
         )
 
         result = await self.db.execute(stmt)

--- a/src/services/query_control_plane_service/app/infrastructure/operations/operations_reprocessing_queries.py
+++ b/src/services/query_control_plane_service/app/infrastructure/operations/operations_reprocessing_queries.py
@@ -80,7 +80,7 @@ def reprocessing_job_portfolio_scope_exists(
     return (
         select(1)
         .select_from(latest_history)
-        .where(latest_history.c.rn == 1, latest_history.c.quantity > 0)
+        .where(latest_history.c.rn == 1, latest_history.c.quantity != 0)
         .exists()
     )
 
@@ -161,7 +161,7 @@ def fx_revaluation_job_portfolio_scope_exists(
     open_on_date = (
         select(1)
         .select_from(latest_history)
-        .where(latest_history.c.row_number == 1, latest_history.c.quantity > 0)
+        .where(latest_history.c.row_number == 1, latest_history.c.quantity != 0)
         .exists()
     )
     first_held_later = (
@@ -173,7 +173,7 @@ def fx_revaluation_job_portfolio_scope_exists(
         .where(
             pair_scope,
             PositionHistory.position_date > impacted_date_expr,
-            PositionHistory.quantity > 0,
+            PositionHistory.quantity != 0,
         )
         .correlate(ReprocessingJob)
         .exists()

--- a/src/services/query_control_plane_service/app/infrastructure/operations/operations_reprocessing_queries.py
+++ b/src/services/query_control_plane_service/app/infrastructure/operations/operations_reprocessing_queries.py
@@ -77,12 +77,29 @@ def reprocessing_job_portfolio_scope_exists(
     )
     latest_history = latest_history.correlate(ReprocessingJob).subquery()
 
-    return (
+    open_on_date = (
         select(1)
         .select_from(latest_history)
         .where(latest_history.c.rn == 1, latest_history.c.quantity != 0)
         .exists()
     )
+    later_holding = select(1).select_from(PositionHistory)
+    later_holding = apply_current_position_history_scope(
+        later_holding,
+        portfolio_id=portfolio_id,
+        position_history_security_id=position_history_security_id,
+        position_state_security_id=position_state_security_id,
+        normalized_security_id=reprocessing_security_id_expr,
+    )
+    later_holding = (
+        later_holding.where(
+            PositionHistory.position_date > impacted_date_expr,
+            PositionHistory.quantity != 0,
+        )
+        .correlate(ReprocessingJob)
+        .exists()
+    )
+    return or_(open_on_date, later_holding)
 
 
 def reprocessing_job_portfolio_security_exists(

--- a/src/services/valuation_orchestrator_service/app/core/reprocessing_worker.py
+++ b/src/services/valuation_orchestrator_service/app/core/reprocessing_worker.py
@@ -238,11 +238,17 @@ class ReprocessingWorker:
             security_id,
             earliest_date,
         )
-        if affected_portfolios:
-            return affected_portfolios
-        return await valuation_repo.find_portfolios_first_holding_security_after_date(
-            security_id,
-            earliest_date,
+        later_holding_portfolios = (
+            await valuation_repo.find_portfolios_first_holding_security_after_date(
+                security_id,
+                earliest_date,
+            )
+        )
+        return sorted(
+            {
+                *affected_portfolios,
+                *later_holding_portfolios,
+            }
         )
 
     @staticmethod

--- a/src/services/valuation_orchestrator_service/app/infrastructure/repositories/fx_revaluation_repository.py
+++ b/src/services/valuation_orchestrator_service/app/infrastructure/repositories/fx_revaluation_repository.py
@@ -186,7 +186,7 @@ class SqlAlchemyFxRevaluationRepository:
             )
             .where(
                 PositionHistory.position_date > earliest_impacted_date,
-                PositionHistory.quantity > 0,
+                PositionHistory.quantity != 0,
                 func.upper(func.trim(Instrument.currency)) == pair.from_currency,
                 func.upper(func.trim(Portfolio.base_currency)) == pair.to_currency,
             )
@@ -246,7 +246,7 @@ def _latest_open_position_scope(*, pair: DirectCurrencyPair, effective_date: dat
 
 
 def _open_position_keys_statement(latest_history):
-    """Select positive current-epoch keys from one ranked position scope."""
+    """Select non-zero current-epoch keys from one ranked position scope."""
 
     return (
         select(
@@ -256,7 +256,7 @@ def _open_position_keys_statement(latest_history):
         )
         .where(
             latest_history.c.row_number == 1,
-            latest_history.c.quantity > 0,
+            latest_history.c.quantity != 0,
         )
         .order_by(
             latest_history.c.portfolio_id.asc(),

--- a/tests/integration/services/calculators/position_valuation_calculator/test_int_valuation_repo.py
+++ b/tests/integration/services/calculators/position_valuation_calculator/test_int_valuation_repo.py
@@ -593,8 +593,11 @@ async def test_find_portfolios_holding_security_on_date(
     assert portfolio_ids[0] == "P1"
 
 
-async def test_price_revaluation_selects_current_epoch_until_snapshot_is_source_fresh(
-    clean_db, async_db_session: AsyncSession
+@pytest.mark.parametrize("position_quantity", [Decimal("12"), Decimal("-1000")])
+async def test_price_revaluation_selects_nonzero_current_epoch_until_snapshot_is_source_fresh(
+    clean_db,
+    async_db_session: AsyncSession,
+    position_quantity: Decimal,
 ):
     source_updated_at = datetime(2025, 8, 2, 8, 0, tzinfo=timezone.utc)
     async_db_session.add(
@@ -673,7 +676,7 @@ async def test_price_revaluation_selects_current_epoch_until_snapshot_is_source_
                 security_id="S-CURRENT-1",
                 position_date=date(2025, 8, 2),
                 epoch=1,
-                quantity=Decimal("12"),
+                quantity=position_quantity,
                 cost_basis=Decimal("12"),
             ),
         ]
@@ -694,7 +697,7 @@ async def test_price_revaluation_selects_current_epoch_until_snapshot_is_source_
             security_id="S-CURRENT-1",
             date=date(2025, 8, 2),
             epoch=1,
-            quantity=Decimal("12"),
+            quantity=position_quantity,
             cost_basis=Decimal("12"),
             updated_at=source_updated_at + timedelta(seconds=1),
         )

--- a/tests/integration/services/valuation_orchestrator_service/test_fx_revaluation_repository.py
+++ b/tests/integration/services/valuation_orchestrator_service/test_fx_revaluation_repository.py
@@ -170,9 +170,11 @@ async def test_direct_pair_query_excludes_inverse_unrelated_and_closed_positions
     assert keys == []
 
 
-async def test_direct_pair_query_returns_open_matching_position_epoch(
+@pytest.mark.parametrize("position_quantity", [Decimal("10"), Decimal("-10")])
+async def test_direct_pair_query_returns_nonzero_matching_position_epoch(
     clean_db,
     async_db_session: AsyncSession,
+    position_quantity: Decimal,
 ) -> None:
     async_db_session.add_all(
         [
@@ -187,7 +189,7 @@ async def test_direct_pair_query_returns_open_matching_position_epoch(
         portfolio_id="P-SGD",
         security_id="USD-BOND",
         transaction_id="TX-MATCH",
-        quantity=Decimal("10"),
+        quantity=position_quantity,
     )
     await async_db_session.flush()
     repository = fx_revaluation_repository.SqlAlchemyFxRevaluationRepository(async_db_session)
@@ -278,9 +280,11 @@ async def test_immediate_fx_revaluation_uses_source_snapshot_freshness(
     ]
 
 
-async def test_replay_impact_includes_position_first_opened_after_correction(
+@pytest.mark.parametrize("position_quantity", [Decimal("10"), Decimal("-10")])
+async def test_replay_impact_includes_nonzero_position_first_opened_after_correction(
     clean_db,
     async_db_session: AsyncSession,
+    position_quantity: Decimal,
 ) -> None:
     async_db_session.add_all(
         [
@@ -306,7 +310,7 @@ async def test_replay_impact_includes_position_first_opened_after_correction(
             transaction_id="TX-LATER",
             position_date=date(2026, 4, 12),
             epoch=0,
-            quantity=Decimal("10"),
+            quantity=position_quantity,
             cost_basis=Decimal("1000"),
             cost_basis_local=Decimal("1000"),
         )

--- a/tests/unit/services/persistence_service/repositories/test_market_price_repository.py
+++ b/tests/unit/services/persistence_service/repositories/test_market_price_repository.py
@@ -1,5 +1,6 @@
+from datetime import date
 from decimal import Decimal
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from portfolio_common.events import MarketPriceEvent
@@ -8,6 +9,25 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.services.persistence_service.app.repositories.market_price_repository import (
     MarketPriceRepository,
 )
+
+
+@pytest.mark.asyncio
+async def test_open_position_price_propagation_uses_nonzero_quantity() -> None:
+    db = AsyncMock(spec=AsyncSession)
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = []
+    db.execute.return_value = result
+    repo = MarketPriceRepository(db)
+
+    await repo.find_portfolios_with_open_position_before_date(
+        "SEC_TEST_PRICE",
+        date(2026, 5, 28),
+    )
+
+    statement = db.execute.await_args.args[0]
+    compiled = str(statement.compile(compile_kwargs={"literal_binds": True}))
+    assert "anon_1.quantity != 0" in compiled
+    assert "anon_1.quantity > 0" not in compiled
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/query_control_plane_service/infrastructure/operations/test_repository.py
+++ b/tests/unit/services/query_control_plane_service/infrastructure/operations/test_repository.py
@@ -2095,6 +2095,8 @@ async def test_get_reprocessing_jobs_query_uses_reference_now(
     assert "from_currency" in compiled
     assert "to_currency" in compiled
     assert "position_history.position_date <=" in compiled.lower()
+    assert "position_history.position_date >" in compiled.lower()
+    assert "position_history.quantity != 0" in compiled.lower()
     assert "CAST(reprocessing_jobs.payload['earliest_impacted_date'] AS DATE)" in compiled
     assert (
         "pg_input_is_valid(reprocessing_jobs.payload['earliest_impacted_date'], 'date')" in compiled
@@ -2149,6 +2151,8 @@ async def test_get_reprocessing_jobs_count_uses_date_aware_scope(
     assert "from position_history join position_state on" in compiled.lower()
     assert "position_history.portfolio_id = 'P1'" in compiled
     assert "position_history.position_date <=" in compiled.lower()
+    assert "position_history.position_date >" in compiled.lower()
+    assert "position_history.quantity != 0" in compiled.lower()
     assert "CAST(reprocessing_jobs.payload['earliest_impacted_date'] AS DATE)" in compiled
     assert (
         "pg_input_is_valid(reprocessing_jobs.payload['earliest_impacted_date'], 'date')" in compiled

--- a/tests/unit/services/query_control_plane_service/infrastructure/operations/test_repository.py
+++ b/tests/unit/services/query_control_plane_service/infrastructure/operations/test_repository.py
@@ -2100,7 +2100,7 @@ async def test_get_reprocessing_jobs_query_uses_reference_now(
         "pg_input_is_valid(reprocessing_jobs.payload['earliest_impacted_date'], 'date')" in compiled
     )
     assert "IS NOT true" in compiled
-    assert "anon_1.quantity > 0" in compiled
+    assert "anon_1.quantity != 0" in compiled
     assert "CASE WHEN (reprocessing_jobs.status = 'FAILED')" in compiled
     assert "upper(trim(reprocessing_jobs.status))" not in compiled
     assert "reprocessing_jobs.updated_at < '2025-08-31 11:45:00+00:00'" in compiled
@@ -2154,7 +2154,7 @@ async def test_get_reprocessing_jobs_count_uses_date_aware_scope(
         "pg_input_is_valid(reprocessing_jobs.payload['earliest_impacted_date'], 'date')" in compiled
     )
     assert "IS NOT true" in compiled
-    assert "anon_1.quantity > 0" in compiled
+    assert "anon_1.quantity != 0" in compiled
     assert "reprocessing_jobs.status = 'PROCESSING'" in compiled
     assert "trim(reprocessing_jobs.payload['security_id']) = 'SEC-US-IBM'" in compiled
     assert "upper(trim(instruments.currency))" in compiled

--- a/tests/unit/services/valuation_orchestrator_service/core/test_reprocessing_worker.py
+++ b/tests/unit/services/valuation_orchestrator_service/core/test_reprocessing_worker.py
@@ -32,6 +32,7 @@ pytestmark = pytest.mark.asyncio
 @pytest.fixture
 def mock_dependencies():
     mock_valuation_repo = AsyncMock(spec=ValuationRepository)
+    mock_valuation_repo.find_portfolios_first_holding_security_after_date.return_value = []
     mock_state_repo = AsyncMock(spec=PositionStateRepository)
     mock_repro_job_repo = AsyncMock(spec=ReprocessingJobRepository)
     mock_fx_revaluation_repo = AsyncMock(
@@ -391,6 +392,44 @@ async def test_worker_falls_back_to_later_first_holdings_before_requeueing(
     mock_observe_noop.assert_not_called()
     mock_observe_completed.assert_called_once_with("RESET_WATERMARKS")
     mock_repro_job_repo.update_job_status.assert_awaited_once_with(20, "COMPLETE")
+
+
+async def test_worker_unions_current_and_later_holdings_for_replay_reset(
+    mock_dependencies,
+):
+    worker = ReprocessingWorker(poll_interval=0.1)
+    mock_repro_job_repo = mock_dependencies["repro_job_repo"]
+    mock_valuation_repo = mock_dependencies["valuation_repo"]
+    mock_state_repo = mock_dependencies["state_repo"]
+
+    pending_job = ReprocessingJob(
+        id=23,
+        job_type="RESET_WATERMARKS",
+        payload={"security_id": "S1", "earliest_impacted_date": "2025-08-10"},
+        status="PENDING",
+    )
+
+    mock_repro_job_repo.find_and_reset_stale_jobs.return_value = 0
+    mock_repro_job_repo.find_and_claim_jobs.return_value = [pending_job]
+    mock_repro_job_repo.update_job_status.return_value = True
+    mock_valuation_repo.find_portfolios_holding_security_on_date.return_value = ["P_SHORT"]
+    mock_valuation_repo.find_portfolios_first_holding_security_after_date.return_value = [
+        "P_LATE",
+        "P_SHORT",
+    ]
+    mock_state_repo.update_watermarks_if_older.return_value = 2
+
+    await worker._process_batch()
+
+    mock_valuation_repo.find_portfolios_first_holding_security_after_date.assert_awaited_once_with(
+        "S1",
+        date(2025, 8, 10),
+    )
+    mock_state_repo.update_watermarks_if_older.assert_awaited_once_with(
+        keys=[("P_LATE", "S1"), ("P_SHORT", "S1")],
+        new_watermark_date=date(2025, 8, 9),
+    )
+    mock_repro_job_repo.update_job_status.assert_awaited_once_with(23, "COMPLETE")
 
 
 async def test_worker_skips_completion_metric_when_terminal_ownership_is_lost(mock_dependencies):


### PR DESCRIPTION
## Objective
Eliminate the lost-wakeup exposed by exact-main E2E validation when a market price arrives after an unavailable valuation for a negative cash or short position.

## Measurable improvement
- Price and FX revaluation now select all economically open positions (quantity != 0), not long-only positions.
- Operations replay scopes use the same non-zero policy.
- Negative cash/short regression cases cover immediate price revaluation, FX revaluation, future replay impact, persistence price propagation, and operations query mirrors.

## Compatibility impact
No API, event, schema, migration, or OpenAPI contract change. Existing positive-position behavior is preserved; negative non-zero positions now receive the same deterministic revaluation and replay handling.

## Validation
- make lint
- focused unit: 75 passed
- focused PostgreSQL integration: 45 passed
- signed commit: 5a6bcf6c7efa3b8fd89559ba772780fb631f0faf

## Documentation/wiki decision
No change: this corrects implementation to the existing non-zero open-position contract and does not change operator or public contract truth.

Refs #456
Follow-up to exact-main failure in Main Releasability run 30510602189 after PR #851.