### PR TITLE
test(qcp): align runtime trust integration fixtures

### DIFF
--- a/tests/integration/services/query_control_plane_service/test_int_operations_service.py
+++ b/tests/integration/services/query_control_plane_service/test_int_operations_service.py
@@ -202,6 +202,8 @@ async def test_support_overview_returns_coherent_snapshot_under_control_churn(
                 business_date=date(2025, 8, 30),
                 epoch=2,
                 detail={"message": "older finding"},
+                owner="TRANSACTION_OPERATIONS",
+                repair_recommendation="REGENERATE_CASHFLOW",
                 created_at=datetime(2025, 8, 30, 10, 50, tzinfo=timezone.utc),
             ),
             FinancialReconciliationFinding(
@@ -216,6 +218,8 @@ async def test_support_overview_returns_coherent_snapshot_under_control_churn(
                 business_date=date(2025, 8, 30),
                 epoch=2,
                 detail={"message": "late finding"},
+                owner="TRANSACTION_OPERATIONS",
+                repair_recommendation="REVIEW_RECONCILIATION_BREAK",
                 created_at=datetime(2025, 8, 30, 11, 40, tzinfo=timezone.utc),
             ),
         ]
@@ -541,6 +545,8 @@ async def test_reconciliation_findings_return_coherent_snapshot_under_finding_ch
                 business_date=date(2025, 8, 30),
                 epoch=2,
                 detail={"message": "visible finding"},
+                owner="TRANSACTION_OPERATIONS",
+                repair_recommendation="REGENERATE_CASHFLOW",
                 created_at=datetime(2025, 8, 30, 11, 10, tzinfo=timezone.utc),
             ),
             FinancialReconciliationFinding(
@@ -555,6 +561,8 @@ async def test_reconciliation_findings_return_coherent_snapshot_under_finding_ch
                 business_date=date(2025, 8, 30),
                 epoch=2,
                 detail={"message": "hidden finding"},
+                owner="TRANSACTION_OPERATIONS",
+                repair_recommendation="REVIEW_RECONCILIATION_BREAK",
                 created_at=datetime(2025, 8, 30, 12, 30, tzinfo=timezone.utc),
             ),
         ]

--- a/tests/integration/services/query_control_plane_service/test_integration_router_dependency.py
+++ b/tests/integration/services/query_control_plane_service/test_integration_router_dependency.py
@@ -415,14 +415,27 @@ async def async_test_client():
     mock_reference_coverage_service.get_benchmark = AsyncMock(
         return_value={
             "request_fingerprint": "fp-benchmark-coverage-1",
+            "coverage_report_id": "dqc_benchmark_coverage_1",
             "observed_start_date": "2026-01-01",
             "observed_end_date": "2026-01-31",
             "expected_start_date": "2026-01-01",
             "expected_end_date": "2026-01-31",
             "total_points": 31,
+            "required_count": 31,
+            "observed_count": 31,
             "missing_dates_count": 0,
             "missing_dates_sample": [],
             "quality_status_distribution": {"ACCEPTED": 31},
+            "stale_count": 0,
+            "blocking_issue_count": 0,
+            "warning_issue_count": 0,
+            "freshness_threshold_minutes": 1440,
+            "evidence_age_minutes": 0,
+            "contributing_evidence_refs": [
+                "lotus-core://source/BenchmarkReturn/BMK_GLOBAL_BALANCED_60_40/2026-01-31"
+            ],
+            "publication_gate": "ALLOW",
+            "publication_block_reasons": [],
             **source_data_product_runtime_metadata(
                 as_of_date=date(2026, 1, 31),
                 generated_at=datetime(2026, 1, 31, 10, 0, 0, tzinfo=UTC),
@@ -432,14 +445,28 @@ async def async_test_client():
     mock_reference_coverage_service.get_risk_free = AsyncMock(
         return_value={
             "request_fingerprint": "fp-risk-free-coverage-1",
+            "coverage_report_id": "dqc_risk_free_coverage_1",
             "observed_start_date": None,
             "observed_end_date": None,
             "expected_start_date": "2026-01-01",
             "expected_end_date": "2026-01-31",
             "total_points": 0,
+            "required_count": 31,
+            "observed_count": 0,
             "missing_dates_count": 31,
             "missing_dates_sample": [],
             "quality_status_distribution": {},
+            "stale_count": 0,
+            "blocking_issue_count": 0,
+            "warning_issue_count": 0,
+            "freshness_threshold_minutes": 1440,
+            "evidence_age_minutes": None,
+            "contributing_evidence_refs": [],
+            "publication_gate": "BLOCK",
+            "publication_block_reasons": [
+                "INCOMPLETE_COVERAGE",
+                "NO_OBSERVED_EVIDENCE",
+            ],
             **source_data_product_runtime_metadata(
                 as_of_date=date(2026, 1, 31),
                 generated_at=datetime(2026, 1, 31, 10, 0, 0, tzinfo=UTC),
@@ -1766,8 +1793,11 @@ async def test_benchmark_coverage_success(async_test_client):
     assert body["observed_start_date"] == "2026-01-01"
     assert body["observed_end_date"] == "2026-01-31"
     assert body["total_points"] == 31
+    assert body["required_count"] == 31
+    assert body["observed_count"] == 31
     assert body["missing_dates_count"] == 0
     assert body["quality_status_distribution"] == {"ACCEPTED": 31}
+    assert body["publication_gate"] == "ALLOW"
     assert body["reconciliation_status"] == "UNKNOWN"
     assert body["data_quality_status"] == "UNKNOWN"
     coverage_service.get_benchmark.assert_awaited_once()
@@ -1791,7 +1821,14 @@ async def test_risk_free_coverage_success(async_test_client):
     assert body["product_name"] == "DataQualityCoverageReport"
     assert body["product_version"] == "v1"
     assert body["total_points"] == 0
+    assert body["required_count"] == 31
+    assert body["observed_count"] == 0
     assert body["missing_dates_count"] == 31
+    assert body["publication_gate"] == "BLOCK"
+    assert body["publication_block_reasons"] == [
+        "INCOMPLETE_COVERAGE",
+        "NO_OBSERVED_EVIDENCE",
+    ]
     assert body["reconciliation_status"] == "UNKNOWN"
     assert body["data_quality_status"] == "UNKNOWN"
     coverage_service.get_risk_free.assert_awaited_once()

--- a/tests/integration/services/query_control_plane_service/test_integration_router_dependency.py
+++ b/tests/integration/services/query_control_plane_service/test_integration_router_dependency.py
@@ -438,7 +438,11 @@ async def async_test_client():
             "publication_block_reasons": [],
             **source_data_product_runtime_metadata(
                 as_of_date=date(2026, 1, 31),
+                data_quality_status="COMPLETE",
                 generated_at=datetime(2026, 1, 31, 10, 0, 0, tzinfo=UTC),
+                latest_evidence_timestamp=datetime(2026, 1, 31, 10, 0, 0, tzinfo=UTC),
+                source_evidence_current=True,
+                freshness_status="CURRENT",
             ),
         }
     )
@@ -464,8 +468,8 @@ async def async_test_client():
             "contributing_evidence_refs": [],
             "publication_gate": "BLOCK",
             "publication_block_reasons": [
-                "INCOMPLETE_COVERAGE",
-                "NO_OBSERVED_EVIDENCE",
+                "NO_OBSERVED_COVERAGE",
+                "MISSING_EVIDENCE_TIMESTAMP",
             ],
             **source_data_product_runtime_metadata(
                 as_of_date=date(2026, 1, 31),
@@ -1799,7 +1803,7 @@ async def test_benchmark_coverage_success(async_test_client):
     assert body["quality_status_distribution"] == {"ACCEPTED": 31}
     assert body["publication_gate"] == "ALLOW"
     assert body["reconciliation_status"] == "UNKNOWN"
-    assert body["data_quality_status"] == "UNKNOWN"
+    assert body["data_quality_status"] == "COMPLETE"
     coverage_service.get_benchmark.assert_awaited_once()
     coverage_call = coverage_service.get_benchmark.await_args.kwargs
     assert coverage_call["benchmark_id"] == "BMK_GLOBAL_BALANCED_60_40"
@@ -1826,8 +1830,8 @@ async def test_risk_free_coverage_success(async_test_client):
     assert body["missing_dates_count"] == 31
     assert body["publication_gate"] == "BLOCK"
     assert body["publication_block_reasons"] == [
-        "INCOMPLETE_COVERAGE",
-        "NO_OBSERVED_EVIDENCE",
+        "NO_OBSERVED_COVERAGE",
+        "MISSING_EVIDENCE_TIMESTAMP",
     ]
     assert body["reconciliation_status"] == "UNKNOWN"
     assert body["data_quality_status"] == "UNKNOWN"


### PR DESCRIPTION
## Objective

Restore exact-main releasability after #859 by aligning the four stale integration fixtures with the runtime trust contracts already merged to `main`.

## Measurable improvement

- Four deterministic Main Releasability failures become passing contract/database proofs.
- All four integration `FinancialReconciliationFinding` constructors now provide governed non-null owner and repair evidence.
- Benchmark and risk-free coverage mocks now satisfy the complete `DataQualityCoverageReport` gate/count contract and assert its publication posture.

## Compatibility impact

Test-fixture correction only. No production schema, API, migration, documentation, context, or wiki truth changes. Explicit docs/wiki decision: no change required because the already-published contract remains unchanged.

## Validation

- `test_support_overview_returns_coherent_snapshot_under_control_churn`: passed
- `test_reconciliation_findings_return_coherent_snapshot_under_finding_churn`: passed
- `test_benchmark_coverage_success`: passed
- `test_risk_free_coverage_success`: passed
- Ruff check/format: passed
- `git diff --check`: passed

Root-cause run: https://github.com/sgajbi/lotus-core/actions/runs/30586512112/job/91023231424

Follow-up to #859; no issue is closed by this fixture-only PR.