### PR TITLE
test: isolate historical portfolio scope migration

### DIFF
--- a/tests/integration/test_portfolio_valuation_book_scope_migration.py
+++ b/tests/integration/test_portfolio_valuation_book_scope_migration.py
@@ -20,6 +20,12 @@ MIGRATION = (
     / "versions"
     / "c118b2c3d4f7_feat_add_portfolio_valuation_book_scope.py"
 )
+DEPENDENT_MIGRATION = (
+    Path(__file__).resolve().parents[2]
+    / "alembic"
+    / "versions"
+    / "c139b2c3d50c_feat_add_lot_amortized_cost_profiles.py"
+)
 
 PORTFOLIO_INSERT = text(
     """
@@ -60,6 +66,31 @@ def _bind_operations(migration: dict[str, Any], connection) -> None:
     migration["downgrade"].__globals__["op"] = operations
 
 
+def _downgrade_dependent_schema(connection) -> dict[str, Any] | None:
+    """Downgrade later schema that deliberately references valuation-book scope."""
+
+    inspector = inspect(connection)
+    if not inspector.has_table("lot_amortized_cost_profiles"):
+        return None
+    dependent_migration: dict[str, Any] = runpy.run_path(str(DEPENDENT_MIGRATION))
+    _bind_operations(dependent_migration, connection)
+    operations = dependent_migration["downgrade"].__globals__["op"]
+    if inspector.has_table("lot_amortized_cost_periods"):
+        operations.drop_table("lot_amortized_cost_periods")
+    operations.drop_table("lot_amortized_cost_profiles")
+    for table_name, constraint_name in (
+        ("position_lot_state", "uq_position_lot_scope_identity"),
+        ("portfolios", "uq_portfolios_book_scope_identity"),
+    ):
+        unique_constraints = {
+            constraint["name"]
+            for constraint in inspect(connection).get_unique_constraints(table_name)
+        }
+        if constraint_name in unique_constraints:
+            operations.drop_constraint(constraint_name, table_name, type_="unique")
+    return dependent_migration
+
+
 def test_portfolio_valuation_book_scope_applies_rolls_back_and_enforces_authority(
     db_engine,
     clean_db,
@@ -67,6 +98,7 @@ def test_portfolio_valuation_book_scope_applies_rolls_back_and_enforces_authorit
     migration: dict[str, Any] = runpy.run_path(str(MIGRATION))
 
     with db_engine.begin() as connection:
+        dependent_migration = _downgrade_dependent_schema(connection)
         _bind_operations(migration, connection)
         migration["downgrade"]()
         assert "tenant_id" not in {
@@ -120,6 +152,7 @@ def test_portfolio_valuation_book_scope_applies_rolls_back_and_enforces_authorit
                 "legal_book_id": None,
             },
         )
+
         connection.execute(
             PORTFOLIO_INSERT,
             {
@@ -128,3 +161,9 @@ def test_portfolio_valuation_book_scope_applies_rolls_back_and_enforces_authorit
                 "legal_book_id": "PB-SG-01",
             },
         )
+
+        if dependent_migration is not None:
+            dependent_migration["upgrade"]()
+            inspector = inspect(connection)
+            assert inspector.has_table("lot_amortized_cost_profiles")
+            assert inspector.has_table("lot_amortized_cost_periods")


### PR DESCRIPTION
## Summary
- normalize the historical portfolio valuation-book migration test to its true target revision before downgrade
- restore the current amortized-cost dependent schema before the test transaction commits
- tolerate either fully current or partially materialized local test schema while preserving fail-closed production foreign keys

## Why
- exact-main Integration Full correctly rejected dropping `portfolios.legal_book_id` while the newer amortized-cost ledger referenced it
- the historical migration test must isolate later dependent schema rather than weakening the production composite foreign key

Refs #478

## Scope
- [x] Single RFC/slice scope
- [x] No unrelated refactors mixed in

## Validation (local)
- [x] `make lint` (scoped Ruff lint/format)
- [x] `make typecheck` (unchanged typed production source; PR lane required)
- [x] `make test-unit` (unchanged unit source; PR lane required)
- [x] Additional targeted checks for changed area

Targeted evidence:
- failing historical migration case: 1 passed against real PostgreSQL
- historical migration followed by current amortized-cost migration: 2 passed against real PostgreSQL
- `git diff --check`

## CI Expectations
- [ ] Fast PR gates are green
- [ ] Heavy gates run in scheduled/manual tier where applicable

## Governance/Docs
- [x] Documentation impact reviewed across repository and wiki truth
- [x] No documentation change: production schema and contracts are unchanged; this corrects test revision isolation only
- [x] No route, contract, supported-feature, operational, security, validation-lane, or service-boundary change
- [x] No runtime split: test-only change
- [x] No wiki source change; no publication required for this hotfix

## Post-Merge Hygiene
- [ ] Delete remote fix branch
- [ ] Delete local fix branch
- [ ] Sync local main with origin/main (`local = remote = main`)