### PR TITLE
test(cost-basis): cover invalid disposal evidence keys

### DIFF
--- a/tests/unit/services/portfolio_transaction_processing_service/domain/cost_basis/calculation/test_disposition_engine.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/domain/cost_basis/calculation/test_disposition_engine.py
@@ -253,6 +253,23 @@ def test_disposal_lifecycle_normalizes_transaction_identity(
     assert disposition_engine.disposal_records() == ()
 
 
+@pytest.mark.parametrize(
+    ("transaction_id", "expected_error", "message"),
+    [
+        (None, TypeError, "must be a string"),
+        ("   ", ValueError, "must be nonblank"),
+    ],
+)
+def test_disposal_lifecycle_rejects_invalid_transaction_identity(
+    disposition_engine: LotDispositionEngine,
+    transaction_id: object,
+    expected_error: type[Exception],
+    message: str,
+) -> None:
+    with pytest.raises(expected_error, match=message):
+        disposition_engine.commit_disposal_record(transaction_id)  # type: ignore[arg-type]
+
+
 def test_set_initial_lots_delegates_to_strategy(
     disposition_engine: LotDispositionEngine,
     mock_strategy: MagicMock,


### PR DESCRIPTION
## Objective
Restore exact-main changed-code branch coverage after #893 by directly proving the non-string and blank transaction-ID rejection branches added at the disposal evidence boundary.

## Validation
- 12 warning-strict disposition-engine tests passed
- scoped Ruff passed
- diff hygiene passed

## Compatibility
Test-only; no runtime, API, persistence, OpenAPI, migration, documentation, or wiki behavior changes. No wiki change is required.

## Evidence
Main Releasability run 30784499700 failed only the changed-code coverage threshold (71.43% vs 85%); all other executed jobs passed.