### PR TITLE
test(migrations): restore dependent schema after rollback proofs

### DIFF
--- a/tests/integration/test_lot_amortized_cost_profile_migration.py
+++ b/tests/integration/test_lot_amortized_cost_profile_migration.py
@@ -20,6 +20,12 @@ MIGRATION = (
     / "versions"
     / "c139b2c3d50c_feat_add_lot_amortized_cost_profiles.py"
 )
+LATER_MIGRATION = (
+    Path(__file__).resolve().parents[2]
+    / "alembic"
+    / "versions"
+    / "c140b2c3d50d_feat_add_lot_amortized_cost_authority.py"
+)
 
 PROFILE_INSERT = text(
     """
@@ -137,6 +143,17 @@ def _normalize_to_previous_revision(migration: dict[str, Any], connection) -> No
         }
         if constraint_name in unique_constraints:
             operations.drop_constraint(constraint_name, table_name, type_="unique")
+
+
+def _downgrade_later_revision(connection) -> dict[str, Any] | None:
+    """Remove the head revision before exercising its direct predecessor."""
+
+    if not inspect(connection).has_table("lot_amortized_cost_authority"):
+        return None
+    later_migration: dict[str, Any] = runpy.run_path(str(LATER_MIGRATION))
+    _bind_operations(later_migration, connection)
+    later_migration["downgrade"]()
+    return later_migration
 
 
 def _seed_source_lot(connection) -> None:
@@ -263,6 +280,7 @@ def test_lot_amortized_cost_profiles_apply_roll_back_and_enforce_ledgers(
     migration: dict[str, Any] = runpy.run_path(str(MIGRATION))
 
     with db_engine.begin() as connection:
+        later_migration = _downgrade_later_revision(connection)
         _bind_operations(migration, connection)
         _normalize_to_previous_revision(migration, connection)
         migration["upgrade"]()
@@ -333,3 +351,6 @@ def test_lot_amortized_cost_profiles_apply_roll_back_and_enforce_ledgers(
         migration["upgrade"]()
         assert inspect(connection).has_table("lot_amortized_cost_profiles")
         assert inspect(connection).has_table("lot_amortized_cost_periods")
+        if later_migration is not None:
+            later_migration["upgrade"]()
+            assert inspect(connection).has_table("lot_amortized_cost_authority")

--- a/tests/integration/test_portfolio_valuation_book_scope_migration.py
+++ b/tests/integration/test_portfolio_valuation_book_scope_migration.py
@@ -26,6 +26,12 @@ DEPENDENT_MIGRATION = (
     / "versions"
     / "c139b2c3d50c_feat_add_lot_amortized_cost_profiles.py"
 )
+LATEST_MIGRATION = (
+    Path(__file__).resolve().parents[2]
+    / "alembic"
+    / "versions"
+    / "c140b2c3d50d_feat_add_lot_amortized_cost_authority.py"
+)
 
 PORTFOLIO_INSERT = text(
     """
@@ -66,12 +72,19 @@ def _bind_operations(migration: dict[str, Any], connection) -> None:
     migration["downgrade"].__globals__["op"] = operations
 
 
-def _downgrade_dependent_schema(connection) -> dict[str, Any] | None:
+def _downgrade_dependent_schema(connection) -> list[dict[str, Any]]:
     """Downgrade later schema that deliberately references valuation-book scope."""
 
     inspector = inspect(connection)
+    dependent_migrations: list[dict[str, Any]] = []
+    if inspector.has_table("lot_amortized_cost_authority"):
+        latest_migration: dict[str, Any] = runpy.run_path(str(LATEST_MIGRATION))
+        _bind_operations(latest_migration, connection)
+        latest_migration["downgrade"]()
+        dependent_migrations.append(latest_migration)
+        inspector = inspect(connection)
     if not inspector.has_table("lot_amortized_cost_profiles"):
-        return None
+        return dependent_migrations
     dependent_migration: dict[str, Any] = runpy.run_path(str(DEPENDENT_MIGRATION))
     _bind_operations(dependent_migration, connection)
     operations = dependent_migration["downgrade"].__globals__["op"]
@@ -88,7 +101,8 @@ def _downgrade_dependent_schema(connection) -> dict[str, Any] | None:
         }
         if constraint_name in unique_constraints:
             operations.drop_constraint(constraint_name, table_name, type_="unique")
-    return dependent_migration
+    dependent_migrations.append(dependent_migration)
+    return dependent_migrations
 
 
 def test_portfolio_valuation_book_scope_applies_rolls_back_and_enforces_authority(
@@ -98,7 +112,7 @@ def test_portfolio_valuation_book_scope_applies_rolls_back_and_enforces_authorit
     migration: dict[str, Any] = runpy.run_path(str(MIGRATION))
 
     with db_engine.begin() as connection:
-        dependent_migration = _downgrade_dependent_schema(connection)
+        dependent_migrations = _downgrade_dependent_schema(connection)
         _bind_operations(migration, connection)
         migration["downgrade"]()
         assert "tenant_id" not in {
@@ -162,8 +176,11 @@ def test_portfolio_valuation_book_scope_applies_rolls_back_and_enforces_authorit
             },
         )
 
-        if dependent_migration is not None:
+        for dependent_migration in reversed(dependent_migrations):
             dependent_migration["upgrade"]()
+        if dependent_migrations:
             inspector = inspect(connection)
             assert inspector.has_table("lot_amortized_cost_profiles")
             assert inspector.has_table("lot_amortized_cost_periods")
+            if len(dependent_migrations) == 2:
+                assert inspector.has_table("lot_amortized_cost_authority")


### PR DESCRIPTION
## Objective\nFix the deterministic exact-main Integration Full failure introduced when c140 added a foreign key to the uniqueness constraint exercised by earlier migration rollback proofs.\n\n## Change\n- downgrade c140 before exercising c139 or c118 rollback behavior\n- restore dependent revisions in chronological order\n- assert that the authority schema returns to head state\n\n## Compatibility\nTest isolation only. No runtime, database, API, OpenAPI, documentation, or wiki contract changes.\n\n## Validation\n- python -m pytest tests/integration/test_lot_amortized_cost_profile_migration.py tests/integration/test_portfolio_valuation_book_scope_migration.py -q — 2 passed\n- python -m pytest tests/integration/test_lot_amortized_cost_authority_migration.py tests/integration/test_lot_amortized_cost_profile_migration.py tests/integration/test_portfolio_valuation_book_scope_migration.py -q — 3 passed\n- Ruff check and format check — passed\n- git diff --check — passed\n\nFix-forward for exact-main run 30743654590 after #888.