### PR TITLE
fix(cost-basis): preserve truthful AVCO allocation continuation

### DIFF
--- a/docs/standards/financial-calculated-output-policies.v1.json
+++ b/docs/standards/financial-calculated-output-policies.v1.json
@@ -87,8 +87,6 @@
           "src/services/portfolio_transaction_processing_service/app/domain/cost_basis/calculation/cost_basis_strategies.py::_apportion_nonnegative_disposal_values"
         ],
         "src/services/portfolio_transaction_processing_service/app/domain/cost_basis/state_lineage.py::build_cost_basis_state_lineage": [
-          "src/services/portfolio_transaction_processing_service/app/domain/cost_basis/average_cost_allocation_checkpoint.py::AverageCostAllocationCheckpoint._validate_materialized_totals",
-          "src/services/portfolio_transaction_processing_service/app/domain/cost_basis/average_cost_allocation_checkpoint.py::_materialized_total",
           "src/services/portfolio_transaction_processing_service/app/domain/cost_basis/average_cost_pool_checkpoint.py::AverageCostPoolTransition.after",
           "src/services/portfolio_transaction_processing_service/app/domain/cost_basis/average_cost_pool_checkpoint.py::_sum_state_field",
           "src/services/portfolio_transaction_processing_service/app/domain/cost_basis/calculation/average_cost_source_allocation.py::AverageCostPool.add",

--- a/docs/standards/financial-calculated-output-policies.v1.json
+++ b/docs/standards/financial-calculated-output-policies.v1.json
@@ -87,6 +87,8 @@
           "src/services/portfolio_transaction_processing_service/app/domain/cost_basis/calculation/cost_basis_strategies.py::_apportion_nonnegative_disposal_values"
         ],
         "src/services/portfolio_transaction_processing_service/app/domain/cost_basis/state_lineage.py::build_cost_basis_state_lineage": [
+          "src/services/portfolio_transaction_processing_service/app/domain/cost_basis/average_cost_allocation_checkpoint.py::AverageCostAllocationCheckpoint._validate_materialized_totals",
+          "src/services/portfolio_transaction_processing_service/app/domain/cost_basis/average_cost_allocation_checkpoint.py::_materialized_total",
           "src/services/portfolio_transaction_processing_service/app/domain/cost_basis/average_cost_pool_checkpoint.py::AverageCostPoolTransition.after",
           "src/services/portfolio_transaction_processing_service/app/domain/cost_basis/average_cost_pool_checkpoint.py::_sum_state_field",
           "src/services/portfolio_transaction_processing_service/app/domain/cost_basis/calculation/average_cost_source_allocation.py::AverageCostPool.add",

--- a/scripts/operations/cost_history_capacity_profile.py
+++ b/scripts/operations/cost_history_capacity_profile.py
@@ -93,7 +93,7 @@ def run_capacity_profile(
             timeline = build_capacity_timeline(transaction_count)
             processor = build_cost_basis_timeline_processor(method)
             started = clock()
-            processed, errors, open_lot_states = processor.process_transactions([], timeline)
+            result = processor.process_transactions([], timeline)
             duration_seconds = max(clock() - started, 0.0)
             throughput = transaction_count / duration_seconds if duration_seconds > 0 else 0.0
             measurements.append(
@@ -102,9 +102,9 @@ def run_capacity_profile(
                     transaction_count=transaction_count,
                     duration_seconds=round(duration_seconds, 6),
                     transactions_per_second=round(throughput, 3),
-                    processed_count=len(processed),
-                    error_count=len(errors),
-                    open_lot_state_count=len(open_lot_states),
+                    processed_count=len(result.processed),
+                    error_count=len(result.errored),
+                    open_lot_state_count=len(result.open_lot_states),
                 )
             )
 

--- a/scripts/operations/cost_processing_mode_capacity_profile.py
+++ b/scripts/operations/cost_processing_mode_capacity_profile.py
@@ -52,23 +52,23 @@ def _open_lot_checkpoint(
     *,
     cost_basis_method: str,
 ) -> tuple[list[dict[str, object]], int]:
-    processed, errors, states = build_cost_basis_timeline_processor(
-        cost_basis_method
-    ).process_transactions([], timeline)
-    if errors or len(processed) != len(timeline):
+    result = build_cost_basis_timeline_processor(cost_basis_method).process_transactions(
+        [], timeline
+    )
+    if result.errored or len(result.processed) != len(timeline):
         raise RuntimeError("Capacity profile prefix failed financial validation")
 
     source_by_id = {row["transaction_id"]: row for row in timeline}
     checkpoint: list[dict[str, object]] = []
-    for source_transaction_id, state in states.items():
+    for source_transaction_id, state in result.open_lot_states.items():
         if state.quantity <= Decimal(0):
             continue
-        source = dict(source_by_id[source_transaction_id])
+        source: dict[str, object] = dict(source_by_id[source_transaction_id])
         source["quantity"] = state.quantity
         source["net_cost_local"] = state.cost_local
         source["net_cost"] = state.cost_base
         checkpoint.append(source)
-    return checkpoint, len(errors)
+    return checkpoint, len(result.errored)
 
 
 def _appended_sell(timeline: list[dict[str, str]]) -> dict[str, str]:
@@ -180,15 +180,14 @@ def run_processing_mode_profile(
             opening_error_count = prefix_error_count
             opening_states = {}
             for _ in range(append_iterations):
-                processed, errors, opening_states = build_cost_basis_timeline_processor(
-                    method
-                ).process_increment(
+                result = build_cost_basis_timeline_processor(method).process_increment(
                     initial_open_lots_raw=[],
                     new_transactions_raw=[opening_event],
                 )
-                opening_error_count += len(errors)
-                if len(processed) != 1:
+                opening_error_count += len(result.errored)
+                if len(result.processed) != 1:
                     raise RuntimeError("Ordered opening profile did not process exactly one event")
+                opening_states = result.open_lot_states
             opening_duration = max(clock() - opening_started, 0.0)
             measurements.append(
                 _measurement(
@@ -208,15 +207,14 @@ def run_processing_mode_profile(
             append_error_count = prefix_error_count
             append_states = {}
             for _ in range(append_iterations):
-                processed, errors, append_states = build_cost_basis_timeline_processor(
-                    method
-                ).process_increment(
+                result = build_cost_basis_timeline_processor(method).process_increment(
                     initial_open_lots_raw=disposal_checkpoint,
                     new_transactions_raw=[append_event],
                 )
-                append_error_count += len(errors)
-                if len(processed) != 1:
+                append_error_count += len(result.errored)
+                if len(result.processed) != 1:
                     raise RuntimeError("Ordered append profile did not process exactly one event")
+                append_states = result.open_lot_states
             append_duration = max(clock() - append_started, 0.0)
             measurements.append(
                 _measurement(
@@ -233,11 +231,11 @@ def run_processing_mode_profile(
             )
 
             backdated_started = clock()
-            processed, errors, backdated_states = build_cost_basis_timeline_processor(
-                method
-            ).process_transactions([], [*timeline, _backdated_buy(timeline)])
+            result = build_cost_basis_timeline_processor(method).process_transactions(
+                [], [*timeline, _backdated_buy(timeline)]
+            )
             backdated_duration = max(clock() - backdated_started, 0.0)
-            if len(processed) != history_count + 1:
+            if len(result.processed) != history_count + 1:
                 raise RuntimeError("Backdated profile did not rebuild the complete history")
             measurements.append(
                 _measurement(
@@ -248,8 +246,8 @@ def run_processing_mode_profile(
                     recalculated_row_count=history_count + 1,
                     restored_open_lot_count=0,
                     duration_seconds=backdated_duration,
-                    error_count=len(errors),
-                    ending_open_quantity=_total_open_quantity(backdated_states),
+                    error_count=len(result.errored),
+                    ending_open_quantity=_total_open_quantity(result.open_lot_states),
                 )
             )
 

--- a/src/services/portfolio_transaction_processing_service/app/application/cost_basis_processing/average_cost_pool_rebuild.py
+++ b/src/services/portfolio_transaction_processing_service/app/application/cost_basis_processing/average_cost_pool_rebuild.py
@@ -74,28 +74,28 @@ class AverageCostPoolRebuildPlanner:
             portfolio_base_currency=portfolio.base_currency,
             fx_rates=fx_rates,
         )
-        processed, errored, source_states = build_cost_basis_timeline_processor(
+        timeline_result = build_cost_basis_timeline_processor(
             CostBasisMethod.AVCO,
             observer=self._observer,
         ).process_transactions(existing_transactions_raw=[], new_transactions_raw=enriched_history)
-        if errored:
-            first_error = errored[0]
+        if timeline_result.errored:
+            first_error = timeline_result.errored[0]
             raise ValueError(
                 f"Cost-basis calculation failed for {first_error.transaction_id}: "
                 f"{first_error.error_reason}"
             )
 
-        latest_transaction = max(processed, key=transaction_order_key)
+        latest_transaction = max(timeline_result.processed, key=transaction_order_key)
         source_transactions = tuple(
             transaction
-            for transaction in processed
+            for transaction in timeline_result.processed
             if transaction_lot_behavior(transaction.transaction_type) in LOT_OPENING_BEHAVIORS
         )
         checkpoint = AverageCostPoolCheckpoint.from_open_lot_states(
             portfolio_id=portfolio_id,
             instrument_id=latest_transaction.instrument_id,
             security_id=security_id,
-            states_by_source_transaction_id=source_states,
+            states_by_source_transaction_id=timeline_result.open_lot_states,
         )
         processing_checkpoint = CostBasisProcessingCheckpoint.from_transaction(
             latest_transaction,
@@ -106,12 +106,12 @@ class AverageCostPoolRebuildPlanner:
             processing_checkpoint=processing_checkpoint,
             replay_lineage=_rebuild_replay_lineage(
                 history=history,
-                processed=processed,
+                processed=timeline_result.processed,
                 checkpoint=checkpoint,
                 processing_checkpoint=processing_checkpoint,
             ),
             source_transactions=source_transactions,
-            source_states=source_states,
+            source_states=timeline_result.open_lot_states,
         )
 
 

--- a/src/services/portfolio_transaction_processing_service/app/application/cost_basis_processing/calculation.py
+++ b/src/services/portfolio_transaction_processing_service/app/application/cost_basis_processing/calculation.py
@@ -75,7 +75,14 @@ class CostBasisCalculationCoordinator:
             security_id=transaction.security_id,
         )
         lot_behavior = transaction_lot_behavior(transaction_type)
-        if checkpoint is not None and lot_behavior in INCREMENTAL_SAFE_LOT_BEHAVIORS:
+        requires_full_source_history = (
+            cost_basis_method is CostBasisMethod.AVCO and lot_behavior == "consume_lot"
+        )
+        if (
+            checkpoint is not None
+            and lot_behavior in INCREMENTAL_SAFE_LOT_BEHAVIORS
+            and not requires_full_source_history
+        ):
             incoming_raw = await self._load_incoming_transaction(
                 transaction=transaction,
                 portfolio_base_currency=portfolio_base_currency,

--- a/src/services/portfolio_transaction_processing_service/app/application/cost_basis_processing/calculation.py
+++ b/src/services/portfolio_transaction_processing_service/app/application/cost_basis_processing/calculation.py
@@ -165,7 +165,7 @@ class CostBasisCalculationCoordinator:
                 lot_count=len(initial_open_lots_raw),
             )
 
-        processed, errored, open_lot_states = build_cost_basis_timeline_processor(
+        timeline_result = build_cost_basis_timeline_processor(
             cost_basis_method,
             observer=self._observer,
         ).process_increment(
@@ -175,19 +175,20 @@ class CostBasisCalculationCoordinator:
         average_cost_pool_transition = (
             self._build_average_cost_pool_transition(
                 checkpoint=average_cost_pool_record.checkpoint,
-                open_lot_states=open_lot_states,
+                open_lot_states=timeline_result.open_lot_states,
             )
-            if average_cost_pool_record is not None and not errored
+            if average_cost_pool_record is not None and not timeline_result.errored
             else None
         )
         self._record_execution(CostBasisExecutionMode.ORDERED_APPEND, cost_basis_method)
         return CostBasisCalculationResult(
-            processed=processed,
-            errored=errored,
-            open_lot_states=open_lot_states,
+            processed=timeline_result.processed,
+            errored=timeline_result.errored,
+            open_lot_states=timeline_result.open_lot_states,
             incremental=True,
             open_lot_persistence_scope=persistence_scope,
             average_cost_pool_transition=average_cost_pool_transition,
+            disposals=timeline_result.disposals,
         )
 
     async def _calculate_full_rebuild(
@@ -204,7 +205,7 @@ class CostBasisCalculationCoordinator:
             portfolio_base_currency=portfolio_base_currency,
             instrument=instrument,
         )
-        processed, errored, open_lot_states = build_cost_basis_timeline_processor(
+        timeline_result = build_cost_basis_timeline_processor(
             cost_basis_method,
             observer=self._observer,
         ).process_transactions(
@@ -219,12 +220,13 @@ class CostBasisCalculationCoordinator:
         )
         self._record_execution(CostBasisExecutionMode.FULL_REBUILD, cost_basis_method)
         return CostBasisCalculationResult(
-            processed=processed,
-            errored=errored,
-            open_lot_states=open_lot_states,
+            processed=timeline_result.processed,
+            errored=timeline_result.errored,
+            open_lot_states=timeline_result.open_lot_states,
             incremental=False,
             open_lot_persistence_scope=persistence_scope,
             average_cost_pool_transition=None,
+            disposals=timeline_result.disposals,
         )
 
     async def _load_incoming_transaction(

--- a/src/services/portfolio_transaction_processing_service/app/application/cost_basis_processing/calculation_result.py
+++ b/src/services/portfolio_transaction_processing_service/app/application/cost_basis_processing/calculation_result.py
@@ -7,6 +7,7 @@ from ...domain.cost_basis import (
     CostBasisTransaction,
     CostCalculationError,
     OpenLotState,
+    TransactionLotDisposal,
 )
 from .lot_state_persistence import OpenLotPersistenceScope
 
@@ -21,3 +22,4 @@ class CostBasisCalculationResult:
     incremental: bool
     open_lot_persistence_scope: OpenLotPersistenceScope
     average_cost_pool_transition: AverageCostPoolTransition | None
+    disposals: tuple[TransactionLotDisposal, ...]

--- a/src/services/portfolio_transaction_processing_service/app/application/cost_basis_processing/timeline.py
+++ b/src/services/portfolio_transaction_processing_service/app/application/cost_basis_processing/timeline.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from types import TracebackType
 from typing import Any
 
@@ -20,6 +21,7 @@ from ...domain.cost_basis import (
     FIFOBasisStrategy,
     LotDispositionEngine,
     OpenLotState,
+    TransactionLotDisposal,
 )
 from ...ports.cost_basis.observability import (
     CostBasisCalculationObservation,
@@ -28,6 +30,16 @@ from ...ports.cost_basis.observability import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class CostBasisTimelineResult:
+    """Carry one accepted timeline result and its immutable disposal evidence."""
+
+    processed: list[CostBasisTransaction]
+    errored: list[CostCalculationError]
+    open_lot_states: dict[str, OpenLotState]
+    disposals: tuple[TransactionLotDisposal, ...]
 
 
 def build_cost_basis_timeline_processor(
@@ -83,9 +95,10 @@ class CostBasisTimelineProcessor:
         self,
         existing_transactions_raw: list[dict[str, Any]],
         new_transactions_raw: list[dict[str, Any]],
-    ) -> tuple[list[CostBasisTransaction], list[CostCalculationError], dict[str, OpenLotState]]:
+    ) -> CostBasisTimelineResult:
         with self._observer.observe_recalculation() as observation:
             self._error_reporter.clear()
+            self._disposition_engine.clear_disposal_records()
 
             parsed_existing = self._parser.parse_transactions(existing_transactions_raw)
             parsed_new = self._parser.parse_transactions(new_transactions_raw)
@@ -100,10 +113,16 @@ class CostBasisTimelineProcessor:
                 new_transaction_ids=new_transaction_ids,
             )
 
-            return (
-                final_processed_new,
-                self._error_reporter.get_errors(),
-                self._disposition_engine.get_open_lot_states(),
+            accepted_transaction_ids = {
+                transaction.transaction_id for transaction in final_processed_new
+            }
+            return CostBasisTimelineResult(
+                processed=final_processed_new,
+                errored=self._error_reporter.get_errors(),
+                open_lot_states=self._disposition_engine.get_open_lot_states(),
+                disposals=self._disposition_engine.disposal_records(
+                    transaction_ids=accepted_transaction_ids
+                ),
             )
 
     def process_increment(
@@ -111,10 +130,11 @@ class CostBasisTimelineProcessor:
         *,
         initial_open_lots_raw: list[dict[str, Any]],
         new_transactions_raw: list[dict[str, Any]],
-    ) -> tuple[list[CostBasisTransaction], list[CostCalculationError], dict[str, OpenLotState]]:
+    ) -> CostBasisTimelineResult:
         """Calculate an ordered append from a previously validated open-lot checkpoint."""
         with self._observer.observe_recalculation() as observation:
             self._error_reporter.clear()
+            self._disposition_engine.clear_disposal_records()
             parsed_initial_lots = self._parser.parse_transactions(initial_open_lots_raw)
             parsed_new = self._parser.parse_transactions(new_transactions_raw)
             valid_initial_lots = [txn for txn in parsed_initial_lots if not txn.error_reason]
@@ -125,10 +145,14 @@ class CostBasisTimelineProcessor:
             self._disposition_engine.restore_open_lots(sorted_initial_lots)
             sorted_new = self._sorter.sort_transactions([], valid_new)
             processed_new = self._process_sorted_timeline(sorted_new)
-            return (
-                processed_new,
-                self._error_reporter.get_errors(),
-                self._disposition_engine.get_open_lot_states(),
+            accepted_transaction_ids = {transaction.transaction_id for transaction in processed_new}
+            return CostBasisTimelineResult(
+                processed=processed_new,
+                errored=self._error_reporter.get_errors(),
+                open_lot_states=self._disposition_engine.get_open_lot_states(),
+                disposals=self._disposition_engine.disposal_records(
+                    transaction_ids=accepted_transaction_ids
+                ),
             )
 
     @staticmethod

--- a/src/services/portfolio_transaction_processing_service/app/domain/cost_basis/__init__.py
+++ b/src/services/portfolio_transaction_processing_service/app/domain/cost_basis/__init__.py
@@ -1,5 +1,10 @@
 """Public cost-basis domain models, policies, and deterministic calculations."""
 
+from .average_cost_allocation_checkpoint import (
+    AVERAGE_COST_ALLOCATION_STATE_VERSION,
+    AverageCostAllocationCheckpoint,
+    AverageCostSourceAccumulator,
+)
 from .average_cost_pool_checkpoint import (
     AVERAGE_COST_POOL_STATE_VERSION,
     AverageCostPoolCheckpoint,
@@ -69,7 +74,9 @@ from .processing_checkpoint import (
 )
 
 __all__ = [
+    "AVERAGE_COST_ALLOCATION_STATE_VERSION",
     "AverageCostBasisStrategy",
+    "AverageCostAllocationCheckpoint",
     "AverageCostPool",
     "AverageCostPoolCheckpoint",
     "AverageCostPoolRebuildPlan",
@@ -77,6 +84,7 @@ __all__ = [
     "AverageCostPoolReconciliationAssessment",
     "AverageCostPoolReconciliationStatus",
     "AverageCostSourceAllocation",
+    "AverageCostSourceAccumulator",
     "AverageCostSourceContribution",
     "AverageCostPoolTransition",
     "build_average_cost_pool_rebuild_lineage",

--- a/src/services/portfolio_transaction_processing_service/app/domain/cost_basis/average_cost_allocation_checkpoint.py
+++ b/src/services/portfolio_transaction_processing_service/app/domain/cost_basis/average_cost_allocation_checkpoint.py
@@ -161,8 +161,33 @@ class AverageCostAllocationCheckpoint:
                 * self.pool.quantity
                 / self.source_allocation_segment_start_quantity
             )
-        if expected_disposal_scale != self.disposal_scale:
+        if _normalize_checkpoint_value(
+            expected_disposal_scale,
+            field_name="disposal_scale",
+        ) != _normalize_checkpoint_value(self.disposal_scale, field_name="disposal_scale"):
             raise ValueError("AVCO disposal scale conflicts with source-allocation segment")
+        if self.pool.quantity > self.segment_start_quantity:
+            raise ValueError("AVCO pool quantity exceeds its disposal segment")
+        with _checkpoint_arithmetic_context():
+            expected_pool_cost_local = (
+                self.segment_start_cost_local * self.pool.quantity / self.segment_start_quantity
+            )
+            expected_pool_cost_base = (
+                self.segment_start_cost_base * self.pool.quantity / self.segment_start_quantity
+            )
+        if (
+            _normalize_checkpoint_value(
+                expected_pool_cost_local,
+                field_name="pool_cost_local",
+            )
+            != self.pool.cost_local
+            or _normalize_checkpoint_value(
+                expected_pool_cost_base,
+                field_name="pool_cost_base",
+            )
+            != self.pool.cost_base
+        ):
+            raise ValueError("AVCO pool costs conflict with disposal segment state")
 
         expected_quantity = _materialized_total(
             self,

--- a/src/services/portfolio_transaction_processing_service/app/domain/cost_basis/average_cost_allocation_checkpoint.py
+++ b/src/services/portfolio_transaction_processing_service/app/domain/cost_basis/average_cost_allocation_checkpoint.py
@@ -65,6 +65,7 @@ class AverageCostAllocationCheckpoint:
     segment_start_quantity: Decimal
     segment_start_cost_local: Decimal
     segment_start_cost_base: Decimal
+    source_allocation_segment_start_quantity: Decimal
     allocation_generation: int
     disposal_scale: Decimal
     segment_start_scale: Decimal
@@ -82,6 +83,7 @@ class AverageCostAllocationCheckpoint:
             "segment_start_quantity",
             "segment_start_cost_local",
             "segment_start_cost_base",
+            "source_allocation_segment_start_quantity",
         ):
             _require_decimal(getattr(self, field_name), field_name=field_name, positive=False)
         for field_name in (
@@ -117,11 +119,11 @@ class AverageCostAllocationCheckpoint:
         if any(source.generation != self.allocation_generation for source in self.sources):
             raise ValueError("active AVCO sources must match the allocation generation")
         if any(
-            source.cost_local_generation != self.cost_local_generation
-            or source.cost_base_generation != self.cost_base_generation
+            source.cost_local_generation > self.cost_local_generation
+            or source.cost_base_generation > self.cost_base_generation
             for source in self.sources
         ):
-            raise ValueError("active AVCO sources must match the cost generations")
+            raise ValueError("active AVCO source cost generation cannot be in the future")
 
         if self.pool.quantity == Decimal(0):
             if self.sources:
@@ -131,6 +133,7 @@ class AverageCostAllocationCheckpoint:
                     self.segment_start_quantity,
                     self.segment_start_cost_local,
                     self.segment_start_cost_base,
+                    self.source_allocation_segment_start_quantity,
                 )
             ):
                 raise ValueError("closed AVCO checkpoint must have zero segment state")
@@ -141,6 +144,8 @@ class AverageCostAllocationCheckpoint:
             raise ValueError("AVCO representative source is absent from the accumulator")
         if self.segment_start_quantity <= Decimal(0):
             raise ValueError("open AVCO checkpoint requires positive segment quantity")
+        if self.source_allocation_segment_start_quantity <= Decimal(0):
+            raise ValueError("open AVCO checkpoint requires positive source-allocation segment")
 
 
 def _require_decimal(value: object, *, field_name: str, positive: bool) -> None:

--- a/src/services/portfolio_transaction_processing_service/app/domain/cost_basis/average_cost_allocation_checkpoint.py
+++ b/src/services/portfolio_transaction_processing_service/app/domain/cost_basis/average_cost_allocation_checkpoint.py
@@ -1,0 +1,160 @@
+"""Define the persisted AVCO source-allocation accumulator contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+
+from .average_cost_pool_checkpoint import AverageCostPoolCheckpoint
+
+AVERAGE_COST_ALLOCATION_STATE_VERSION = "avco-source-allocation-v1"
+
+
+@dataclass(frozen=True, slots=True)
+class AverageCostSourceAccumulator:
+    """Persist one active source contribution without materializing every disposal."""
+
+    source_transaction_id: str
+    source_lot_id: str
+    source_acquisition_date: date
+    source_sequence: int
+    generation: int
+    quantity: Decimal
+    cost_local: Decimal
+    cost_base: Decimal
+    disposal_scale_at_entry: Decimal
+    cost_local_scale_at_entry: Decimal
+    cost_base_scale_at_entry: Decimal
+    cost_local_generation: int
+    cost_base_generation: int
+
+    def __post_init__(self) -> None:
+        for field_name in ("source_transaction_id", "source_lot_id"):
+            value = getattr(self, field_name)
+            if not isinstance(value, str):
+                raise TypeError(f"{field_name} must be a string")
+            normalized = value.strip()
+            if not normalized:
+                raise ValueError(f"{field_name} must be nonblank")
+            object.__setattr__(self, field_name, normalized)
+        if type(self.source_acquisition_date) is not date:
+            raise TypeError("source_acquisition_date must be a date")
+        _require_nonnegative_integer(self.source_sequence, field_name="source_sequence")
+        if self.source_sequence < 1:
+            raise ValueError("source_sequence must be positive")
+        for field_name in ("generation", "cost_local_generation", "cost_base_generation"):
+            _require_nonnegative_integer(getattr(self, field_name), field_name=field_name)
+        for field_name in ("quantity", "cost_local", "cost_base"):
+            _require_decimal(getattr(self, field_name), field_name=field_name, positive=False)
+        if self.quantity == Decimal(0):
+            raise ValueError("active AVCO source quantity must be positive")
+        for field_name in (
+            "disposal_scale_at_entry",
+            "cost_local_scale_at_entry",
+            "cost_base_scale_at_entry",
+        ):
+            _require_decimal(getattr(self, field_name), field_name=field_name, positive=True)
+
+
+@dataclass(frozen=True, slots=True)
+class AverageCostAllocationCheckpoint:
+    """Bind an aggregate pool to the exact lazy source-allocation accumulator."""
+
+    pool: AverageCostPoolCheckpoint
+    segment_start_quantity: Decimal
+    segment_start_cost_local: Decimal
+    segment_start_cost_base: Decimal
+    allocation_generation: int
+    disposal_scale: Decimal
+    segment_start_scale: Decimal
+    cost_local_scale: Decimal
+    cost_base_scale: Decimal
+    cost_local_generation: int
+    cost_base_generation: int
+    sources: tuple[AverageCostSourceAccumulator, ...]
+    state_version: str = AVERAGE_COST_ALLOCATION_STATE_VERSION
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.pool, AverageCostPoolCheckpoint):
+            raise TypeError("pool must be an AverageCostPoolCheckpoint")
+        for field_name in (
+            "segment_start_quantity",
+            "segment_start_cost_local",
+            "segment_start_cost_base",
+        ):
+            _require_decimal(getattr(self, field_name), field_name=field_name, positive=False)
+        for field_name in (
+            "allocation_generation",
+            "cost_local_generation",
+            "cost_base_generation",
+        ):
+            _require_nonnegative_integer(getattr(self, field_name), field_name=field_name)
+        for field_name in (
+            "disposal_scale",
+            "segment_start_scale",
+            "cost_local_scale",
+            "cost_base_scale",
+        ):
+            _require_decimal(getattr(self, field_name), field_name=field_name, positive=True)
+        if not isinstance(self.sources, tuple) or not all(
+            isinstance(source, AverageCostSourceAccumulator) for source in self.sources
+        ):
+            raise TypeError("sources must be a tuple of AverageCostSourceAccumulator")
+        if self.state_version != AVERAGE_COST_ALLOCATION_STATE_VERSION:
+            raise ValueError("unsupported AVCO source-allocation checkpoint version")
+
+        source_ids = tuple(source.source_transaction_id for source in self.sources)
+        source_lot_ids = tuple(source.source_lot_id for source in self.sources)
+        if len(set(source_ids)) != len(source_ids) or len(set(source_lot_ids)) != len(
+            source_lot_ids
+        ):
+            raise ValueError("AVCO source-allocation identities must be unique")
+        if tuple(source.source_sequence for source in self.sources) != tuple(
+            range(1, len(self.sources) + 1)
+        ):
+            raise ValueError("AVCO source sequences must be contiguous from one")
+        if any(source.generation != self.allocation_generation for source in self.sources):
+            raise ValueError("active AVCO sources must match the allocation generation")
+        if any(
+            source.cost_local_generation != self.cost_local_generation
+            or source.cost_base_generation != self.cost_base_generation
+            for source in self.sources
+        ):
+            raise ValueError("active AVCO sources must match the cost generations")
+
+        if self.pool.quantity == Decimal(0):
+            if self.sources:
+                raise ValueError("closed AVCO checkpoint cannot retain active sources")
+            if any(
+                (
+                    self.segment_start_quantity,
+                    self.segment_start_cost_local,
+                    self.segment_start_cost_base,
+                )
+            ):
+                raise ValueError("closed AVCO checkpoint must have zero segment state")
+            return
+        if not self.sources:
+            raise ValueError("open AVCO checkpoint requires active source accumulators")
+        if self.pool.representative_source_transaction_id not in source_ids:
+            raise ValueError("AVCO representative source is absent from the accumulator")
+        if self.segment_start_quantity <= Decimal(0):
+            raise ValueError("open AVCO checkpoint requires positive segment quantity")
+
+
+def _require_decimal(value: object, *, field_name: str, positive: bool) -> None:
+    if not isinstance(value, Decimal):
+        raise TypeError(f"{field_name} must be a Decimal")
+    if not value.is_finite():
+        raise ValueError(f"{field_name} must be finite")
+    if value < Decimal(0) or (positive and value == Decimal(0)):
+        requirement = "positive" if positive else "nonnegative"
+        raise ValueError(f"{field_name} must be {requirement}")
+
+
+def _require_nonnegative_integer(value: object, *, field_name: str) -> None:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise TypeError(f"{field_name} must be an integer")
+    if value < 0:
+        raise ValueError(f"{field_name} must be nonnegative")

--- a/src/services/portfolio_transaction_processing_service/app/domain/cost_basis/average_cost_allocation_checkpoint.py
+++ b/src/services/portfolio_transaction_processing_service/app/domain/cost_basis/average_cost_allocation_checkpoint.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date
 from decimal import Decimal
+from typing import cast
+
+from portfolio_common.domain.transaction.numeric_policy import (
+    COST_BASIS_STATE_LEDGER_OUTPUT_V1,
+)
 
 from .average_cost_pool_checkpoint import AverageCostPoolCheckpoint
 
@@ -146,6 +151,51 @@ class AverageCostAllocationCheckpoint:
             raise ValueError("open AVCO checkpoint requires positive segment quantity")
         if self.source_allocation_segment_start_quantity <= Decimal(0):
             raise ValueError("open AVCO checkpoint requires positive source-allocation segment")
+        self._validate_materialized_totals()
+
+    def _validate_materialized_totals(self) -> None:
+        with COST_BASIS_STATE_LEDGER_OUTPUT_V1.arithmetic_context():
+            expected_disposal_scale = (
+                self.segment_start_scale
+                * self.pool.quantity
+                / self.source_allocation_segment_start_quantity
+            )
+        if expected_disposal_scale != self.disposal_scale:
+            raise ValueError("AVCO disposal scale conflicts with source-allocation segment")
+
+        expected_quantity = _materialized_total(
+            self,
+            value_field="quantity",
+            scale_field=None,
+            scale_at_entry_field=None,
+            generation_field=None,
+            current_generation=None,
+            output_field="open_quantity",
+        )
+        expected_cost_local = _materialized_total(
+            self,
+            value_field="cost_local",
+            scale_field="cost_local_scale",
+            scale_at_entry_field="cost_local_scale_at_entry",
+            generation_field="cost_local_generation",
+            current_generation=self.cost_local_generation,
+            output_field="lot_cost_local",
+        )
+        expected_cost_base = _materialized_total(
+            self,
+            value_field="cost_base",
+            scale_field="cost_base_scale",
+            scale_at_entry_field="cost_base_scale_at_entry",
+            generation_field="cost_base_generation",
+            current_generation=self.cost_base_generation,
+            output_field="lot_cost_base",
+        )
+        if (
+            expected_quantity != self.pool.quantity
+            or expected_cost_local != self.pool.cost_local
+            or expected_cost_base != self.pool.cost_base
+        ):
+            raise ValueError("AVCO source accumulators conflict with aggregate pool state")
 
 
 def _require_decimal(value: object, *, field_name: str, positive: bool) -> None:
@@ -156,6 +206,41 @@ def _require_decimal(value: object, *, field_name: str, positive: bool) -> None:
     if value < Decimal(0) or (positive and value == Decimal(0)):
         requirement = "positive" if positive else "nonnegative"
         raise ValueError(f"{field_name} must be {requirement}")
+
+
+def _materialized_total(
+    checkpoint: AverageCostAllocationCheckpoint,
+    *,
+    value_field: str,
+    scale_field: str | None,
+    scale_at_entry_field: str | None,
+    generation_field: str | None,
+    current_generation: int | None,
+    output_field: str,
+) -> Decimal:
+    total = Decimal(0)
+    with COST_BASIS_STATE_LEDGER_OUTPUT_V1.arithmetic_context():
+        for source in checkpoint.sources:
+            if generation_field is not None and (
+                getattr(source, generation_field) != current_generation
+            ):
+                continue
+            materialized = (
+                cast(Decimal, getattr(source, value_field))
+                * checkpoint.disposal_scale
+                / source.disposal_scale_at_entry
+            )
+            if scale_field is not None and scale_at_entry_field is not None:
+                materialized = (
+                    materialized
+                    * cast(Decimal, getattr(checkpoint, scale_field))
+                    / cast(Decimal, getattr(source, scale_at_entry_field))
+                )
+            total += materialized
+    return cast(
+        Decimal,
+        COST_BASIS_STATE_LEDGER_OUTPUT_V1.normalize(total, field_name=output_field),
+    )
 
 
 def _require_nonnegative_integer(value: object, *, field_name: str) -> None:

--- a/src/services/portfolio_transaction_processing_service/app/domain/cost_basis/average_cost_allocation_checkpoint.py
+++ b/src/services/portfolio_transaction_processing_service/app/domain/cost_basis/average_cost_allocation_checkpoint.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from datetime import date
-from decimal import Decimal
+from decimal import Context, Decimal, localcontext
 from typing import cast
 
 from portfolio_common.domain.transaction.numeric_policy import (
@@ -154,7 +155,7 @@ class AverageCostAllocationCheckpoint:
         self._validate_materialized_totals()
 
     def _validate_materialized_totals(self) -> None:
-        with COST_BASIS_STATE_LEDGER_OUTPUT_V1.arithmetic_context():
+        with _checkpoint_arithmetic_context():
             expected_disposal_scale = (
                 self.segment_start_scale
                 * self.pool.quantity
@@ -219,7 +220,7 @@ def _materialized_total(
     output_field: str,
 ) -> Decimal:
     total = Decimal(0)
-    with COST_BASIS_STATE_LEDGER_OUTPUT_V1.arithmetic_context():
+    with _checkpoint_arithmetic_context():
         for source in checkpoint.sources:
             if generation_field is not None and (
                 getattr(source, generation_field) != current_generation
@@ -237,10 +238,27 @@ def _materialized_total(
                     / cast(Decimal, getattr(source, scale_at_entry_field))
                 )
             total += materialized
-    return cast(
-        Decimal,
-        COST_BASIS_STATE_LEDGER_OUTPUT_V1.normalize(total, field_name=output_field),
+    return _normalize_checkpoint_value(total, field_name=output_field)
+
+
+def _checkpoint_arithmetic_context() -> AbstractContextManager[Context]:
+    return localcontext(
+        Context(
+            prec=COST_BASIS_STATE_LEDGER_OUTPUT_V1.working_precision,
+            rounding=COST_BASIS_STATE_LEDGER_OUTPUT_V1.rounding,
+        )
     )
+
+
+def _normalize_checkpoint_value(value: Decimal, *, field_name: str) -> Decimal:
+    if not value.is_finite():
+        raise ValueError(f"{field_name} checkpoint total must be finite")
+    quantum = Decimal(1).scaleb(-COST_BASIS_STATE_LEDGER_OUTPUT_V1.scale)
+    with _checkpoint_arithmetic_context():
+        return value.quantize(
+            quantum,
+            rounding=COST_BASIS_STATE_LEDGER_OUTPUT_V1.rounding,
+        )
 
 
 def _require_nonnegative_integer(value: object, *, field_name: str) -> None:

--- a/src/services/portfolio_transaction_processing_service/app/domain/cost_basis/calculation/average_cost_source_allocation.py
+++ b/src/services/portfolio_transaction_processing_service/app/domain/cost_basis/calculation/average_cost_source_allocation.py
@@ -399,6 +399,9 @@ class AverageCostSourceAllocation:
             segment_start_quantity=(Decimal(0) if is_closed else pool.segment_start_quantity),
             segment_start_cost_local=(Decimal(0) if is_closed else pool.segment_start_cost_local),
             segment_start_cost_base=(Decimal(0) if is_closed else pool.segment_start_cost_base),
+            source_allocation_segment_start_quantity=(
+                Decimal(0) if is_closed else self._segment_start_quantity_by_key[book_key]
+            ),
             allocation_generation=self._generation_by_key[book_key],
             disposal_scale=self._disposal_scale_by_key[book_key],
             segment_start_scale=self._segment_start_scale_by_key[book_key],
@@ -463,7 +466,9 @@ class AverageCostSourceAllocation:
         self._generation_by_key[book_key] = checkpoint.allocation_generation
         self._disposal_scale_by_key[book_key] = checkpoint.disposal_scale
         self._segment_start_scale_by_key[book_key] = checkpoint.segment_start_scale
-        self._segment_start_quantity_by_key[book_key] = checkpoint.segment_start_quantity
+        self._segment_start_quantity_by_key[book_key] = (
+            checkpoint.source_allocation_segment_start_quantity
+        )
         self._cost_local_scale_by_key[book_key] = checkpoint.cost_local_scale
         self._cost_base_scale_by_key[book_key] = checkpoint.cost_base_scale
         self._cost_local_generation_by_key[book_key] = checkpoint.cost_local_generation

--- a/src/services/portfolio_transaction_processing_service/app/domain/cost_basis/calculation/average_cost_source_allocation.py
+++ b/src/services/portfolio_transaction_processing_service/app/domain/cost_basis/calculation/average_cost_source_allocation.py
@@ -13,6 +13,11 @@ from portfolio_common.domain.transaction.numeric_policy import (
     COST_BASIS_STATE_LEDGER_OUTPUT_V1,
 )
 
+from ..average_cost_allocation_checkpoint import (
+    AverageCostAllocationCheckpoint,
+    AverageCostSourceAccumulator,
+)
+from ..average_cost_pool_checkpoint import AverageCostPoolCheckpoint
 from .lot_state import OpenLotState
 from .residual_allocation import allocate_nonnegative_storage_share
 
@@ -364,6 +369,112 @@ class AverageCostSourceAllocation:
         return tuple(
             (source_transaction_id, self._contributions[source_transaction_id])
             for source_transaction_id in self._active_source_ids_by_key[book_key]
+        )
+
+    def export_checkpoint(
+        self,
+        *,
+        book_key: BookKey,
+        security_id: str,
+        pool: AverageCostPool,
+    ) -> AverageCostAllocationCheckpoint:
+        """Export the exact lazy accumulator needed for deterministic ordered continuation."""
+
+        active_sources = self.active_source_contributions(book_key)
+        representative_source_transaction_id = (
+            active_sources[-1][0] if pool.quantity > Decimal(0) and active_sources else None
+        )
+        pool_checkpoint = AverageCostPoolCheckpoint(
+            portfolio_id=book_key[0],
+            instrument_id=book_key[1],
+            security_id=security_id,
+            representative_source_transaction_id=representative_source_transaction_id,
+            quantity=pool.quantity,
+            cost_local=pool.cost_local,
+            cost_base=pool.cost_base,
+        )
+        is_closed = pool.quantity.is_zero()
+        return AverageCostAllocationCheckpoint(
+            pool=pool_checkpoint,
+            segment_start_quantity=(Decimal(0) if is_closed else pool.segment_start_quantity),
+            segment_start_cost_local=(Decimal(0) if is_closed else pool.segment_start_cost_local),
+            segment_start_cost_base=(Decimal(0) if is_closed else pool.segment_start_cost_base),
+            allocation_generation=self._generation_by_key[book_key],
+            disposal_scale=self._disposal_scale_by_key[book_key],
+            segment_start_scale=self._segment_start_scale_by_key[book_key],
+            cost_local_scale=self._cost_local_scale_by_key[book_key],
+            cost_base_scale=self._cost_base_scale_by_key[book_key],
+            cost_local_generation=self._cost_local_generation_by_key[book_key],
+            cost_base_generation=self._cost_base_generation_by_key[book_key],
+            sources=tuple(
+                AverageCostSourceAccumulator(
+                    source_transaction_id=source_transaction_id,
+                    source_lot_id=contribution.source_lot_id,
+                    source_acquisition_date=contribution.source_acquisition_date,
+                    source_sequence=source_sequence,
+                    generation=contribution.generation,
+                    quantity=contribution.quantity,
+                    cost_local=contribution.cost_local,
+                    cost_base=contribution.cost_base,
+                    disposal_scale_at_entry=contribution.disposal_scale_at_entry,
+                    cost_local_scale_at_entry=contribution.cost_local_scale_at_entry,
+                    cost_base_scale_at_entry=contribution.cost_base_scale_at_entry,
+                    cost_local_generation=contribution.cost_local_generation,
+                    cost_base_generation=contribution.cost_base_generation,
+                )
+                for source_sequence, (source_transaction_id, contribution) in enumerate(
+                    active_sources,
+                    start=1,
+                )
+            ),
+        )
+
+    def restore_checkpoint(
+        self,
+        checkpoint: AverageCostAllocationCheckpoint,
+    ) -> AverageCostPool:
+        """Restore one validated checkpoint into an otherwise empty allocation engine."""
+
+        if self._contributions:
+            raise ValueError("AVCO source-allocation restore requires an empty engine")
+        book_key = (checkpoint.pool.portfolio_id, checkpoint.pool.instrument_id)
+        if book_key in self._source_ids_by_key or book_key in self._active_source_ids_by_key:
+            raise ValueError("AVCO source-allocation checkpoint book already exists")
+
+        source_ids: list[str] = []
+        for source in checkpoint.sources:
+            self._contributions[source.source_transaction_id] = AverageCostSourceContribution(
+                book_key=book_key,
+                source_lot_id=source.source_lot_id,
+                source_acquisition_date=source.source_acquisition_date,
+                generation=source.generation,
+                quantity=source.quantity,
+                cost_local=source.cost_local,
+                cost_base=source.cost_base,
+                disposal_scale_at_entry=source.disposal_scale_at_entry,
+                cost_local_scale_at_entry=source.cost_local_scale_at_entry,
+                cost_base_scale_at_entry=source.cost_base_scale_at_entry,
+                cost_local_generation=source.cost_local_generation,
+                cost_base_generation=source.cost_base_generation,
+            )
+            source_ids.append(source.source_transaction_id)
+        self._source_ids_by_key[book_key] = list(source_ids)
+        self._active_source_ids_by_key[book_key] = list(source_ids)
+        self._generation_by_key[book_key] = checkpoint.allocation_generation
+        self._disposal_scale_by_key[book_key] = checkpoint.disposal_scale
+        self._segment_start_scale_by_key[book_key] = checkpoint.segment_start_scale
+        self._segment_start_quantity_by_key[book_key] = checkpoint.segment_start_quantity
+        self._cost_local_scale_by_key[book_key] = checkpoint.cost_local_scale
+        self._cost_base_scale_by_key[book_key] = checkpoint.cost_base_scale
+        self._cost_local_generation_by_key[book_key] = checkpoint.cost_local_generation
+        self._cost_base_generation_by_key[book_key] = checkpoint.cost_base_generation
+        return AverageCostPool(
+            quantity=checkpoint.pool.quantity,
+            cost_local=checkpoint.pool.cost_local,
+            cost_base=checkpoint.pool.cost_base,
+            segment_start_quantity=checkpoint.segment_start_quantity,
+            segment_start_cost_local=checkpoint.segment_start_cost_local,
+            segment_start_cost_base=checkpoint.segment_start_cost_base,
         )
 
     def _disposal_factor(self, contribution: AverageCostSourceContribution) -> Decimal:

--- a/src/services/portfolio_transaction_processing_service/app/domain/cost_basis/calculation/cost_basis_strategies.py
+++ b/src/services/portfolio_transaction_processing_service/app/domain/cost_basis/calculation/cost_basis_strategies.py
@@ -1,5 +1,7 @@
 """Implement FIFO and average-cost lot allocation strategies."""
 
+from __future__ import annotations
+
 import logging
 from collections import defaultdict, deque
 from dataclasses import dataclass
@@ -12,6 +14,7 @@ from portfolio_common.domain.transaction.numeric_policy import (
     COST_BASIS_STATE_LEDGER_OUTPUT_V1,
 )
 
+from ..average_cost_allocation_checkpoint import AverageCostAllocationCheckpoint
 from ..models.cost_basis_transaction import CostBasisTransaction
 from .average_cost_source_allocation import (
     AverageCostPool,
@@ -566,6 +569,37 @@ class AverageCostBasisStrategy(CostBasisStrategy):
 
     def get_open_lot_states(self) -> dict[str, OpenLotState]:
         return self._source_allocation.materialize(self._pools)
+
+    def export_allocation_checkpoint(
+        self,
+        *,
+        portfolio_id: str,
+        instrument_id: str,
+        security_id: str,
+    ) -> AverageCostAllocationCheckpoint:
+        """Export exact continuation state for one AVCO book."""
+
+        key = (portfolio_id, instrument_id)
+        pool = self._pools.get(key)
+        if pool is None:
+            raise ValueError("Average cost allocation checkpoint book was not found")
+        return self._source_allocation.export_checkpoint(
+            book_key=key,
+            security_id=security_id,
+            pool=pool,
+        )
+
+    @classmethod
+    def from_allocation_checkpoint(
+        cls,
+        checkpoint: AverageCostAllocationCheckpoint,
+    ) -> AverageCostBasisStrategy:
+        """Create an AVCO strategy from validated persisted continuation state."""
+
+        strategy = cls()
+        key = (checkpoint.pool.portfolio_id, checkpoint.pool.instrument_id)
+        strategy._pools[key] = strategy._source_allocation.restore_checkpoint(checkpoint)
+        return strategy
 
 
 def _basis_transfer_error(

--- a/tests/integration/services/portfolio_transaction_processing_service/test_int_average_cost_pool_capacity.py
+++ b/tests/integration/services/portfolio_transaction_processing_service/test_int_average_cost_pool_capacity.py
@@ -47,7 +47,7 @@ pytestmark = [
 ]
 
 
-async def test_ordered_avco_database_work_is_source_count_independent_and_indexed(
+async def test_avco_replay_statement_count_is_bounded_and_lot_read_is_indexed(
     clean_db,
     async_db_session: AsyncSession,
 ) -> None:
@@ -92,9 +92,10 @@ async def test_ordered_avco_database_work_is_source_count_independent_and_indexe
     small_cost_state_statements = _cost_state_statements(small_statements)
     large_cost_state_statements = _cost_state_statements(large_statements)
     assert len(small_statements) == len(large_statements)
-    # The fixed-size state work includes ordered row reads for exact per-source
-    # lineage receipts; its statement count must remain independent of pool size.
-    assert len(small_cost_state_statements) == len(large_cost_state_statements) == 8
+    # Until #481 persists the source-aware checkpoint, AVCO disposal replays canonical
+    # history and writes a complete lot snapshot. SQL statement count stays bounded;
+    # selected and written row volume intentionally scales with the source count.
+    assert len(small_cost_state_statements) == len(large_cost_state_statements) == 3
     assert (
         sum(
             statement.startswith("SELECT position_lot_state.id")
@@ -107,14 +108,14 @@ async def test_ordered_avco_database_work_is_source_count_independent_and_indexe
             statement.startswith("UPDATE position_lot_state")
             for statement in large_cost_state_statements
         )
-        == 3
+        == 1
     )
     assert (
         sum(
             "sum(position_lot_state.open_quantity)" in statement
             for statement in large_cost_state_statements
         )
-        == 1
+        == 0
     )
 
     plan = await async_db_session.scalar(

--- a/tests/unit/services/portfolio_transaction_processing_service/application/cost_basis_processing/test_calculation.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/application/cost_basis_processing/test_calculation.py
@@ -273,14 +273,15 @@ async def test_later_sell_restores_open_lots_without_loading_full_history() -> N
     )
 
 
-async def test_ordered_avco_sell_restores_one_aggregate_pool_source() -> None:
+async def test_avco_sell_rebuilds_full_history_for_source_allocation_truth() -> None:
     repo = AsyncMock(spec=CostBasisTransactionStatePort)
     processing_state = _processing_state_port()
     average_cost_pools = _average_cost_pool_port()
     lot_states = _lot_state_port()
     buy_date = datetime(2026, 1, 1, 10, 0, tzinfo=timezone.utc)
     sell_date = datetime(2026, 1, 2, 10, 0, tzinfo=timezone.utc)
-    prior_buy = _processed_buy("BUY-AVCO-1", buy_date)
+    second_buy_date = datetime(2026, 1, 1, 11, 0, tzinfo=timezone.utc)
+    prior_buy = _processed_buy("BUY-AVCO-2", second_buy_date)
     processing_state.get_cost_basis_processing_checkpoint.return_value = (
         CostBasisProcessingCheckpoint.from_transaction(
             prior_buy, cost_basis_method=CostBasisMethod.AVCO
@@ -292,14 +293,20 @@ async def test_ordered_avco_sell_restores_one_aggregate_pool_source() -> None:
                 portfolio_id="P1",
                 instrument_id="I1",
                 security_id="S1",
-                representative_source_transaction_id="BUY-AVCO-1",
-                quantity=Decimal("10"),
-                cost_local=Decimal("100"),
-                cost_base=Decimal("100"),
+                representative_source_transaction_id="BUY-AVCO-2",
+                quantity=Decimal("20"),
+                cost_local=Decimal("200"),
+                cost_base=Decimal("200"),
             ),
-            representative_transaction=_history_transaction(_persisted_buy("BUY-AVCO-1", buy_date)),
+            representative_transaction=_history_transaction(
+                _persisted_buy("BUY-AVCO-2", second_buy_date)
+            ),
         )
     )
+    repo.get_transaction_history.return_value = [
+        _history_transaction(_persisted_buy("BUY-AVCO-1", buy_date)),
+        _history_transaction(_persisted_buy("BUY-AVCO-2", second_buy_date)),
+    ]
     sell_event, sell_type, method = _prepare_event(
         _event(
             transaction_id="SELL-AVCO-1",
@@ -323,19 +330,23 @@ async def test_ordered_avco_sell_restores_one_aggregate_pool_source() -> None:
         cost_basis_method=method,
     )
 
-    assert calculation.incremental is True
+    assert calculation.incremental is False
     assert calculation.errored == []
-    assert calculation.open_lot_persistence_scope is OpenLotPersistenceScope.AVERAGE_COST_POOL
-    assert calculation.average_cost_pool_transition is not None
-    assert calculation.average_cost_pool_transition.existing_sources_after.quantity == Decimal("6")
-    assert calculation.average_cost_pool_transition.existing_sources_after.cost_base == Decimal(
-        "60"
-    )
-    assert calculation.average_cost_pool_transition.explicit_sources_after == {}
-    average_cost_pools.get_average_cost_pool_checkpoint_record.assert_awaited_once_with(
+    assert calculation.open_lot_persistence_scope is OpenLotPersistenceScope.COMPLETE_SNAPSHOT
+    assert calculation.average_cost_pool_transition is None
+    assert [
+        allocation.source_transaction_id
+        for allocation in calculation.disposals[0].result.allocations
+    ] == ["BUY-AVCO-1", "BUY-AVCO-2"]
+    assert calculation.disposals[0].result.consumed_quantity == Decimal("4")
+    assert calculation.open_lot_states["BUY-AVCO-1"].quantity == Decimal("8")
+    assert calculation.open_lot_states["BUY-AVCO-2"].quantity == Decimal("8")
+    repo.get_transaction_history.assert_awaited_once_with(
         portfolio_id="P1",
         security_id="S1",
+        exclude_id="SELL-AVCO-1",
     )
+    average_cost_pools.get_average_cost_pool_checkpoint_record.assert_not_awaited()
     lot_states.get_open_lot_checkpoint_records.assert_not_awaited()
     lot_states.get_fifo_disposal_lot_checkpoint_records.assert_not_awaited()
 

--- a/tests/unit/services/portfolio_transaction_processing_service/application/cost_basis_processing/test_timeline.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/application/cost_basis_processing/test_timeline.py
@@ -147,12 +147,13 @@ def test_cost_basis_timeline_processor_handles_backdated_insert(
 
     # ACT
     # The engine processes the full list and is responsible for sorting and calculating
-    processed_txns, errored_txns, open_lot_states = (
-        cost_basis_timeline_processor.process_transactions(
-            existing_transactions_raw=[],  # Simulating a full recalculation call
-            new_transactions_raw=all_transactions_raw,
-        )
+    result = cost_basis_timeline_processor.process_transactions(
+        existing_transactions_raw=[],  # Simulating a full recalculation call
+        new_transactions_raw=all_transactions_raw,
     )
+    processed_txns = result.processed
+    errored_txns = result.errored
+    open_lot_states = result.open_lot_states
 
     # ASSERT
     assert not errored_txns
@@ -183,6 +184,11 @@ def test_cost_basis_timeline_processor_handles_backdated_insert(
             cost_base=Decimal("800"),
         ),
     }
+    assert [disposal.disposal_transaction_id for disposal in result.disposals] == ["SELL_1"]
+    assert [
+        allocation.source_transaction_id for allocation in result.disposals[0].result.allocations
+    ] == ["BUY_1"]
+    assert result.disposals[0].result.consumed_quantity == Decimal("50")
 
 
 @pytest.mark.parametrize("cost_basis_method", ["FIFO", "AVCO"])
@@ -195,14 +201,14 @@ def test_increment_from_open_lot_checkpoint_matches_full_history(
         _raw_transaction("SELL-1", "2026-01-03T10:00:00+00:00", "SELL", "5", "75"),
     ]
     appended_sell = _raw_transaction("SELL-2", "2026-01-04T10:00:00+00:00", "SELL", "10", "160")
-    prefix_processed, prefix_errors, prefix_states = build_cost_basis_timeline_processor(
-        cost_basis_method
-    ).process_transactions([], prefix)
-    assert prefix_errors == []
+    prefix_result = build_cost_basis_timeline_processor(cost_basis_method).process_transactions(
+        [], prefix
+    )
+    assert prefix_result.errored == []
 
     source_by_id = {row["transaction_id"]: row for row in prefix}
     checkpoint = []
-    for source_transaction_id, state in prefix_states.items():
+    for source_transaction_id, state in prefix_result.open_lot_states.items():
         source = dict(source_by_id[source_transaction_id])
         source["quantity"] = state.quantity
         source["gross_transaction_amount"] = state.cost_local
@@ -210,41 +216,57 @@ def test_increment_from_open_lot_checkpoint_matches_full_history(
         source["net_cost"] = state.cost_base
         checkpoint.append(source)
 
-    incremental_processed, incremental_errors, incremental_states = (
-        build_cost_basis_timeline_processor(cost_basis_method).process_increment(
-            initial_open_lots_raw=list(reversed(checkpoint)),
-            new_transactions_raw=[appended_sell],
-        )
+    incremental_result = build_cost_basis_timeline_processor(cost_basis_method).process_increment(
+        initial_open_lots_raw=list(reversed(checkpoint)),
+        new_transactions_raw=[appended_sell],
     )
-    full_processed, full_errors, full_states = build_cost_basis_timeline_processor(
-        cost_basis_method
-    ).process_transactions([], [*prefix, appended_sell])
+    full_result = build_cost_basis_timeline_processor(cost_basis_method).process_transactions(
+        [], [*prefix, appended_sell]
+    )
 
-    assert incremental_errors == full_errors == []
-    assert [transaction.transaction_id for transaction in incremental_processed] == ["SELL-2"]
+    assert incremental_result.errored == full_result.errored == []
+    assert [transaction.transaction_id for transaction in incremental_result.processed] == [
+        "SELL-2"
+    ]
     full_sell = next(
-        transaction for transaction in full_processed if transaction.transaction_id == "SELL-2"
+        transaction
+        for transaction in full_result.processed
+        if transaction.transaction_id == "SELL-2"
     )
-    incremental_sell = incremental_processed[0]
+    incremental_sell = incremental_result.processed[0]
     assert incremental_sell.net_cost_local == full_sell.net_cost_local
     assert incremental_sell.net_cost == full_sell.net_cost
     assert incremental_sell.realized_gain_loss_local == full_sell.realized_gain_loss_local
     assert incremental_sell.realized_gain_loss == full_sell.realized_gain_loss
-    assert sum((state.quantity for state in incremental_states.values()), Decimal(0)) == sum(
-        (state.quantity for state in full_states.values()), Decimal(0)
+    full_disposals = tuple(
+        disposal
+        for disposal in full_result.disposals
+        if disposal.disposal_transaction_id == "SELL-2"
     )
-    assert sum((state.cost_local for state in incremental_states.values()), Decimal(0)) == sum(
-        (state.cost_local for state in full_states.values()), Decimal(0)
+    assert [
+        allocation.source_transaction_id
+        for allocation in incremental_result.disposals[0].result.allocations
+    ] == [allocation.source_transaction_id for allocation in full_disposals[0].result.allocations]
+    assert incremental_result.disposals[0].result.consumed_quantity == (
+        full_disposals[0].result.consumed_quantity
     )
-    assert sum((state.cost_base for state in incremental_states.values()), Decimal(0)) == sum(
-        (state.cost_base for state in full_states.values()), Decimal(0)
-    )
-    for source_transaction_id, full_state in full_states.items():
-        incremental_state = incremental_states[source_transaction_id]
+    assert incremental_result.disposals[0].result.cost_local == full_disposals[0].result.cost_local
+    assert incremental_result.disposals[0].result.cost_base == full_disposals[0].result.cost_base
+    assert sum(
+        (state.quantity for state in incremental_result.open_lot_states.values()), Decimal(0)
+    ) == sum((state.quantity for state in full_result.open_lot_states.values()), Decimal(0))
+    assert sum(
+        (state.cost_local for state in incremental_result.open_lot_states.values()), Decimal(0)
+    ) == sum((state.cost_local for state in full_result.open_lot_states.values()), Decimal(0))
+    assert sum(
+        (state.cost_base for state in incremental_result.open_lot_states.values()), Decimal(0)
+    ) == sum((state.cost_base for state in full_result.open_lot_states.values()), Decimal(0))
+    for source_transaction_id, full_state in full_result.open_lot_states.items():
+        incremental_state = incremental_result.open_lot_states[source_transaction_id]
         assert abs(incremental_state.quantity - full_state.quantity) <= Decimal("0.0000000001")
         assert incremental_state.cost_local == full_state.cost_local
         assert incremental_state.cost_base == full_state.cost_base
-    assert len(prefix_processed) == 3
+    assert len(prefix_result.processed) == 3
 
 
 def test_increment_preserves_original_quantity_tiebreak_for_partially_consumed_lots() -> None:
@@ -263,15 +285,17 @@ def test_increment_preserves_original_quantity_tiebreak_for_partially_consumed_l
     }
     sell = _raw_transaction("SELL-1", "2026-01-02T10:00:00+00:00", "SELL", "1", "30")
 
-    processed, errors, states = build_cost_basis_timeline_processor("FIFO").process_increment(
+    result = build_cost_basis_timeline_processor("FIFO").process_increment(
         initial_open_lots_raw=[smaller_original_lot, larger_original_lot],
         new_transactions_raw=[sell],
     )
 
-    assert errors == []
-    assert processed[0].realized_gain_loss == Decimal("20")
-    assert states["BUY-LARGE"].quantity == Decimal(0)
-    assert states["BUY-SMALL"].quantity == Decimal("5")
+    assert result.errored == []
+    assert result.processed[0].realized_gain_loss == Decimal("20")
+    assert result.open_lot_states["BUY-LARGE"].quantity == Decimal(0)
+    assert result.open_lot_states["BUY-SMALL"].quantity == Decimal("5")
+    assert result.disposals[0].disposal_transaction_id == "SELL-1"
+    assert result.disposals[0].result.allocations[0].source_transaction_id == "BUY-LARGE"
 
 
 def test_cost_basis_timeline_processor_records_observation_depth() -> None:
@@ -350,6 +374,13 @@ def test_cost_basis_timeline_processor_reports_unexpected_calculator_errors():
                 raise RuntimeError("calculation failed")
 
     class _DispositionEngine:
+        def clear_disposal_records(self):
+            return None
+
+        def disposal_records(self, *, transaction_ids=None):
+            del transaction_ids
+            return ()
+
         def get_open_lot_states(self):
             return {
                 "NEW_OK": OpenLotState(
@@ -368,7 +399,7 @@ def test_cost_basis_timeline_processor_reports_unexpected_calculator_errors():
         error_reporter=error_reporter,
     )
 
-    processed_txns, errored_txns, open_lot_states = processor.process_transactions(
+    result = processor.process_transactions(
         existing_transactions_raw=[{"transaction_id": "EXISTING_OK"}],
         new_transactions_raw=[
             {"transaction_id": "NEW_OK"},
@@ -376,14 +407,15 @@ def test_cost_basis_timeline_processor_reports_unexpected_calculator_errors():
         ],
     )
 
-    assert [txn.transaction_id for txn in processed_txns] == ["NEW_OK"]
-    assert [(txn.transaction_id, txn.error_reason) for txn in errored_txns] == [
+    assert [txn.transaction_id for txn in result.processed] == ["NEW_OK"]
+    assert [(txn.transaction_id, txn.error_reason) for txn in result.errored] == [
         ("NEW_FAIL", "Unexpected error: calculation failed")
     ]
-    assert open_lot_states == {
+    assert result.open_lot_states == {
         "NEW_OK": OpenLotState(
             quantity=Decimal("1"),
             cost_local=Decimal("10"),
             cost_base=Decimal("10"),
         )
     }
+    assert result.disposals == ()

--- a/tests/unit/services/portfolio_transaction_processing_service/cost/test_avco_private_banking_scenario_matrix.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/cost/test_avco_private_banking_scenario_matrix.py
@@ -89,7 +89,10 @@ def _seed_buy() -> dict[str, str]:
 
 
 def _process(*transactions: dict[str, str]):
-    return build_cost_basis_timeline_processor("AVCO").process_transactions([], list(transactions))
+    result = build_cost_basis_timeline_processor("AVCO").process_transactions(
+        [], list(transactions)
+    )
+    return result.processed, result.errored, result.open_lot_states
 
 
 def _source_values(states):

--- a/tests/unit/services/portfolio_transaction_processing_service/domain/cost_basis/calculation/test_cost_basis_strategies.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/domain/cost_basis/calculation/test_cost_basis_strategies.py
@@ -565,6 +565,82 @@ def test_average_cost_source_allocation_is_independent_of_sell_batching() -> Non
     )
 
 
+def test_average_cost_checkpoint_restore_preserves_exact_disposal_receipts() -> None:
+    uninterrupted = AverageCostBasisStrategy()
+    for index, (quantity, cost) in enumerate((("10", "100"), ("20", "240")), start=1):
+        uninterrupted.add_buy_lot(
+            CostBasisTransaction(
+                transaction_id=f"AVCO-CHECKPOINT-BUY-{index}",
+                portfolio_id="P1",
+                instrument_id="I1",
+                security_id="S1",
+                transaction_type="BUY",
+                transaction_date=datetime(2026, 1, index),
+                quantity=Decimal(quantity),
+                gross_transaction_amount=Decimal(cost),
+                net_cost=Decimal(cost),
+                net_cost_local=Decimal(cost),
+                trade_currency="USD",
+                portfolio_base_currency="USD",
+            )
+        )
+    uninterrupted.consume_sell_quantity_with_allocations("P1", "I1", Decimal("5"))
+    checkpoint = uninterrupted.export_allocation_checkpoint(
+        portfolio_id="P1",
+        instrument_id="I1",
+        security_id="S1",
+    )
+    restored = AverageCostBasisStrategy.from_allocation_checkpoint(checkpoint)
+
+    uninterrupted_result = uninterrupted.consume_sell_quantity_with_allocations(
+        "P1", "I1", Decimal("10")
+    )
+    restored_result = restored.consume_sell_quantity_with_allocations("P1", "I1", Decimal("10"))
+
+    assert restored_result == uninterrupted_result
+    assert restored.get_open_lot_states() == uninterrupted.get_open_lot_states()
+
+
+def test_average_cost_closed_generation_checkpoint_restores_without_stale_sources() -> None:
+    uninterrupted = AverageCostBasisStrategy()
+    uninterrupted.add_buy_lot(
+        CostBasisTransaction(
+            transaction_id="AVCO-CHECKPOINT-CLOSED-BUY",
+            portfolio_id="P1",
+            instrument_id="I1",
+            security_id="S1",
+            transaction_type="BUY",
+            transaction_date=datetime(2026, 1, 1),
+            quantity=Decimal("10"),
+            gross_transaction_amount=Decimal("100"),
+            net_cost=Decimal("100"),
+            net_cost_local=Decimal("100"),
+            trade_currency="USD",
+            portfolio_base_currency="USD",
+        )
+    )
+    uninterrupted.consume_sell_quantity_with_allocations("P1", "I1", Decimal("10"))
+    checkpoint = uninterrupted.export_allocation_checkpoint(
+        portfolio_id="P1",
+        instrument_id="I1",
+        security_id="S1",
+    )
+
+    restored = AverageCostBasisStrategy.from_allocation_checkpoint(checkpoint)
+
+    assert checkpoint.sources == ()
+    assert restored.get_open_lot_states() == {}
+
+
+def test_average_cost_checkpoint_export_requires_existing_book() -> None:
+    with pytest.raises(ValueError, match="checkpoint book was not found"):
+        AverageCostBasisStrategy().export_allocation_checkpoint(
+            portfolio_id="P1",
+            instrument_id="I1",
+            security_id="S1",
+        )
+
+
 def test_average_cost_full_close_and_reopen_does_not_resurrect_prior_sources() -> None:
     strategy = AverageCostBasisStrategy()
     closed_source = CostBasisTransaction(

--- a/tests/unit/services/portfolio_transaction_processing_service/domain/cost_basis/calculation/test_cost_basis_strategies.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/domain/cost_basis/calculation/test_cost_basis_strategies.py
@@ -602,6 +602,49 @@ def test_average_cost_checkpoint_restore_preserves_exact_disposal_receipts() -> 
     assert restored.get_open_lot_states() == uninterrupted.get_open_lot_states()
 
 
+def test_average_cost_checkpoint_accepts_repeating_scale_followed_by_buy() -> None:
+    uninterrupted = AverageCostBasisStrategy()
+    first_buy = CostBasisTransaction(
+        transaction_id="AVCO-REPEATING-SCALE-BUY-1",
+        portfolio_id="P1",
+        instrument_id="I1",
+        security_id="S1",
+        transaction_type="BUY",
+        transaction_date=datetime(2026, 1, 1),
+        quantity=Decimal("3"),
+        gross_transaction_amount=Decimal("30"),
+        net_cost=Decimal("30"),
+        net_cost_local=Decimal("30"),
+        trade_currency="USD",
+        portfolio_base_currency="USD",
+    )
+    uninterrupted.add_buy_lot(first_buy)
+    uninterrupted.consume_sell_quantity_with_allocations("P1", "I1", Decimal("1"))
+    uninterrupted.add_buy_lot(
+        first_buy.model_copy(
+            update={
+                "transaction_id": "AVCO-REPEATING-SCALE-BUY-2",
+                "transaction_date": datetime(2026, 1, 2),
+            }
+        )
+    )
+
+    checkpoint = uninterrupted.export_allocation_checkpoint(
+        portfolio_id="P1",
+        instrument_id="I1",
+        security_id="S1",
+    )
+    restored = AverageCostBasisStrategy.from_allocation_checkpoint(checkpoint)
+
+    uninterrupted_result = uninterrupted.consume_sell_quantity_with_allocations(
+        "P1", "I1", Decimal("1")
+    )
+    restored_result = restored.consume_sell_quantity_with_allocations("P1", "I1", Decimal("1"))
+
+    assert restored_result == uninterrupted_result
+    assert restored.get_open_lot_states() == uninterrupted.get_open_lot_states()
+
+
 def test_average_cost_closed_generation_checkpoint_restores_without_stale_sources() -> None:
     uninterrupted = AverageCostBasisStrategy()
     uninterrupted.add_buy_lot(

--- a/tests/unit/services/portfolio_transaction_processing_service/domain/cost_basis/calculation/test_cost_basis_strategies.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/domain/cost_basis/calculation/test_cost_basis_strategies.py
@@ -585,6 +585,7 @@ def test_average_cost_checkpoint_restore_preserves_exact_disposal_receipts() -> 
             )
         )
     uninterrupted.consume_sell_quantity_with_allocations("P1", "I1", Decimal("5"))
+    assert uninterrupted.transfer_basis_out("P1", "I1", Decimal("40"), Decimal("40")) is None
     checkpoint = uninterrupted.export_allocation_checkpoint(
         portfolio_id="P1",
         instrument_id="I1",
@@ -1060,6 +1061,23 @@ def test_average_cost_full_basis_transfer_then_new_buy_keeps_old_source_cost_zer
         cost_local=Decimal("300"),
         cost_base=Decimal("300"),
     )
+
+    checkpoint = strategy.export_allocation_checkpoint(
+        portfolio_id="P-BASIS",
+        instrument_id="PARENT-SECURITY",
+        security_id="PARENT-SECURITY",
+    )
+    restored = AverageCostBasisStrategy.from_allocation_checkpoint(checkpoint)
+
+    uninterrupted_result = strategy.consume_sell_quantity_with_allocations(
+        "P-BASIS", "PARENT-SECURITY", Decimal("10")
+    )
+    restored_result = restored.consume_sell_quantity_with_allocations(
+        "P-BASIS", "PARENT-SECURITY", Decimal("10")
+    )
+
+    assert restored_result == uninterrupted_result
+    assert restored.get_open_lot_states() == strategy.get_open_lot_states()
 
 
 @pytest.mark.parametrize("strategy_type", [FIFOBasisStrategy, AverageCostBasisStrategy])

--- a/tests/unit/services/portfolio_transaction_processing_service/domain/cost_basis/test_average_cost_allocation_checkpoint.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/domain/cost_basis/test_average_cost_allocation_checkpoint.py
@@ -1,0 +1,193 @@
+"""Prove the persisted AVCO source-allocation checkpoint contract."""
+
+from collections.abc import Callable
+from dataclasses import replace
+from datetime import date, datetime
+from decimal import Decimal
+
+import pytest
+
+from src.services.portfolio_transaction_processing_service.app.domain.cost_basis import (
+    AVERAGE_COST_ALLOCATION_STATE_VERSION,
+    AverageCostAllocationCheckpoint,
+    AverageCostPoolCheckpoint,
+    AverageCostSourceAccumulator,
+)
+
+
+def _source(
+    source_transaction_id: str = "BUY-1",
+    *,
+    source_sequence: int = 1,
+) -> AverageCostSourceAccumulator:
+    return AverageCostSourceAccumulator(
+        source_transaction_id=source_transaction_id,
+        source_lot_id=f"LOT-{source_transaction_id}",
+        source_acquisition_date=date(2026, 1, source_sequence),
+        source_sequence=source_sequence,
+        generation=2,
+        quantity=Decimal("10"),
+        cost_local=Decimal("98"),
+        cost_base=Decimal("100"),
+        disposal_scale_at_entry=Decimal("0.875"),
+        cost_local_scale_at_entry=Decimal("1"),
+        cost_base_scale_at_entry=Decimal("1"),
+        cost_local_generation=1,
+        cost_base_generation=1,
+    )
+
+
+def _open_checkpoint() -> AverageCostAllocationCheckpoint:
+    return AverageCostAllocationCheckpoint(
+        pool=AverageCostPoolCheckpoint(
+            portfolio_id="P1",
+            instrument_id="I1",
+            security_id="S1",
+            representative_source_transaction_id="BUY-2",
+            quantity=Decimal("20"),
+            cost_local=Decimal("196"),
+            cost_base=Decimal("200"),
+        ),
+        segment_start_quantity=Decimal("24"),
+        segment_start_cost_local=Decimal("235.2"),
+        segment_start_cost_base=Decimal("240"),
+        allocation_generation=2,
+        disposal_scale=Decimal("0.75"),
+        segment_start_scale=Decimal("0.9"),
+        cost_local_scale=Decimal("1"),
+        cost_base_scale=Decimal("1"),
+        cost_local_generation=1,
+        cost_base_generation=1,
+        sources=(
+            _source(),
+            _source("BUY-2", source_sequence=2),
+        ),
+    )
+
+
+def test_open_checkpoint_binds_pool_and_ordered_active_sources() -> None:
+    checkpoint = _open_checkpoint()
+
+    assert checkpoint.state_version == AVERAGE_COST_ALLOCATION_STATE_VERSION
+    assert [source.source_transaction_id for source in checkpoint.sources] == ["BUY-1", "BUY-2"]
+    assert checkpoint.pool.representative_source_transaction_id == "BUY-2"
+
+
+def test_closed_checkpoint_requires_zero_segment_and_no_sources() -> None:
+    checkpoint = AverageCostAllocationCheckpoint(
+        pool=AverageCostPoolCheckpoint(
+            portfolio_id="P1",
+            instrument_id="I1",
+            security_id="S1",
+            representative_source_transaction_id=None,
+            quantity=Decimal(0),
+            cost_local=Decimal(0),
+            cost_base=Decimal(0),
+        ),
+        segment_start_quantity=Decimal(0),
+        segment_start_cost_local=Decimal(0),
+        segment_start_cost_base=Decimal(0),
+        allocation_generation=3,
+        disposal_scale=Decimal(1),
+        segment_start_scale=Decimal(1),
+        cost_local_scale=Decimal(1),
+        cost_base_scale=Decimal(1),
+        cost_local_generation=2,
+        cost_base_generation=2,
+        sources=(),
+    )
+
+    assert checkpoint.sources == ()
+
+
+@pytest.mark.parametrize(
+    "mutator, expected",
+    [
+        (lambda value: replace(value, sources=()), "requires active source"),
+        (
+            lambda value: replace(value, sources=(value.sources[0], value.sources[0])),
+            "identities must be unique",
+        ),
+        (
+            lambda value: replace(
+                value,
+                sources=(value.sources[0], replace(value.sources[1], source_sequence=3)),
+            ),
+            "sequences must be contiguous",
+        ),
+        (
+            lambda value: replace(
+                value,
+                sources=(replace(value.sources[0], generation=1), value.sources[1]),
+            ),
+            "match the allocation generation",
+        ),
+        (
+            lambda value: replace(
+                value,
+                sources=(
+                    replace(value.sources[0], cost_local_generation=0),
+                    value.sources[1],
+                ),
+            ),
+            "match the cost generations",
+        ),
+        (
+            lambda value: replace(
+                value,
+                pool=replace(value.pool, representative_source_transaction_id="BUY-3"),
+            ),
+            "representative source is absent",
+        ),
+    ],
+)
+def test_checkpoint_rejects_incomplete_or_conflicting_source_state(
+    mutator: Callable[[AverageCostAllocationCheckpoint], AverageCostAllocationCheckpoint],
+    expected: str,
+) -> None:
+    with pytest.raises(ValueError, match=expected):
+        mutator(_open_checkpoint())
+
+
+@pytest.mark.parametrize(
+    "field_name, value, error",
+    [
+        ("source_transaction_id", " ", "must be nonblank"),
+        ("source_lot_id", 1, "must be a string"),
+        ("source_acquisition_date", datetime(2026, 1, 1), "must be a date"),
+        ("source_sequence", True, "must be an integer"),
+        ("generation", -1, "must be nonnegative"),
+        ("quantity", Decimal(0), "must be positive"),
+        ("cost_local", Decimal("NaN"), "must be finite"),
+        ("disposal_scale_at_entry", Decimal(0), "must be positive"),
+    ],
+)
+def test_source_accumulator_rejects_malformed_identity_and_numeric_state(
+    field_name: str,
+    value: object,
+    error: str,
+) -> None:
+    with pytest.raises((TypeError, ValueError), match=error):
+        replace(_source(), **{field_name: value})
+
+
+def test_checkpoint_rejects_active_sources_after_pool_close() -> None:
+    open_checkpoint = _open_checkpoint()
+    closed_pool = AverageCostPoolCheckpoint(
+        portfolio_id="P1",
+        instrument_id="I1",
+        security_id="S1",
+        representative_source_transaction_id=None,
+        quantity=Decimal(0),
+        cost_local=Decimal(0),
+        cost_base=Decimal(0),
+    )
+
+    with pytest.raises(ValueError, match="cannot retain active sources"):
+        replace(
+            open_checkpoint,
+            pool=closed_pool,
+            segment_start_quantity=Decimal(0),
+            segment_start_cost_local=Decimal(0),
+            segment_start_cost_base=Decimal(0),
+        )

--- a/tests/unit/services/portfolio_transaction_processing_service/domain/cost_basis/test_average_cost_allocation_checkpoint.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/domain/cost_basis/test_average_cost_allocation_checkpoint.py
@@ -51,6 +51,7 @@ def _open_checkpoint() -> AverageCostAllocationCheckpoint:
         segment_start_quantity=Decimal("24"),
         segment_start_cost_local=Decimal("235.2"),
         segment_start_cost_base=Decimal("240"),
+        source_allocation_segment_start_quantity=Decimal("24"),
         allocation_generation=2,
         disposal_scale=Decimal("0.75"),
         segment_start_scale=Decimal("0.9"),
@@ -73,6 +74,25 @@ def test_open_checkpoint_binds_pool_and_ordered_active_sources() -> None:
     assert checkpoint.pool.representative_source_transaction_id == "BUY-2"
 
 
+def test_open_checkpoint_allows_quantity_sources_from_prior_cost_generation() -> None:
+    checkpoint = _open_checkpoint()
+
+    restored = replace(
+        checkpoint,
+        sources=(
+            replace(
+                checkpoint.sources[0],
+                cost_local_generation=0,
+                cost_base_generation=0,
+            ),
+            checkpoint.sources[1],
+        ),
+    )
+
+    assert restored.sources[0].cost_local_generation == 0
+    assert restored.sources[0].cost_base_generation == 0
+
+
 def test_closed_checkpoint_requires_zero_segment_and_no_sources() -> None:
     checkpoint = AverageCostAllocationCheckpoint(
         pool=AverageCostPoolCheckpoint(
@@ -87,6 +107,7 @@ def test_closed_checkpoint_requires_zero_segment_and_no_sources() -> None:
         segment_start_quantity=Decimal(0),
         segment_start_cost_local=Decimal(0),
         segment_start_cost_base=Decimal(0),
+        source_allocation_segment_start_quantity=Decimal(0),
         allocation_generation=3,
         disposal_scale=Decimal(1),
         segment_start_scale=Decimal(1),
@@ -126,11 +147,11 @@ def test_closed_checkpoint_requires_zero_segment_and_no_sources() -> None:
             lambda value: replace(
                 value,
                 sources=(
-                    replace(value.sources[0], cost_local_generation=0),
+                    replace(value.sources[0], cost_local_generation=2),
                     value.sources[1],
                 ),
             ),
-            "match the cost generations",
+            "generation cannot be in the future",
         ),
         (
             lambda value: replace(

--- a/tests/unit/services/portfolio_transaction_processing_service/domain/cost_basis/test_average_cost_allocation_checkpoint.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/domain/cost_basis/test_average_cost_allocation_checkpoint.py
@@ -29,7 +29,7 @@ def _source(
         quantity=Decimal("10"),
         cost_local=Decimal("98"),
         cost_base=Decimal("100"),
-        disposal_scale_at_entry=Decimal("0.875"),
+        disposal_scale_at_entry=Decimal("0.75"),
         cost_local_scale_at_entry=Decimal("1"),
         cost_base_scale_at_entry=Decimal("1"),
         cost_local_generation=1,
@@ -79,6 +79,11 @@ def test_open_checkpoint_allows_quantity_sources_from_prior_cost_generation() ->
 
     restored = replace(
         checkpoint,
+        pool=replace(
+            checkpoint.pool,
+            cost_local=Decimal("98"),
+            cost_base=Decimal("100"),
+        ),
         sources=(
             replace(
                 checkpoint.sources[0],
@@ -91,6 +96,26 @@ def test_open_checkpoint_allows_quantity_sources_from_prior_cost_generation() ->
 
     assert restored.sources[0].cost_local_generation == 0
     assert restored.sources[0].cost_base_generation == 0
+
+
+def test_open_checkpoint_rejects_disposal_scale_inconsistent_with_source_segment() -> None:
+    checkpoint = _open_checkpoint()
+
+    with pytest.raises(ValueError, match="disposal scale conflicts"):
+        replace(checkpoint, disposal_scale=checkpoint.disposal_scale * Decimal(2))
+
+
+def test_open_checkpoint_rejects_source_cost_inconsistent_with_pool() -> None:
+    checkpoint = _open_checkpoint()
+
+    with pytest.raises(ValueError, match="accumulators conflict"):
+        replace(
+            checkpoint,
+            sources=(
+                replace(checkpoint.sources[0], cost_base=Decimal("101")),
+                checkpoint.sources[1],
+            ),
+        )
 
 
 def test_closed_checkpoint_requires_zero_segment_and_no_sources() -> None:

--- a/tests/unit/services/portfolio_transaction_processing_service/domain/cost_basis/test_average_cost_allocation_checkpoint.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/domain/cost_basis/test_average_cost_allocation_checkpoint.py
@@ -84,6 +84,9 @@ def test_open_checkpoint_allows_quantity_sources_from_prior_cost_generation() ->
             cost_local=Decimal("98"),
             cost_base=Decimal("100"),
         ),
+        segment_start_quantity=Decimal("20"),
+        segment_start_cost_local=Decimal("98"),
+        segment_start_cost_base=Decimal("100"),
         sources=(
             replace(
                 checkpoint.sources[0],
@@ -115,6 +118,17 @@ def test_open_checkpoint_rejects_source_cost_inconsistent_with_pool() -> None:
                 replace(checkpoint.sources[0], cost_base=Decimal("101")),
                 checkpoint.sources[1],
             ),
+        )
+
+
+def test_open_checkpoint_rejects_pool_cost_inconsistent_with_disposal_segment() -> None:
+    checkpoint = _open_checkpoint()
+
+    with pytest.raises(ValueError, match="pool costs conflict"):
+        replace(
+            checkpoint,
+            segment_start_cost_local=Decimal("90"),
+            segment_start_cost_base=Decimal("90"),
         )
 
 


### PR DESCRIPTION
## Objective

Deliver the bounded #481 correctness increment needed before immutable lot-disposal receipts can be persisted: transport accepted disposal evidence, prevent aggregate-only AVCO source attribution, and define/restore a source-aware, fail-closed AVCO continuation checkpoint.

## Measurable improvement

- Timeline and coordinator results retain accepted immutable disposal evidence through typed contracts.
- AVCO disposal fails safe by replaying canonical history while only aggregate persisted state exists.
- The versioned checkpoint retains original source/lot/date identities, independent pool/source segment state, and exact lazy allocation/cost scales.
- Restarted processing produces the same next disposal receipt and remaining source states as uninterrupted processing across partial disposal, basis transfer, full basis transfer, and repeating-scale histories.
- Malformed source scales/costs and pool disposal-segment state fail closed before restore.
- Closed books restore without stale sources or historical segment state.
- Capacity profilers consume the typed result; no tuple compatibility shim remains.

## Compatibility

Internal additive/refactoring change only. Existing transaction behavior and aggregate outputs remain stable. No schema, public API/OpenAPI, Kafka, migration, supported-feature, runtime-topology, authored docs/context, or wiki-source change. #481 remains open because checkpoint/receipt persistence, UoW atomicity, query/recovery, lifecycle integration, and bounded-row-volume proof are not in this PR.

The temporary full-replay AVCO posture keeps SQL statement count bounded but row volume scales with canonical history. This is explicitly represented by the integration capacity contract and remains owned by #481.

## Validation

- Exact-head repository-native `make check`: passed, including two complete unit passes of 6,774 passed / 12 deselected and zero warnings.
- 251 warning-strict cost-basis domain tests passed.
- Targeted AVCO database capacity regression passed in isolated ephemeral runtime: 1 passed in 59.33s.
- Full MyPy: 268 source files passed.
- Ruff, architecture/contracts/security guards, calculated-output policy guard, and `git diff --check` passed.
- Five actionable PR review findings were fixed forward with regression proof; all review threads are resolved.
- Protected Feature Lane and PR Merge Gate run on exact head `15579d22a`; merge waits for every required check.

Refs #481