### PR TITLE
test(migrations): preserve amortized rollback order

### DIFF
--- a/tests/integration/test_lot_amortized_cost_profile_migration.py
+++ b/tests/integration/test_lot_amortized_cost_profile_migration.py
@@ -32,6 +32,18 @@ HEAD_MIGRATION = (
     / "versions"
     / "c141b2c3d50e_feat_add_lot_disposal_receipts.py"
 )
+DISPOSAL_EVIDENCE_MIGRATION = (
+    Path(__file__).resolve().parents[2]
+    / "alembic"
+    / "versions"
+    / "c142b2c3d50f_feat_add_amortized_disposal_evidence.py"
+)
+RESIDUAL_CARRY_MIGRATION = (
+    Path(__file__).resolve().parents[2]
+    / "alembic"
+    / "versions"
+    / "c143b2c3d510_fix_conserve_amortized_cost_residual.py"
+)
 
 PROFILE_INSERT = text(
     """
@@ -155,11 +167,18 @@ def _downgrade_later_revisions(connection) -> list[dict[str, Any]]:
     """Remove dependent revisions newest-first before exercising the profile schema."""
 
     later_migrations: list[dict[str, Any]] = []
-    for table_name, migration_path in (
-        ("lot_disposal_receipts", HEAD_MIGRATION),
-        ("lot_amortized_cost_authority", LATER_MIGRATION),
+    for table_name, marker_column, migration_path in (
+        ("position_lot_state", "amortized_cost_profile_id", RESIDUAL_CARRY_MIGRATION),
+        ("lot_disposal_allocations", "amortized_cost_profile_id", DISPOSAL_EVIDENCE_MIGRATION),
+        ("lot_disposal_receipts", None, HEAD_MIGRATION),
+        ("lot_amortized_cost_authority", None, LATER_MIGRATION),
     ):
-        if not inspect(connection).has_table(table_name):
+        inspector = inspect(connection)
+        if not inspector.has_table(table_name):
+            continue
+        if marker_column is not None and marker_column not in {
+            column["name"] for column in inspector.get_columns(table_name)
+        }:
             continue
         later_migration: dict[str, Any] = runpy.run_path(str(migration_path))
         _bind_operations(later_migration, connection)
@@ -370,3 +389,12 @@ def test_lot_amortized_cost_profiles_apply_roll_back_and_enforce_ledgers(
         if any(migration["revision"] == "c141b2c3d50e" for migration in later_migrations):
             assert inspect(connection).has_table("lot_disposal_receipts")
             assert inspect(connection).has_table("lot_disposal_allocations")
+        if any(migration["revision"] == "c142b2c3d50f" for migration in later_migrations):
+            assert "amortized_cost_profile_id" in {
+                column["name"]
+                for column in inspect(connection).get_columns("lot_disposal_allocations")
+            }
+        if any(migration["revision"] == "c143b2c3d510" for migration in later_migrations):
+            assert "amortized_cost_profile_id" in {
+                column["name"] for column in inspect(connection).get_columns("position_lot_state")
+            }

--- a/tests/integration/test_portfolio_valuation_book_scope_migration.py
+++ b/tests/integration/test_portfolio_valuation_book_scope_migration.py
@@ -38,6 +38,18 @@ HEAD_MIGRATION = (
     / "versions"
     / "c141b2c3d50e_feat_add_lot_disposal_receipts.py"
 )
+DISPOSAL_EVIDENCE_MIGRATION = (
+    Path(__file__).resolve().parents[2]
+    / "alembic"
+    / "versions"
+    / "c142b2c3d50f_feat_add_amortized_disposal_evidence.py"
+)
+RESIDUAL_CARRY_MIGRATION = (
+    Path(__file__).resolve().parents[2]
+    / "alembic"
+    / "versions"
+    / "c143b2c3d510_fix_conserve_amortized_cost_residual.py"
+)
 
 PORTFOLIO_INSERT = text(
     """
@@ -81,8 +93,26 @@ def _bind_operations(migration: dict[str, Any], connection) -> None:
 def _downgrade_dependent_schema(connection) -> list[dict[str, Any]]:
     """Downgrade later schema that deliberately references valuation-book scope."""
 
-    inspector = inspect(connection)
     dependent_migrations: list[dict[str, Any]] = []
+    inspector = inspect(connection)
+    residual_columns = {column["name"] for column in inspector.get_columns("position_lot_state")}
+    if "amortized_cost_profile_id" in residual_columns:
+        residual_migration: dict[str, Any] = runpy.run_path(str(RESIDUAL_CARRY_MIGRATION))
+        _bind_operations(residual_migration, connection)
+        residual_migration["downgrade"]()
+        dependent_migrations.append(residual_migration)
+        inspector = inspect(connection)
+    disposal_evidence_columns = {
+        column["name"] for column in inspector.get_columns("lot_disposal_allocations")
+    }
+    if "amortized_cost_profile_id" in disposal_evidence_columns:
+        disposal_evidence_migration: dict[str, Any] = runpy.run_path(
+            str(DISPOSAL_EVIDENCE_MIGRATION)
+        )
+        _bind_operations(disposal_evidence_migration, connection)
+        disposal_evidence_migration["downgrade"]()
+        dependent_migrations.append(disposal_evidence_migration)
+        inspector = inspect(connection)
     if inspector.has_table("lot_disposal_receipts"):
         head_migration: dict[str, Any] = runpy.run_path(str(HEAD_MIGRATION))
         _bind_operations(head_migration, connection)
@@ -199,3 +229,11 @@ def test_portfolio_valuation_book_scope_applies_rolls_back_and_enforces_authorit
             if any(migration["revision"] == "c141b2c3d50e" for migration in dependent_migrations):
                 assert inspector.has_table("lot_disposal_receipts")
                 assert inspector.has_table("lot_disposal_allocations")
+            if any(migration["revision"] == "c142b2c3d50f" for migration in dependent_migrations):
+                assert "amortized_cost_profile_id" in {
+                    column["name"] for column in inspector.get_columns("lot_disposal_allocations")
+                }
+            if any(migration["revision"] == "c143b2c3d510" for migration in dependent_migrations):
+                assert "amortized_cost_profile_id" in {
+                    column["name"] for column in inspector.get_columns("position_lot_state")
+                }


### PR DESCRIPTION
## Objective\nRestore exact-main integration reliability after amortized residual-carry migrations introduced dependent foreign keys beyond the rollback fixtures' known head.\n\n## Measurable improvement\n- Main Releasability baseline: 2 failed, 997 passed (run 30854324963)\n- Focused PostgreSQL proof after fix: 2 passed in 64.78s\n- Unit migration contracts: 6 passed\n- Ruff: passed\n\n## Compatibility impact\nTest-only migration lifecycle correction. Production schema and runtime contracts are unchanged. The fixtures now downgrade c143 and c142 newest-first and restore them oldest-first before exercising older revisions.\n\n## Scope and documentation\nSame defect pattern corrected in both affected rollback fixtures. No OpenAPI, migration, product documentation, context, or wiki truth changed; explicit no-change decision.\n\n## Durable issue linkage\nFix-forward exact-main validation finding for #901 and merged PR #904. #901 remains open because amortized overlay activation is still intentionally disabled.