### PR TITLE
feat(fixed-income): establish fail-closed correction replay foundation

### DIFF
--- a/src/libs/portfolio-common/portfolio_common/config.py
+++ b/src/libs/portfolio-common/portfolio_common/config.py
@@ -117,6 +117,10 @@ KAFKA_FIXED_INCOME_BOOK_COST_AUTHORITY_RECEIVED_TOPIC = os.getenv(
     "KAFKA_FIXED_INCOME_BOOK_COST_AUTHORITY_RECEIVED_TOPIC",
     "fixed_income.book_cost.authority.received",
 )
+KAFKA_FIXED_INCOME_BOOK_COST_DISPOSAL_REPLAY_REQUESTED_TOPIC = os.getenv(
+    "KAFKA_FIXED_INCOME_BOOK_COST_DISPOSAL_REPLAY_REQUESTED_TOPIC",
+    "fixed_income.book_cost.disposal_replay.requested",
+)
 KAFKA_PERSISTENCE_SERVICE_DLQ_TOPIC = os.getenv(
     "KAFKA_PERSISTENCE_SERVICE_DLQ_TOPIC", "dlq.persistence_service"
 )
@@ -217,6 +221,14 @@ KAFKA_TOPIC_DEFINITIONS = (
         runtime_name=KAFKA_FIXED_INCOME_BOOK_COST_AUTHORITY_RECEIVED_TOPIC,
         lifecycle_status="active",
         semantic_type="fact",
+        scope="tenant_legal_book_portfolio_security_lot",
+        partition_count=12,
+    ),
+    KafkaTopicDefinition(
+        canonical_name="fixed_income.book_cost.disposal_replay.requested",
+        runtime_name=KAFKA_FIXED_INCOME_BOOK_COST_DISPOSAL_REPLAY_REQUESTED_TOPIC,
+        lifecycle_status="active",
+        semantic_type="command",
         scope="tenant_legal_book_portfolio_security_lot",
         partition_count=12,
     ),

--- a/src/libs/portfolio-common/portfolio_common/config.py
+++ b/src/libs/portfolio-common/portfolio_common/config.py
@@ -227,7 +227,7 @@ KAFKA_TOPIC_DEFINITIONS = (
     KafkaTopicDefinition(
         canonical_name="fixed_income.book_cost.disposal_replay.requested",
         runtime_name=KAFKA_FIXED_INCOME_BOOK_COST_DISPOSAL_REPLAY_REQUESTED_TOPIC,
-        lifecycle_status="active",
+        lifecycle_status="inactive",
         semantic_type="command",
         scope="tenant_legal_book_portfolio_security_lot",
         partition_count=12,

--- a/src/libs/portfolio-common/portfolio_common/event_contracts/__init__.py
+++ b/src/libs/portfolio-common/portfolio_common/event_contracts/__init__.py
@@ -3,6 +3,8 @@
 from .fixed_income_book_cost import (
     FIXED_INCOME_BOOK_COST_AUTHORITY_EVENT_TYPE,
     FIXED_INCOME_BOOK_COST_AUTHORITY_SCHEMA_VERSION,
+    FIXED_INCOME_BOOK_COST_DISPOSAL_REPLAY_EVENT_TYPE,
+    FIXED_INCOME_BOOK_COST_DISPOSAL_REPLAY_SCHEMA_VERSION,
     AmortizationScheduleAuthorityContract,
     CleanCostBasisAuthorityContract,
     EffectiveYieldAuthorityContract,
@@ -10,12 +12,17 @@ from .fixed_income_book_cost import (
     FixedIncomeBookCostAuthorityHeader,
     FixedIncomeBookCostAuthorityScope,
     FixedIncomeBookCostAuthoritySource,
+    FixedIncomeBookCostDisposalReplayRequestedEvent,
+    FixedIncomeBookCostProfileDecisionContract,
+    FixedIncomeBookCostReplayEligibilityReason,
     PolicyAssignmentAuthorityContract,
 )
 
 __all__ = [
     "FIXED_INCOME_BOOK_COST_AUTHORITY_EVENT_TYPE",
     "FIXED_INCOME_BOOK_COST_AUTHORITY_SCHEMA_VERSION",
+    "FIXED_INCOME_BOOK_COST_DISPOSAL_REPLAY_EVENT_TYPE",
+    "FIXED_INCOME_BOOK_COST_DISPOSAL_REPLAY_SCHEMA_VERSION",
     "AmortizationScheduleAuthorityContract",
     "CleanCostBasisAuthorityContract",
     "EffectiveYieldAuthorityContract",
@@ -23,5 +30,8 @@ __all__ = [
     "FixedIncomeBookCostAuthorityHeader",
     "FixedIncomeBookCostAuthorityScope",
     "FixedIncomeBookCostAuthoritySource",
+    "FixedIncomeBookCostDisposalReplayRequestedEvent",
+    "FixedIncomeBookCostProfileDecisionContract",
+    "FixedIncomeBookCostReplayEligibilityReason",
     "PolicyAssignmentAuthorityContract",
 ]

--- a/src/libs/portfolio-common/portfolio_common/event_contracts/fixed_income_book_cost.py
+++ b/src/libs/portfolio-common/portfolio_common/event_contracts/fixed_income_book_cost.py
@@ -27,6 +27,10 @@ from portfolio_common.pydantic_financial_numeric import (
 
 FIXED_INCOME_BOOK_COST_AUTHORITY_EVENT_TYPE = "fixed_income.book_cost.authority.received"
 FIXED_INCOME_BOOK_COST_AUTHORITY_SCHEMA_VERSION = "1.0.0"
+FIXED_INCOME_BOOK_COST_DISPOSAL_REPLAY_EVENT_TYPE = (
+    "fixed_income.book_cost.disposal_replay.requested"
+)
+FIXED_INCOME_BOOK_COST_DISPOSAL_REPLAY_SCHEMA_VERSION = "1.0.0"
 
 _STRICT_MODEL_CONFIG = ConfigDict(
     extra="forbid",
@@ -37,6 +41,7 @@ _STRICT_MODEL_CONFIG = ConfigDict(
 
 _PositiveStrictVersion = Annotated[int, Field(strict=True, ge=1)]
 _ExactPeriodRate = Annotated[ExactDecimal18_10, Field(gt=Decimal(-1))]
+_Sha256Digest = Annotated[str, Field(pattern=r"^[0-9a-f]{64}$")]
 
 
 def _parse_iso_date(value: object) -> date:
@@ -64,6 +69,8 @@ _IsoDatetime = Annotated[datetime, BeforeValidator(_parse_iso_datetime)]
 def _canonicalize_hash_decimals(value: object) -> object:
     if isinstance(value, Decimal):
         sign, digits, exponent = value.as_tuple()
+        if not isinstance(exponent, int):
+            raise ValueError("content-hash decimals must be finite")
         canonical_digits = list(digits)
         while canonical_digits and canonical_digits[-1] == 0:
             canonical_digits.pop()
@@ -101,6 +108,28 @@ class FixedIncomeYieldApplication(StrEnum):
     ANNUAL_EFFECTIVE = "ANNUAL_EFFECTIVE"
     ANNUAL_NOMINAL_SIMPLE = "ANNUAL_NOMINAL_SIMPLE"
     PER_PERIOD_EFFECTIVE = "PER_PERIOD_EFFECTIVE"
+
+
+class FixedIncomeBookCostReplayEligibilityReason(StrEnum):
+    """Fail-closed profile decision carried into correction replay evidence."""
+
+    ASSIGNMENT_MISSING = "ASSIGNMENT_MISSING"
+    ASSIGNMENT_OVERLAPPING = "ASSIGNMENT_OVERLAPPING"
+    ASSIGNMENT_CONFLICTING = "ASSIGNMENT_CONFLICTING"
+    SOURCE_FACT_OVERLAPPING = "SOURCE_FACT_OVERLAPPING"
+    SOURCE_FACT_CONFLICTING = "SOURCE_FACT_CONFLICTING"
+    AUTHORITY_STALE = "AUTHORITY_STALE"
+    CLEAN_COST_EVIDENCE_MISSING = "CLEAN_COST_EVIDENCE_MISSING"
+    REDEMPTION_VALUE_MISSING = "REDEMPTION_VALUE_MISSING"
+    CASHFLOW_SCHEDULE_MISSING = "CASHFLOW_SCHEDULE_MISSING"
+    EFFECTIVE_YIELD_MISSING = "EFFECTIVE_YIELD_MISSING"
+    YIELD_CONVENTION_MISSING = "YIELD_CONVENTION_MISSING"
+    YIELD_CONVENTION_MISMATCH = "YIELD_CONVENTION_MISMATCH"
+    PERIOD_RATE_MISSING = "PERIOD_RATE_MISSING"
+    POLICY_IDENTITY_MISMATCH = "POLICY_IDENTITY_MISMATCH"
+    POLICY_UNSUPPORTED = "POLICY_UNSUPPORTED"
+    CALCULATION_FAILED = "CALCULATION_FAILED"
+    RESIDUAL_OUTSIDE_TOLERANCE = "RESIDUAL_OUTSIDE_TOLERANCE"
 
 
 class FixedIncomeBookCostAuthorityScope(BaseModel):
@@ -312,5 +341,72 @@ class FixedIncomeBookCostAuthorityEvent(BaseModel):
             for key, value in self.model_dump(mode="python").items()
         }
         return cast(str, canonical_content_hash(payload))
+
+    model_config = _STRICT_MODEL_CONFIG
+
+
+class FixedIncomeBookCostProfileDecisionContract(BaseModel):
+    """One exact profile decision committed before replay was requested."""
+
+    effective_date: _IsoDate
+    profile_id: str = Field(min_length=1, max_length=96)
+    profile_version: _PositiveStrictVersion
+    authority_content_hash: _Sha256Digest
+    eligibility_reason: FixedIncomeBookCostReplayEligibilityReason | None = None
+
+    model_config = _STRICT_MODEL_CONFIG
+
+
+class FixedIncomeBookCostDisposalReplayRequestedEvent(BaseModel):
+    """Durable source-lot command for one deterministic disposal suffix rebuild."""
+
+    event_type: Literal["fixed_income.book_cost.disposal_replay.requested"] = (
+        "fixed_income.book_cost.disposal_replay.requested"
+    )
+    schema_version: Literal["1.0.0"] = "1.0.0"
+    command_id: _Sha256Digest
+    scope: FixedIncomeBookCostAuthorityScope
+    earliest_affected_date: _IsoDate
+    first_affected_transaction_id: str = Field(min_length=1, max_length=200)
+    first_affected_transaction_timestamp: _IsoDatetime
+    source_authority_event_content_hash: _Sha256Digest
+    profile_decisions: tuple[FixedIncomeBookCostProfileDecisionContract, ...] = Field(
+        min_length=1,
+        max_length=1000,
+    )
+    correlation_id: str | None = Field(default=None, min_length=1, max_length=255)
+    traceparent: str | None = Field(default=None, min_length=1, max_length=512)
+
+    @field_validator("first_affected_transaction_timestamp")
+    @classmethod
+    def require_aware_transaction_timestamp(cls, value: datetime) -> datetime:
+        if value.utcoffset() is None:
+            raise ValueError("first_affected_transaction_timestamp must include a timezone offset")
+        return value.astimezone(UTC)
+
+    @model_validator(mode="after")
+    def validate_replay_boundary_and_decisions(
+        self,
+    ) -> FixedIncomeBookCostDisposalReplayRequestedEvent:
+        if self.first_affected_transaction_timestamp.date() < self.earliest_affected_date:
+            raise ValueError(
+                "first_affected_transaction_timestamp cannot precede earliest_affected_date"
+            )
+        decision_order = tuple(
+            (decision.effective_date, decision.profile_version, decision.profile_id)
+            for decision in self.profile_decisions
+        )
+        if decision_order != tuple(sorted(decision_order)):
+            raise ValueError("profile_decisions must use canonical effective-date order")
+        effective_dates = [decision.effective_date for decision in self.profile_decisions]
+        if len(effective_dates) != len(set(effective_dates)):
+            raise ValueError("profile_decisions must have unique effective dates")
+        return self
+
+    @property
+    def partition_key(self) -> str:
+        """Return the exact source-lot stream key required for broker ordering."""
+
+        return self.scope.partition_key()
 
     model_config = _STRICT_MODEL_CONFIG

--- a/src/services/portfolio_transaction_processing_service/app/application/fixed_income_book_cost/__init__.py
+++ b/src/services/portfolio_transaction_processing_service/app/application/fixed_income_book_cost/__init__.py
@@ -16,6 +16,11 @@ from .authority_writer import (
     PersistLotAmortizedCostAuthorityResult,
     PersistLotAmortizedCostAuthorityUseCase,
 )
+from .correction_replay_mapping import (
+    ConflictingFixedIncomeBookCostReplayCommandError,
+    fixed_income_book_cost_disposal_replay_event,
+    map_fixed_income_book_cost_disposal_replay_event,
+)
 from .materialization import (
     LotAmortizedCostMaterializationResult,
     MaterializeLotAmortizedCostProfileUseCase,
@@ -24,6 +29,7 @@ from .materialization import (
 __all__ = [
     "ApplyFixedIncomeBookCostAuthorityEventResult",
     "ApplyFixedIncomeBookCostAuthorityEventUseCase",
+    "ConflictingFixedIncomeBookCostReplayCommandError",
     "FixedIncomeBookCostAuthorityUnitOfWork",
     "FixedIncomeBookCostAuthorityUnitOfWorkFactory",
     "HandleFixedIncomeBookCostAuthorityEventUseCase",
@@ -33,5 +39,7 @@ __all__ = [
     "PersistLotAmortizedCostAuthorityResult",
     "PersistLotAmortizedCostAuthorityUseCase",
     "UnsupportedFixedIncomeBookCostAuthorityMappingError",
+    "fixed_income_book_cost_disposal_replay_event",
     "map_fixed_income_book_cost_authority_event",
+    "map_fixed_income_book_cost_disposal_replay_event",
 ]

--- a/src/services/portfolio_transaction_processing_service/app/application/fixed_income_book_cost/authority_event_orchestration.py
+++ b/src/services/portfolio_transaction_processing_service/app/application/fixed_income_book_cost/authority_event_orchestration.py
@@ -133,9 +133,11 @@ class HandleFixedIncomeBookCostAuthorityEventUseCase:
         *,
         unit_of_work_factory: FixedIncomeBookCostAuthorityUnitOfWorkFactory,
         policies: AmortizedCostPolicyRegistry,
+        correction_replay_enabled: bool = False,
     ) -> None:
         self._unit_of_work_factory = unit_of_work_factory
         self._policies = policies
+        self._correction_replay_enabled = correction_replay_enabled
 
     async def execute(
         self,
@@ -222,6 +224,8 @@ class HandleFixedIncomeBookCostAuthorityEventUseCase:
     ) -> FixedIncomeBookCostCorrectionReplayIntent | None:
         """Stage one suffix replay only for a newly committed profile decision."""
 
+        if not self._correction_replay_enabled:
+            return None
         if persistence.appended_count == 0 or not any(
             result.outcome is LotAmortizedCostProfileAppendOutcome.APPENDED
             for result in materializations

--- a/src/services/portfolio_transaction_processing_service/app/application/fixed_income_book_cost/authority_event_orchestration.py
+++ b/src/services/portfolio_transaction_processing_service/app/application/fixed_income_book_cost/authority_event_orchestration.py
@@ -15,6 +15,8 @@ from ...domain.fixed_income_book_cost import (
     AmortizedCostEligibilityReason,
     AmortizedCostPolicy,
     AmortizedCostPolicyRegistry,
+    FixedIncomeBookCostCorrectionReplayIntent,
+    FixedIncomeBookCostProfileDecisionEvidence,
     LotAmortizedCostPolicyAssignment,
     LotBookCostAuthorityScope,
     MissingAmortizedCostAssignmentError,
@@ -24,8 +26,10 @@ from ...domain.fixed_income_book_cost import (
     resolve_amortized_cost_assignment,
 )
 from ...ports import (
+    FixedIncomeBookCostCorrectionReplayPort,
     LotAmortizedCostAuthority,
     LotAmortizedCostAuthorityPort,
+    LotAmortizedCostProfileAppendOutcome,
     LotAmortizedCostProfilePort,
 )
 from .authority_event_mapping import map_fixed_income_book_cost_authority_event
@@ -47,6 +51,7 @@ class ApplyFixedIncomeBookCostAuthorityEventResult:
     persistence: PersistLotAmortizedCostAuthorityResult
     materialization: LotAmortizedCostMaterializationResult
     rematerializations: tuple[LotAmortizedCostMaterializationResult, ...] = ()
+    correction_replay_intent: FixedIncomeBookCostCorrectionReplayIntent | None = None
 
 
 class FixedIncomeBookCostAuthorityUnitOfWork(Protocol):
@@ -57,6 +62,9 @@ class FixedIncomeBookCostAuthorityUnitOfWork(Protocol):
 
     @property
     def profiles(self) -> LotAmortizedCostProfilePort: ...
+
+    @property
+    def correction_replay(self) -> FixedIncomeBookCostCorrectionReplayPort: ...
 
     async def __aenter__(self) -> Self: ...
 
@@ -132,6 +140,9 @@ class HandleFixedIncomeBookCostAuthorityEventUseCase:
     async def execute(
         self,
         event: FixedIncomeBookCostAuthorityEvent,
+        *,
+        correlation_id: str | None = None,
+        traceparent: str | None = None,
     ) -> ApplyFixedIncomeBookCostAuthorityEventResult:
         """Persist and atomically rebuild every profile boundary affected by the event."""
 
@@ -176,13 +187,74 @@ class HandleFixedIncomeBookCostAuthorityEventUseCase:
             rematerializations = tuple(
                 result for index, result in enumerate(materializations) if index != primary_index
             )
+            correction_replay_intent = await self._stage_correction_replay(
+                replay=unit_of_work.correction_replay,
+                event=event,
+                scope=mapped.scope,
+                persistence=persistence,
+                replay_start=replay_start,
+                boundaries=tuple(affected_boundaries),
+                materializations=materializations,
+                correlation_id=correlation_id,
+                traceparent=traceparent,
+            )
             await unit_of_work.commit()
         return ApplyFixedIncomeBookCostAuthorityEventResult(
             scope=mapped.scope,
             persistence=persistence,
             materialization=materialization,
             rematerializations=rematerializations,
+            correction_replay_intent=correction_replay_intent,
         )
+
+    async def _stage_correction_replay(
+        self,
+        *,
+        replay: FixedIncomeBookCostCorrectionReplayPort,
+        event: FixedIncomeBookCostAuthorityEvent,
+        scope: LotBookCostAuthorityScope,
+        persistence: PersistLotAmortizedCostAuthorityResult,
+        replay_start: date,
+        boundaries: tuple[date, ...],
+        materializations: tuple[LotAmortizedCostMaterializationResult, ...],
+        correlation_id: str | None,
+        traceparent: str | None,
+    ) -> FixedIncomeBookCostCorrectionReplayIntent | None:
+        """Stage one suffix replay only for a newly committed profile decision."""
+
+        if persistence.appended_count == 0 or not any(
+            result.outcome is LotAmortizedCostProfileAppendOutcome.APPENDED
+            for result in materializations
+        ):
+            return None
+        anchor = await replay.find_earliest_affected_disposal(
+            scope,
+            effective_date=replay_start,
+        )
+        if anchor is None:
+            return None
+        intent = FixedIncomeBookCostCorrectionReplayIntent(
+            scope=scope,
+            earliest_affected_date=replay_start,
+            anchor=anchor,
+            source_authority_event_content_hash=event.content_hash(),
+            profile_decisions=tuple(
+                FixedIncomeBookCostProfileDecisionEvidence(
+                    effective_date=boundary,
+                    profile_id=result.profile_id,
+                    profile_version=result.profile_version,
+                    authority_content_hash=result.authority_content_hash,
+                    eligibility_reason=result.eligibility_reason,
+                )
+                for boundary, result in zip(boundaries, materializations, strict=True)
+            ),
+        )
+        await replay.stage_replay_intent(
+            intent,
+            correlation_id=correlation_id,
+            traceparent=traceparent,
+        )
+        return intent
 
     async def _replay_start(
         self,

--- a/src/services/portfolio_transaction_processing_service/app/application/fixed_income_book_cost/correction_replay_mapping.py
+++ b/src/services/portfolio_transaction_processing_service/app/application/fixed_income_book_cost/correction_replay_mapping.py
@@ -1,0 +1,111 @@
+"""Map fixed-income correction replay between domain and transport contracts."""
+
+from __future__ import annotations
+
+from portfolio_common.event_contracts import (
+    FixedIncomeBookCostAuthorityScope,
+    FixedIncomeBookCostDisposalReplayRequestedEvent,
+    FixedIncomeBookCostProfileDecisionContract,
+    FixedIncomeBookCostReplayEligibilityReason,
+)
+
+from ...domain.fixed_income_book_cost import (
+    AffectedLotDisposalReplayAnchor,
+    AmortizedCostEligibilityReason,
+    FixedIncomeBookCostCorrectionReplayIntent,
+    FixedIncomeBookCostProfileDecisionEvidence,
+    LotBookCostAuthorityScope,
+)
+
+
+class ConflictingFixedIncomeBookCostReplayCommandError(ValueError):
+    """Raised when transport command identity differs from its business evidence."""
+
+
+def fixed_income_book_cost_disposal_replay_event(
+    intent: FixedIncomeBookCostCorrectionReplayIntent,
+    *,
+    correlation_id: str | None,
+    traceparent: str | None,
+) -> FixedIncomeBookCostDisposalReplayRequestedEvent:
+    """Return the strict additive event staged for one domain replay intent."""
+
+    if not isinstance(intent, FixedIncomeBookCostCorrectionReplayIntent):
+        raise TypeError("intent must be a FixedIncomeBookCostCorrectionReplayIntent")
+    return FixedIncomeBookCostDisposalReplayRequestedEvent(
+        command_id=intent.command_id,
+        scope=_event_scope(intent.scope),
+        earliest_affected_date=intent.earliest_affected_date.isoformat(),
+        first_affected_transaction_id=intent.anchor.transaction_id,
+        first_affected_transaction_timestamp=intent.anchor.transaction_timestamp.isoformat(),
+        source_authority_event_content_hash=intent.source_authority_event_content_hash,
+        profile_decisions=tuple(
+            FixedIncomeBookCostProfileDecisionContract(
+                effective_date=decision.effective_date.isoformat(),
+                profile_id=decision.profile_id,
+                profile_version=decision.profile_version,
+                authority_content_hash=decision.authority_content_hash,
+                eligibility_reason=(
+                    FixedIncomeBookCostReplayEligibilityReason(decision.eligibility_reason.value)
+                    if decision.eligibility_reason is not None
+                    else None
+                ),
+            )
+            for decision in intent.profile_decisions
+        ),
+        correlation_id=correlation_id,
+        traceparent=traceparent,
+    )
+
+
+def map_fixed_income_book_cost_disposal_replay_event(
+    event: FixedIncomeBookCostDisposalReplayRequestedEvent,
+) -> FixedIncomeBookCostCorrectionReplayIntent:
+    """Return a domain intent and reject a forged or stale command identity."""
+
+    if not isinstance(event, FixedIncomeBookCostDisposalReplayRequestedEvent):
+        raise TypeError("event must be a FixedIncomeBookCostDisposalReplayRequestedEvent")
+    intent = FixedIncomeBookCostCorrectionReplayIntent(
+        scope=LotBookCostAuthorityScope(
+            tenant_id=event.scope.tenant_id,
+            legal_book_id=event.scope.legal_book_id,
+            portfolio_id=event.scope.portfolio_id,
+            security_id=event.scope.security_id,
+            lot_id=event.scope.lot_id,
+        ),
+        earliest_affected_date=event.earliest_affected_date,
+        anchor=AffectedLotDisposalReplayAnchor(
+            transaction_id=event.first_affected_transaction_id,
+            transaction_timestamp=event.first_affected_transaction_timestamp,
+        ),
+        source_authority_event_content_hash=event.source_authority_event_content_hash,
+        profile_decisions=tuple(
+            FixedIncomeBookCostProfileDecisionEvidence(
+                effective_date=decision.effective_date,
+                profile_id=decision.profile_id,
+                profile_version=decision.profile_version,
+                authority_content_hash=decision.authority_content_hash,
+                eligibility_reason=(
+                    AmortizedCostEligibilityReason(decision.eligibility_reason.value)
+                    if decision.eligibility_reason is not None
+                    else None
+                ),
+            )
+            for decision in event.profile_decisions
+        ),
+    )
+    if event.command_id != intent.command_id:
+        raise ConflictingFixedIncomeBookCostReplayCommandError(
+            "fixed-income book-cost replay command_id does not match business evidence"
+        )
+    return intent
+
+
+def _event_scope(scope: LotBookCostAuthorityScope) -> FixedIncomeBookCostAuthorityScope:
+    return FixedIncomeBookCostAuthorityScope(
+        tenant_id=scope.tenant_id,
+        legal_book_id=scope.legal_book_id,
+        portfolio_id=scope.portfolio_id,
+        security_id=scope.security_id,
+        lot_id=scope.lot_id,
+    )

--- a/src/services/portfolio_transaction_processing_service/app/delivery/kafka/fixed_income_book_cost_authority_consumer.py
+++ b/src/services/portfolio_transaction_processing_service/app/delivery/kafka/fixed_income_book_cost_authority_consumer.py
@@ -16,6 +16,7 @@ from portfolio_common.event_mapping import (
 from portfolio_common.exceptions import RetryableConsumerError
 from portfolio_common.kafka_consumer import BaseConsumer
 from portfolio_common.kafka_consumer_execution import KafkaConsumerExecutionProfile
+from portfolio_common.logging_utils import normalize_traceparent, traceparent_var
 from sqlalchemy.exc import DBAPIError, IntegrityError
 
 from ...application.fixed_income_book_cost import (
@@ -71,9 +72,13 @@ class FixedIncomeBookCostAuthorityConsumer(BaseConsumer):
             raise ValueError(
                 "fixed-income book-cost authority partition key does not match event scope"
             )
-        with self._message_correlation_context(msg):
+        with self._message_correlation_context(msg) as correlation_id:
             try:
-                result = await self._use_case.execute(event)
+                result = await self._use_case.execute(
+                    event,
+                    correlation_id=correlation_id,
+                    traceparent=normalize_traceparent(traceparent_var.get()),
+                )
             except (DBAPIError, IntegrityError) as exc:
                 raise RetryableConsumerError(
                     "Fixed-income book-cost database dependency unavailable"

--- a/src/services/portfolio_transaction_processing_service/app/domain/fixed_income_book_cost/__init__.py
+++ b/src/services/portfolio_transaction_processing_service/app/domain/fixed_income_book_cost/__init__.py
@@ -25,6 +25,12 @@ from .calculation import (
     amortized_cost_calculation_identity,
     calculate_amortized_cost_schedule,
 )
+from .correction_replay import (
+    FIXED_INCOME_BOOK_COST_CORRECTION_REPLAY_ID_VERSION,
+    AffectedLotDisposalReplayAnchor,
+    FixedIncomeBookCostCorrectionReplayIntent,
+    FixedIncomeBookCostProfileDecisionEvidence,
+)
 from .disposal_basis import (
     AMORTIZED_COST_DISPOSAL_ALGORITHM_ID,
     AMORTIZED_COST_DISPOSAL_ALGORITHM_VERSION,
@@ -82,8 +88,10 @@ __all__ = [
     "AMORTIZED_COST_SCHEDULE_ALGORITHM_VERSION",
     "AMORTIZED_COST_DISPOSAL_ALGORITHM_ID",
     "AMORTIZED_COST_DISPOSAL_ALGORITHM_VERSION",
+    "FIXED_INCOME_BOOK_COST_CORRECTION_REPLAY_ID_VERSION",
     "LOT_AMORTIZED_COST_PROFILE_ID_VERSION",
     "AmortizedCostAssignmentCacheKey",
+    "AffectedLotDisposalReplayAnchor",
     "AmortizedCostAssignmentStatus",
     "AmortizedCostAuthorityError",
     "AmortizedCostDirection",
@@ -114,6 +122,8 @@ __all__ = [
     "LotAmortizedCostBasisFact",
     "LotAmortizedCostPolicyAssignment",
     "LotBookCostAuthorityScope",
+    "FixedIncomeBookCostCorrectionReplayIntent",
+    "FixedIncomeBookCostProfileDecisionEvidence",
     "LotEffectiveYieldFact",
     "IFRS9_EIR_LOCAL_POLICY_ID",
     "MissingAmortizedCostAssignmentError",

--- a/src/services/portfolio_transaction_processing_service/app/domain/fixed_income_book_cost/correction_replay.py
+++ b/src/services/portfolio_transaction_processing_service/app/domain/fixed_income_book_cost/correction_replay.py
@@ -1,0 +1,179 @@
+"""Deterministic replay intent for fixed-income authority corrections."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from typing import cast
+
+from portfolio_common.domain.calculation_lineage import (
+    canonical_content_hash,
+    require_sha256_digest,
+)
+
+from .authority import LotBookCostAuthorityScope
+from .policy import AmortizedCostEligibilityReason
+
+FIXED_INCOME_BOOK_COST_CORRECTION_REPLAY_ID_VERSION = 1
+
+
+@dataclass(frozen=True, slots=True)
+class AffectedLotDisposalReplayAnchor:
+    """Earliest booked disposal in the deterministic transaction order."""
+
+    transaction_id: str
+    transaction_timestamp: datetime
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "transaction_id",
+            _normalized_nonblank(self.transaction_id, "transaction_id"),
+        )
+        if not isinstance(self.transaction_timestamp, datetime):
+            raise TypeError("transaction_timestamp must be a datetime")
+        if (
+            self.transaction_timestamp.tzinfo is None
+            or self.transaction_timestamp.utcoffset() is None
+        ):
+            raise ValueError("transaction_timestamp must be timezone-aware")
+        object.__setattr__(
+            self,
+            "transaction_timestamp",
+            self.transaction_timestamp.astimezone(UTC),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class FixedIncomeBookCostProfileDecisionEvidence:
+    """Exact immutable profile decision produced by one authority transaction."""
+
+    effective_date: date
+    profile_id: str
+    profile_version: int
+    authority_content_hash: str
+    eligibility_reason: AmortizedCostEligibilityReason | None
+
+    def __post_init__(self) -> None:
+        if type(self.effective_date) is not date:
+            raise TypeError("effective_date must be a date")
+        object.__setattr__(
+            self,
+            "profile_id",
+            _normalized_nonblank(self.profile_id, "profile_id"),
+        )
+        _require_positive_integer(self.profile_version, "profile_version")
+        require_sha256_digest(self.authority_content_hash, "authority_content_hash")
+        if self.eligibility_reason is not None and not isinstance(
+            self.eligibility_reason,
+            AmortizedCostEligibilityReason,
+        ):
+            raise TypeError("eligibility_reason must be an AmortizedCostEligibilityReason or None")
+
+
+@dataclass(frozen=True, slots=True)
+class FixedIncomeBookCostCorrectionReplayIntent:
+    """One source-lot correction and its earliest affected disposal suffix."""
+
+    scope: LotBookCostAuthorityScope
+    earliest_affected_date: date
+    anchor: AffectedLotDisposalReplayAnchor
+    source_authority_event_content_hash: str
+    profile_decisions: tuple[FixedIncomeBookCostProfileDecisionEvidence, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.scope, LotBookCostAuthorityScope):
+            raise TypeError("scope must be a LotBookCostAuthorityScope")
+        if type(self.earliest_affected_date) is not date:
+            raise TypeError("earliest_affected_date must be a date")
+        if not isinstance(self.anchor, AffectedLotDisposalReplayAnchor):
+            raise TypeError("anchor must be an AffectedLotDisposalReplayAnchor")
+        if self.anchor.transaction_timestamp.date() < self.earliest_affected_date:
+            raise ValueError("anchor cannot precede earliest_affected_date")
+        require_sha256_digest(
+            self.source_authority_event_content_hash,
+            "source_authority_event_content_hash",
+        )
+        if not isinstance(self.profile_decisions, tuple):
+            raise TypeError("profile_decisions must be a tuple")
+        if not self.profile_decisions:
+            raise ValueError("profile_decisions must not be empty")
+        if not all(
+            isinstance(decision, FixedIncomeBookCostProfileDecisionEvidence)
+            for decision in self.profile_decisions
+        ):
+            raise TypeError(
+                "profile_decisions must contain FixedIncomeBookCostProfileDecisionEvidence values"
+            )
+        ordered = tuple(
+            sorted(
+                self.profile_decisions,
+                key=lambda decision: (
+                    decision.effective_date,
+                    decision.profile_version,
+                    decision.profile_id,
+                ),
+            )
+        )
+        effective_dates = [decision.effective_date for decision in ordered]
+        if len(effective_dates) != len(set(effective_dates)):
+            raise ValueError("profile_decisions must have unique effective dates")
+        object.__setattr__(self, "profile_decisions", ordered)
+
+    @property
+    def command_id(self) -> str:
+        """Return the stable business idempotency identity for this replay intent."""
+
+        return cast(
+            str,
+            canonical_content_hash(
+                {
+                    "anchor": {
+                        "transaction_id": self.anchor.transaction_id,
+                        "transaction_timestamp": self.anchor.transaction_timestamp,
+                    },
+                    "earliest_affected_date": self.earliest_affected_date,
+                    "identity_version": FIXED_INCOME_BOOK_COST_CORRECTION_REPLAY_ID_VERSION,
+                    "profile_decisions": [
+                        {
+                            "authority_content_hash": decision.authority_content_hash,
+                            "effective_date": decision.effective_date,
+                            "eligibility_reason": (
+                                decision.eligibility_reason.value
+                                if decision.eligibility_reason is not None
+                                else None
+                            ),
+                            "profile_id": decision.profile_id,
+                            "profile_version": decision.profile_version,
+                        }
+                        for decision in self.profile_decisions
+                    ],
+                    "scope": {
+                        "legal_book_id": self.scope.legal_book_id,
+                        "lot_id": self.scope.lot_id,
+                        "portfolio_id": self.scope.portfolio_id,
+                        "security_id": self.scope.security_id,
+                        "tenant_id": self.scope.tenant_id,
+                    },
+                    "source_authority_event_content_hash": (
+                        self.source_authority_event_content_hash
+                    ),
+                }
+            ),
+        )
+
+
+def _normalized_nonblank(value: object, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must be nonblank")
+    return normalized
+
+
+def _require_positive_integer(value: object, field_name: str) -> None:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise TypeError(f"{field_name} must be an integer")
+    if value < 1:
+        raise ValueError(f"{field_name} must be positive")

--- a/src/services/portfolio_transaction_processing_service/app/infrastructure/fixed_income_book_cost/__init__.py
+++ b/src/services/portfolio_transaction_processing_service/app/infrastructure/fixed_income_book_cost/__init__.py
@@ -1,5 +1,8 @@
 """Infrastructure adapters for fixed-income book-cost processing."""
 
+from .correction_replay_repository import (
+    SqlAlchemyFixedIncomeBookCostCorrectionReplayRepository,
+)
 from .profile_repository import (
     ConflictingLotAmortizedCostProfileError,
     SqlAlchemyLotAmortizedCostProfileRepository,
@@ -14,6 +17,7 @@ from .unit_of_work import SqlAlchemyFixedIncomeBookCostAuthorityUnitOfWork
 __all__ = [
     "ConflictingLotAmortizedCostProfileError",
     "SqlAlchemyLotAmortizedCostProfileRepository",
+    "SqlAlchemyFixedIncomeBookCostCorrectionReplayRepository",
     "lot_amortized_cost_profile_lock_key",
     "ConflictingLotAmortizedCostAuthorityError",
     "SqlAlchemyLotAmortizedCostAuthorityRepository",

--- a/src/services/portfolio_transaction_processing_service/app/infrastructure/fixed_income_book_cost/correction_replay_repository.py
+++ b/src/services/portfolio_transaction_processing_service/app/infrastructure/fixed_income_book_cost/correction_replay_repository.py
@@ -1,0 +1,161 @@
+"""SQL and transactional-outbox adapter for fixed-income correction replay."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, time
+
+from portfolio_common.database_models import (
+    LotDisposalAllocationRecord,
+    LotDisposalReceiptRecord,
+    Portfolio,
+    Transaction,
+)
+from portfolio_common.event_contracts import (
+    FIXED_INCOME_BOOK_COST_DISPOSAL_REPLAY_EVENT_TYPE,
+)
+from portfolio_common.outbox_repository import OutboxRepository
+from sqlalchemy import Select, and_, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ...application.fixed_income_book_cost import (
+    fixed_income_book_cost_disposal_replay_event,
+)
+from ...domain.fixed_income_book_cost import (
+    AffectedLotDisposalReplayAnchor,
+    FixedIncomeBookCostCorrectionReplayIntent,
+    LotBookCostAuthorityScope,
+)
+
+
+class SqlAlchemyFixedIncomeBookCostCorrectionReplayRepository:
+    """Select one deterministic suffix anchor and stage one ordered replay command."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        topic: str,
+        outbox_repository: OutboxRepository | None = None,
+    ) -> None:
+        normalized_topic = topic.strip()
+        if not normalized_topic:
+            raise ValueError("fixed-income correction replay topic must be nonblank")
+        self._session = session
+        self._topic = normalized_topic
+        self._outbox = outbox_repository or OutboxRepository(session)
+
+    async def find_earliest_affected_disposal(
+        self,
+        scope: LotBookCostAuthorityScope,
+        *,
+        effective_date: date,
+    ) -> AffectedLotDisposalReplayAnchor | None:
+        """Return the earliest latest-active disposal allocation for the exact source lot."""
+
+        row = (
+            await self._session.execute(
+                _earliest_affected_disposal_statement(
+                    scope,
+                    effective_date=effective_date,
+                )
+            )
+        ).first()
+        if row is None:
+            return None
+        return AffectedLotDisposalReplayAnchor(
+            transaction_id=str(row.transaction_id),
+            transaction_timestamp=row.transaction_date,
+        )
+
+    async def stage_replay_intent(
+        self,
+        intent: FixedIncomeBookCostCorrectionReplayIntent,
+        *,
+        correlation_id: str | None,
+        traceparent: str | None,
+    ) -> None:
+        """Write one strict command to the caller-owned transactional outbox."""
+
+        event = fixed_income_book_cost_disposal_replay_event(
+            intent,
+            correlation_id=correlation_id,
+            traceparent=traceparent,
+        )
+        await self._outbox.create_outbox_event(
+            aggregate_type="FixedIncomeBookCostCorrectionReplay",
+            aggregate_id=intent.command_id,
+            event_type=FIXED_INCOME_BOOK_COST_DISPOSAL_REPLAY_EVENT_TYPE,
+            payload=event.model_dump(mode="json"),
+            topic=self._topic,
+            partition_key=event.partition_key,
+            correlation_id=event.correlation_id,
+            traceparent=event.traceparent,
+        )
+
+
+def _earliest_affected_disposal_statement(
+    scope: LotBookCostAuthorityScope,
+    *,
+    effective_date: date,
+) -> Select[tuple[str, datetime]]:
+    if not isinstance(scope, LotBookCostAuthorityScope):
+        raise TypeError("scope must be a LotBookCostAuthorityScope")
+    if type(effective_date) is not date:
+        raise TypeError("effective_date must be a date")
+    receipt = LotDisposalReceiptRecord
+    allocation = LotDisposalAllocationRecord
+    transaction = Transaction
+    portfolio = Portfolio
+    latest_receipt = (
+        select(
+            receipt.disposal_transaction_id.label("disposal_transaction_id"),
+            func.max(receipt.receipt_version).label("receipt_version"),
+        )
+        .group_by(receipt.disposal_transaction_id)
+        .subquery("latest_lot_disposal_receipt")
+    )
+    boundary = datetime.combine(effective_date, time.min, tzinfo=UTC)
+    return (
+        select(
+            transaction.transaction_id.label("transaction_id"),
+            transaction.transaction_date.label("transaction_date"),
+        )
+        .select_from(allocation)
+        .join(
+            receipt,
+            and_(
+                receipt.receipt_id == allocation.receipt_id,
+                receipt.receipt_version == allocation.receipt_version,
+                receipt.portfolio_id == allocation.portfolio_id,
+                receipt.security_id == allocation.security_id,
+            ),
+        )
+        .join(
+            latest_receipt,
+            and_(
+                latest_receipt.c.disposal_transaction_id == receipt.disposal_transaction_id,
+                latest_receipt.c.receipt_version == receipt.receipt_version,
+            ),
+        )
+        .join(
+            transaction,
+            transaction.transaction_id == receipt.disposal_transaction_id,
+        )
+        .join(portfolio, portfolio.portfolio_id == transaction.portfolio_id)
+        .where(
+            portfolio.tenant_id == scope.tenant_id,
+            portfolio.legal_book_id == scope.legal_book_id,
+            transaction.portfolio_id == scope.portfolio_id,
+            transaction.security_id == scope.security_id,
+            transaction.transaction_date >= boundary,
+            receipt.status == "ACTIVE",
+            allocation.portfolio_id == scope.portfolio_id,
+            allocation.security_id == scope.security_id,
+            allocation.source_lot_id == scope.lot_id,
+        )
+        .order_by(
+            transaction.transaction_date.asc(),
+            transaction.transaction_id.asc(),
+        )
+        .limit(1)
+    )

--- a/src/services/portfolio_transaction_processing_service/app/infrastructure/fixed_income_book_cost/unit_of_work.py
+++ b/src/services/portfolio_transaction_processing_service/app/infrastructure/fixed_income_book_cost/unit_of_work.py
@@ -6,9 +6,19 @@ from collections.abc import Callable
 from types import TracebackType
 from typing import TypeVar
 
+from portfolio_common.config import (
+    KAFKA_FIXED_INCOME_BOOK_COST_DISPOSAL_REPLAY_REQUESTED_TOPIC,
+)
 from sqlalchemy.ext.asyncio import AsyncSession, AsyncSessionTransaction
 
-from ...ports import LotAmortizedCostAuthorityPort, LotAmortizedCostProfilePort
+from ...ports import (
+    FixedIncomeBookCostCorrectionReplayPort,
+    LotAmortizedCostAuthorityPort,
+    LotAmortizedCostProfilePort,
+)
+from .correction_replay_repository import (
+    SqlAlchemyFixedIncomeBookCostCorrectionReplayRepository,
+)
 from .profile_repository import SqlAlchemyLotAmortizedCostProfileRepository
 from .source_authority_repository import SqlAlchemyLotAmortizedCostAuthorityRepository
 
@@ -25,6 +35,7 @@ class SqlAlchemyFixedIncomeBookCostAuthorityUnitOfWork:
         self._committed = False
         self._authority: LotAmortizedCostAuthorityPort | None = None
         self._profiles: LotAmortizedCostProfilePort | None = None
+        self._correction_replay: FixedIncomeBookCostCorrectionReplayPort | None = None
 
     @property
     def authority(self) -> LotAmortizedCostAuthorityPort:
@@ -33,6 +44,10 @@ class SqlAlchemyFixedIncomeBookCostAuthorityUnitOfWork:
     @property
     def profiles(self) -> LotAmortizedCostProfilePort:
         return _required_adapter(self._profiles, "profiles")
+
+    @property
+    def correction_replay(self) -> FixedIncomeBookCostCorrectionReplayPort:
+        return _required_adapter(self._correction_replay, "correction replay")
 
     async def __aenter__(self) -> SqlAlchemyFixedIncomeBookCostAuthorityUnitOfWork:
         if self._session is not None:
@@ -45,6 +60,10 @@ class SqlAlchemyFixedIncomeBookCostAuthorityUnitOfWork:
             self._transaction = transaction
             self._authority = SqlAlchemyLotAmortizedCostAuthorityRepository(session)
             self._profiles = SqlAlchemyLotAmortizedCostProfileRepository(session)
+            self._correction_replay = SqlAlchemyFixedIncomeBookCostCorrectionReplayRepository(
+                session,
+                topic=KAFKA_FIXED_INCOME_BOOK_COST_DISPOSAL_REPLAY_REQUESTED_TOPIC,
+            )
         except BaseException:
             if self._transaction is not None:
                 await self._transaction.rollback()

--- a/src/services/portfolio_transaction_processing_service/app/ports/__init__.py
+++ b/src/services/portfolio_transaction_processing_service/app/ports/__init__.py
@@ -42,6 +42,7 @@ from .cost_basis import (
 )
 from .fixed_income_book_cost import (
     EffectiveLotAmortizedCostProfileRequest,
+    FixedIncomeBookCostCorrectionReplayPort,
     LotAmortizedCostAuthority,
     LotAmortizedCostAuthorityAppendOutcome,
     LotAmortizedCostAuthorityBundle,
@@ -88,6 +89,7 @@ from .transaction_replay import BookedTransactionReplayPort
 
 __all__ = [
     "EffectiveLotAmortizedCostProfileRequest",
+    "FixedIncomeBookCostCorrectionReplayPort",
     "AccruedIncomeOffsetStatePort",
     "AverageCostPoolCheckpointRecord",
     "AverageCostPoolPersistedSummary",

--- a/src/services/portfolio_transaction_processing_service/app/ports/fixed_income_book_cost/__init__.py
+++ b/src/services/portfolio_transaction_processing_service/app/ports/fixed_income_book_cost/__init__.py
@@ -1,5 +1,6 @@
 """Application-owned ports for fixed-income book-cost processing."""
 
+from .correction_replay import FixedIncomeBookCostCorrectionReplayPort
 from .profile_persistence import (
     EffectiveLotAmortizedCostProfileRequest,
     LotAmortizedCostProfileAppendOutcome,
@@ -15,6 +16,7 @@ from .source_authority import (
 
 __all__ = [
     "EffectiveLotAmortizedCostProfileRequest",
+    "FixedIncomeBookCostCorrectionReplayPort",
     "LotAmortizedCostProfileAppendOutcome",
     "LotAmortizedCostProfileHead",
     "LotAmortizedCostProfilePort",

--- a/src/services/portfolio_transaction_processing_service/app/ports/fixed_income_book_cost/correction_replay.py
+++ b/src/services/portfolio_transaction_processing_service/app/ports/fixed_income_book_cost/correction_replay.py
@@ -1,0 +1,37 @@
+"""Application port for correction-triggered fixed-income disposal replay."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Protocol
+
+from ...domain.fixed_income_book_cost import (
+    AffectedLotDisposalReplayAnchor,
+    FixedIncomeBookCostCorrectionReplayIntent,
+    LotBookCostAuthorityScope,
+)
+
+
+class FixedIncomeBookCostCorrectionReplayPort(Protocol):
+    """Find and durably stage one affected source-lot replay suffix."""
+
+    async def find_earliest_affected_disposal(
+        self,
+        scope: LotBookCostAuthorityScope,
+        *,
+        effective_date: date,
+    ) -> AffectedLotDisposalReplayAnchor | None:
+        """Return the earliest current disposal using the source lot after the boundary."""
+
+        ...
+
+    async def stage_replay_intent(
+        self,
+        intent: FixedIncomeBookCostCorrectionReplayIntent,
+        *,
+        correlation_id: str | None,
+        traceparent: str | None,
+    ) -> None:
+        """Stage one intent in the caller-owned transaction."""
+
+        ...

--- a/src/services/portfolio_transaction_processing_service/app/runtime/dependency_composition.py
+++ b/src/services/portfolio_transaction_processing_service/app/runtime/dependency_composition.py
@@ -143,8 +143,9 @@ def build_fixed_income_book_cost_authority_use_case(
     *,
     session_factory: Callable[[], AsyncSession] | None = None,
     policies: AmortizedCostPolicyRegistry | None = None,
+    correction_replay_enabled: bool = False,
 ) -> HandleFixedIncomeBookCostAuthorityEventUseCase:
-    """Compose the authority handler with one SQL transaction and governed methodology."""
+    """Compose authority handling with replay fail-closed until its consumer is certified."""
 
     resolved_policies = policies or AmortizedCostPolicyRegistry(
         governed_amortized_cost_policy_catalog()
@@ -154,4 +155,5 @@ def build_fixed_income_book_cost_authority_use_case(
             session_factory=session_factory or get_async_session_factory()
         ),
         policies=resolved_policies,
+        correction_replay_enabled=correction_replay_enabled,
     )

--- a/tests/unit/libs/portfolio-common/event_contracts/test_fixed_income_book_cost.py
+++ b/tests/unit/libs/portfolio-common/event_contracts/test_fixed_income_book_cost.py
@@ -1,11 +1,12 @@
 """Prove the fixed-income book-cost authority event contract."""
 
 from copy import deepcopy
-from decimal import localcontext
+from decimal import Decimal, localcontext
 
 import pytest
 from portfolio_common.event_contracts.fixed_income_book_cost import (
     FixedIncomeBookCostAuthorityEvent,
+    _canonicalize_hash_decimals,
 )
 from pydantic import ValidationError
 
@@ -94,6 +95,12 @@ def _replace_nested(
             target = target[int(component)]
     assert isinstance(target, dict)
     target[path[-1]] = value
+
+
+@pytest.mark.parametrize("value", ("NaN", "Infinity", "-Infinity"))
+def test_content_hash_decimal_canonicalizer_rejects_nonfinite_values(value: str) -> None:
+    with pytest.raises(ValueError, match="must be finite"):
+        _canonicalize_hash_decimals(Decimal(value))
 
 
 def test_event_normalizes_exact_scope_and_preserves_decimal_strings() -> None:

--- a/tests/unit/libs/portfolio-common/event_contracts/test_fixed_income_book_cost_replay.py
+++ b/tests/unit/libs/portfolio-common/event_contracts/test_fixed_income_book_cost_replay.py
@@ -1,0 +1,116 @@
+"""Prove the correction-triggered fixed-income disposal replay contract."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+from portfolio_common.event_contracts import (
+    FixedIncomeBookCostDisposalReplayRequestedEvent,
+)
+from pydantic import ValidationError
+
+_HASH_A = "a" * 64
+_HASH_B = "b" * 64
+
+
+def _event() -> dict[str, object]:
+    return {
+        "event_type": "fixed_income.book_cost.disposal_replay.requested",
+        "schema_version": "1.0.0",
+        "command_id": _HASH_A,
+        "scope": {
+            "tenant_id": " TENANT_001 ",
+            "legal_book_id": " BOOK_001 ",
+            "portfolio_id": " PORTFOLIO_001 ",
+            "security_id": " SECURITY_001 ",
+            "lot_id": " LOT_001 ",
+        },
+        "earliest_affected_date": "2026-01-01",
+        "first_affected_transaction_id": " SELL_001 ",
+        "first_affected_transaction_timestamp": "2026-03-01T17:30:00+08:00",
+        "source_authority_event_content_hash": _HASH_B,
+        "profile_decisions": [
+            {
+                "effective_date": "2026-01-01",
+                "profile_id": " PROFILE_001 ",
+                "profile_version": 2,
+                "authority_content_hash": _HASH_B,
+                "eligibility_reason": None,
+            }
+        ],
+        "correlation_id": " correlation-1 ",
+        "traceparent": " 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01 ",
+    }
+
+
+def test_replay_event_normalizes_scope_timestamp_and_diagnostics() -> None:
+    event = FixedIncomeBookCostDisposalReplayRequestedEvent.model_validate(_event())
+
+    assert event.partition_key == ("TENANT_001|BOOK_001|PORTFOLIO_001|SECURITY_001|LOT_001")
+    assert event.first_affected_transaction_id == "SELL_001"
+    assert event.first_affected_transaction_timestamp.isoformat() == ("2026-03-01T09:30:00+00:00")
+    assert event.correlation_id == "correlation-1"
+    assert event.profile_decisions[0].profile_id == "PROFILE_001"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("event_type", "fixed_income.book_cost.authority.received"),
+        ("schema_version", "2.0.0"),
+        ("command_id", "not-a-hash"),
+        ("source_authority_event_content_hash", "not-a-hash"),
+        ("first_affected_transaction_timestamp", "2026-03-01T09:30:00"),
+    ),
+)
+def test_replay_event_rejects_wrong_or_malformed_contract_fields(
+    field: str,
+    value: object,
+) -> None:
+    payload = _event()
+    payload[field] = value
+
+    with pytest.raises(ValidationError):
+        FixedIncomeBookCostDisposalReplayRequestedEvent.model_validate(payload)
+
+
+def test_replay_event_rejects_noncanonical_or_duplicate_profile_decisions() -> None:
+    later = {
+        "effective_date": "2026-07-01",
+        "profile_id": "PROFILE_002",
+        "profile_version": 3,
+        "authority_content_hash": _HASH_A,
+        "eligibility_reason": "ASSIGNMENT_MISSING",
+    }
+    payload = _event()
+    payload["profile_decisions"] = [later, *payload["profile_decisions"]]  # type: ignore[misc]
+
+    with pytest.raises(ValidationError, match="canonical effective-date order"):
+        FixedIncomeBookCostDisposalReplayRequestedEvent.model_validate(payload)
+
+    duplicate = _event()
+    duplicate["profile_decisions"] = [
+        *duplicate["profile_decisions"],  # type: ignore[misc]
+        {
+            "effective_date": "2026-01-01",
+            "profile_id": "PROFILE_002",
+            "profile_version": 3,
+            "authority_content_hash": _HASH_A,
+            "eligibility_reason": None,
+        },
+    ]
+    with pytest.raises(ValidationError, match="unique effective dates"):
+        FixedIncomeBookCostDisposalReplayRequestedEvent.model_validate(duplicate)
+
+
+def test_replay_event_rejects_anchor_before_affected_boundary_and_unknown_fields() -> None:
+    before = _event()
+    before["earliest_affected_date"] = "2026-04-01"
+    with pytest.raises(ValidationError, match="cannot precede"):
+        FixedIncomeBookCostDisposalReplayRequestedEvent.model_validate(before)
+
+    extra = deepcopy(_event())
+    extra["unexpected"] = "value"
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        FixedIncomeBookCostDisposalReplayRequestedEvent.model_validate(extra)

--- a/tests/unit/libs/portfolio-common/test_config.py
+++ b/tests/unit/libs/portfolio-common/test_config.py
@@ -477,12 +477,14 @@ def test_active_topic_registry_has_explicit_source_owned_partition_counts():
         config_module.KAFKA_TOPIC_PARTITION_COUNTS["fixed_income.book_cost.authority.received"]
         == 12
     )
-    assert (
-        config_module.KAFKA_TOPIC_PARTITION_COUNTS[
-            "fixed_income.book_cost.disposal_replay.requested"
-        ]
-        == 12
+    replay_topic = next(
+        topic
+        for topic in config_module.KAFKA_TOPIC_DEFINITIONS
+        if topic.canonical_name == "fixed_income.book_cost.disposal_replay.requested"
     )
+    assert replay_topic.lifecycle_status == "inactive"
+    assert replay_topic.partition_count == 12
+    assert replay_topic.runtime_name not in config_module.KAFKA_TOPIC_PARTITION_COUNTS
     assert config_module.KAFKA_TOPIC_PARTITION_COUNTS["market_prices.raw.received"] == 12
     assert config_module.KAFKA_TOPIC_PARTITION_COUNTS["market_prices.persisted"] == 12
     assert config_module.KAFKA_TOPIC_PARTITION_COUNTS["transactions.reprocessing.requested"] == 8

--- a/tests/unit/libs/portfolio-common/test_config.py
+++ b/tests/unit/libs/portfolio-common/test_config.py
@@ -422,6 +422,10 @@ def test_canonical_topic_defaults_match_rfc_runtime_names(monkeypatch):
     monkeypatch.delenv("KAFKA_VALUATION_JOB_REQUESTED_TOPIC", raising=False)
     monkeypatch.delenv("KAFKA_TRANSACTIONS_PERSISTED_TOPIC", raising=False)
     monkeypatch.delenv("KAFKA_FIXED_INCOME_BOOK_COST_AUTHORITY_RECEIVED_TOPIC", raising=False)
+    monkeypatch.delenv(
+        "KAFKA_FIXED_INCOME_BOOK_COST_DISPOSAL_REPLAY_REQUESTED_TOPIC",
+        raising=False,
+    )
 
     import portfolio_common.config as config_module
 
@@ -432,6 +436,10 @@ def test_canonical_topic_defaults_match_rfc_runtime_names(monkeypatch):
     assert (
         reloaded.KAFKA_FIXED_INCOME_BOOK_COST_AUTHORITY_RECEIVED_TOPIC
         == "fixed_income.book_cost.authority.received"
+    )
+    assert (
+        reloaded.KAFKA_FIXED_INCOME_BOOK_COST_DISPOSAL_REPLAY_REQUESTED_TOPIC
+        == "fixed_income.book_cost.disposal_replay.requested"
     )
 
 
@@ -467,6 +475,12 @@ def test_active_topic_registry_has_explicit_source_owned_partition_counts():
     assert config_module.KAFKA_TOPIC_PARTITION_COUNTS["transactions.persisted"] == 12
     assert (
         config_module.KAFKA_TOPIC_PARTITION_COUNTS["fixed_income.book_cost.authority.received"]
+        == 12
+    )
+    assert (
+        config_module.KAFKA_TOPIC_PARTITION_COUNTS[
+            "fixed_income.book_cost.disposal_replay.requested"
+        ]
         == 12
     )
     assert config_module.KAFKA_TOPIC_PARTITION_COUNTS["market_prices.raw.received"] == 12

--- a/tests/unit/services/portfolio_transaction_processing_service/application/fixed_income_book_cost/test_authority_event_orchestration.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/application/fixed_income_book_cost/test_authority_event_orchestration.py
@@ -307,6 +307,7 @@ async def test_atomic_handler_stages_one_replay_for_earliest_affected_disposal()
     result = await HandleFixedIncomeBookCostAuthorityEventUseCase(
         unit_of_work_factory=lambda: unit_of_work,
         policies=AmortizedCostPolicyRegistry((resolved.policy,)),
+        correction_replay_enabled=True,
     ).execute(
         _basis_event(resolved.basis_fact),
         correlation_id="correlation-1",
@@ -334,6 +335,27 @@ async def test_atomic_handler_stages_one_replay_for_earliest_affected_disposal()
 
 
 @pytest.mark.asyncio
+async def test_atomic_handler_keeps_correction_replay_fail_closed_by_default() -> None:
+    authority, profiles = _dependencies()
+    resolved = resolved_fixed_income_book_cost_inputs()
+    authority.load.return_value = _bundle(basis_facts=(resolved.basis_fact,))
+    unit_of_work = _UnitOfWork(authority, profiles)
+    unit_of_work.correction_replay.find_earliest_affected_disposal.return_value = (
+        _affected_disposal_anchor()
+    )
+
+    result = await HandleFixedIncomeBookCostAuthorityEventUseCase(
+        unit_of_work_factory=lambda: unit_of_work,
+        policies=AmortizedCostPolicyRegistry((resolved.policy,)),
+    ).execute(_basis_event(resolved.basis_fact))
+
+    assert result.correction_replay_intent is None
+    unit_of_work.correction_replay.find_earliest_affected_disposal.assert_not_awaited()
+    unit_of_work.correction_replay.stage_replay_intent.assert_not_awaited()
+    assert unit_of_work.committed is True
+
+
+@pytest.mark.asyncio
 async def test_atomic_handler_does_not_stage_replay_without_affected_disposal() -> None:
     authority, profiles = _dependencies()
     resolved = resolved_fixed_income_book_cost_inputs()
@@ -343,6 +365,7 @@ async def test_atomic_handler_does_not_stage_replay_without_affected_disposal() 
     result = await HandleFixedIncomeBookCostAuthorityEventUseCase(
         unit_of_work_factory=lambda: unit_of_work,
         policies=AmortizedCostPolicyRegistry((resolved.policy,)),
+        correction_replay_enabled=True,
     ).execute(_basis_event(resolved.basis_fact))
 
     assert result.correction_replay_intent is None
@@ -367,6 +390,7 @@ async def test_atomic_handler_rolls_back_authority_when_replay_staging_fails() -
         await HandleFixedIncomeBookCostAuthorityEventUseCase(
             unit_of_work_factory=lambda: unit_of_work,
             policies=AmortizedCostPolicyRegistry((resolved.policy,)),
+            correction_replay_enabled=True,
         ).execute(_basis_event(resolved.basis_fact))
 
     assert unit_of_work.committed is False

--- a/tests/unit/services/portfolio_transaction_processing_service/application/fixed_income_book_cost/test_authority_event_orchestration.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/application/fixed_income_book_cost/test_authority_event_orchestration.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from datetime import date
+from datetime import UTC, date, datetime
 from unittest.mock import AsyncMock
 
 import pytest
@@ -14,10 +14,12 @@ from services.portfolio_transaction_processing_service.app.application.fixed_inc
     HandleFixedIncomeBookCostAuthorityEventUseCase,
 )
 from services.portfolio_transaction_processing_service.app.domain.fixed_income_book_cost import (
+    AffectedLotDisposalReplayAnchor,
     AmortizedCostEligibilityReason,
     AmortizedCostPolicyRegistry,
 )
 from services.portfolio_transaction_processing_service.app.ports import (
+    FixedIncomeBookCostCorrectionReplayPort,
     LotAmortizedCostAuthorityAppendOutcome,
     LotAmortizedCostAuthorityBundle,
     LotAmortizedCostAuthorityPort,
@@ -126,6 +128,8 @@ class _UnitOfWork:
     def __init__(self, authority, profiles) -> None:
         self.authority = authority
         self.profiles = profiles
+        self.correction_replay = AsyncMock(spec=FixedIncomeBookCostCorrectionReplayPort)
+        self.correction_replay.find_earliest_affected_disposal.return_value = None
         self.committed = False
         self.exit_error: BaseException | None = None
 
@@ -137,6 +141,13 @@ class _UnitOfWork:
 
     async def commit(self) -> None:
         self.committed = True
+
+
+def _affected_disposal_anchor() -> AffectedLotDisposalReplayAnchor:
+    return AffectedLotDisposalReplayAnchor(
+        transaction_id="SELL_001",
+        transaction_timestamp=datetime(2026, 3, 1, 9, 30, tzinfo=UTC),
+    )
 
 
 @pytest.mark.asyncio
@@ -281,6 +292,85 @@ async def test_atomic_handler_resolves_exact_policy_and_commits_active_profile()
     assert result.materialization.eligibility_reason is None
     assert profiles.append.await_args.args[0].policy_id == resolved.policy.policy_id
     assert authority.load.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_atomic_handler_stages_one_replay_for_earliest_affected_disposal() -> None:
+    authority, profiles = _dependencies()
+    resolved = resolved_fixed_income_book_cost_inputs()
+    authority.load.return_value = _bundle(basis_facts=(resolved.basis_fact,))
+    unit_of_work = _UnitOfWork(authority, profiles)
+    unit_of_work.correction_replay.find_earliest_affected_disposal.return_value = (
+        _affected_disposal_anchor()
+    )
+
+    result = await HandleFixedIncomeBookCostAuthorityEventUseCase(
+        unit_of_work_factory=lambda: unit_of_work,
+        policies=AmortizedCostPolicyRegistry((resolved.policy,)),
+    ).execute(
+        _basis_event(resolved.basis_fact),
+        correlation_id="correlation-1",
+        traceparent="00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+    )
+
+    unit_of_work.correction_replay.find_earliest_affected_disposal.assert_awaited_once_with(
+        resolved.basis_fact.scope,
+        effective_date=resolved.basis_fact.valid_from,
+    )
+    unit_of_work.correction_replay.stage_replay_intent.assert_awaited_once()
+    staged = unit_of_work.correction_replay.stage_replay_intent.await_args.args[0]
+    assert staged == result.correction_replay_intent
+    assert staged.anchor == _affected_disposal_anchor()
+    assert (
+        staged.source_authority_event_content_hash
+        == _basis_event(resolved.basis_fact).content_hash()
+    )
+    assert staged.profile_decisions[0].profile_id == result.materialization.profile_id
+    assert unit_of_work.correction_replay.stage_replay_intent.await_args.kwargs == {
+        "correlation_id": "correlation-1",
+        "traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+    }
+    assert unit_of_work.committed is True
+
+
+@pytest.mark.asyncio
+async def test_atomic_handler_does_not_stage_replay_without_affected_disposal() -> None:
+    authority, profiles = _dependencies()
+    resolved = resolved_fixed_income_book_cost_inputs()
+    authority.load.return_value = _bundle(basis_facts=(resolved.basis_fact,))
+    unit_of_work = _UnitOfWork(authority, profiles)
+
+    result = await HandleFixedIncomeBookCostAuthorityEventUseCase(
+        unit_of_work_factory=lambda: unit_of_work,
+        policies=AmortizedCostPolicyRegistry((resolved.policy,)),
+    ).execute(_basis_event(resolved.basis_fact))
+
+    assert result.correction_replay_intent is None
+    unit_of_work.correction_replay.stage_replay_intent.assert_not_awaited()
+    assert unit_of_work.committed is True
+
+
+@pytest.mark.asyncio
+async def test_atomic_handler_rolls_back_authority_when_replay_staging_fails() -> None:
+    authority, profiles = _dependencies()
+    resolved = resolved_fixed_income_book_cost_inputs()
+    authority.load.return_value = _bundle(basis_facts=(resolved.basis_fact,))
+    unit_of_work = _UnitOfWork(authority, profiles)
+    unit_of_work.correction_replay.find_earliest_affected_disposal.return_value = (
+        _affected_disposal_anchor()
+    )
+    unit_of_work.correction_replay.stage_replay_intent.side_effect = RuntimeError(
+        "outbox unavailable"
+    )
+
+    with pytest.raises(RuntimeError, match="outbox unavailable"):
+        await HandleFixedIncomeBookCostAuthorityEventUseCase(
+            unit_of_work_factory=lambda: unit_of_work,
+            policies=AmortizedCostPolicyRegistry((resolved.policy,)),
+        ).execute(_basis_event(resolved.basis_fact))
+
+    assert unit_of_work.committed is False
+    assert isinstance(unit_of_work.exit_error, RuntimeError)
 
 
 @pytest.mark.asyncio
@@ -439,6 +529,7 @@ async def test_exact_duplicate_assignment_does_not_broaden_replay_or_append_prof
     authority.load.reset_mock()
     profiles.append.reset_mock()
     profiles.effective_boundaries_from.reset_mock()
+    first_unit_of_work.correction_replay.reset_mock()
     duplicate_unit_of_work = _UnitOfWork(authority, profiles)
     duplicate_handler = HandleFixedIncomeBookCostAuthorityEventUseCase(
         unit_of_work_factory=lambda: duplicate_unit_of_work,
@@ -455,6 +546,8 @@ async def test_exact_duplicate_assignment_does_not_broaden_replay_or_append_prof
         effective_date=assignment.valid_from,
     )
     assert authority.load.await_count == 2
+    duplicate_unit_of_work.correction_replay.find_earliest_affected_disposal.assert_not_awaited()
+    duplicate_unit_of_work.correction_replay.stage_replay_intent.assert_not_awaited()
     assert duplicate_unit_of_work.committed is True
 
 

--- a/tests/unit/services/portfolio_transaction_processing_service/application/fixed_income_book_cost/test_correction_replay_mapping.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/application/fixed_income_book_cost/test_correction_replay_mapping.py
@@ -1,0 +1,95 @@
+"""Verify strict mapping for correction-triggered disposal replay."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+import pytest
+
+from services.portfolio_transaction_processing_service.app.application.fixed_income_book_cost import (  # noqa: E501
+    ConflictingFixedIncomeBookCostReplayCommandError,
+    fixed_income_book_cost_disposal_replay_event,
+    map_fixed_income_book_cost_disposal_replay_event,
+)
+from services.portfolio_transaction_processing_service.app.domain.fixed_income_book_cost import (
+    AffectedLotDisposalReplayAnchor,
+    AmortizedCostEligibilityReason,
+    FixedIncomeBookCostCorrectionReplayIntent,
+    FixedIncomeBookCostProfileDecisionEvidence,
+    LotBookCostAuthorityScope,
+)
+
+
+def _intent() -> FixedIncomeBookCostCorrectionReplayIntent:
+    return FixedIncomeBookCostCorrectionReplayIntent(
+        scope=LotBookCostAuthorityScope(
+            tenant_id="tenant-1",
+            legal_book_id="book-1",
+            portfolio_id="portfolio-1",
+            security_id="security-1",
+            lot_id="lot-1",
+        ),
+        earliest_affected_date=date(2026, 1, 1),
+        anchor=AffectedLotDisposalReplayAnchor(
+            transaction_id="sell-1",
+            transaction_timestamp=datetime(2026, 3, 1, 9, 30, tzinfo=UTC),
+        ),
+        source_authority_event_content_hash="a" * 64,
+        profile_decisions=(
+            FixedIncomeBookCostProfileDecisionEvidence(
+                effective_date=date(2026, 1, 1),
+                profile_id="profile-1",
+                profile_version=2,
+                authority_content_hash="b" * 64,
+                eligibility_reason=AmortizedCostEligibilityReason.ASSIGNMENT_MISSING,
+            ),
+        ),
+    )
+
+
+def test_round_trip_preserves_business_identity_and_diagnostics() -> None:
+    intent = _intent()
+
+    event = fixed_income_book_cost_disposal_replay_event(
+        intent,
+        correlation_id="correlation-1",
+        traceparent="00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+    )
+
+    assert event.command_id == intent.command_id
+    assert event.partition_key == "tenant-1|book-1|portfolio-1|security-1|lot-1"
+    assert event.correlation_id == "correlation-1"
+    assert map_fixed_income_book_cost_disposal_replay_event(event) == intent
+
+
+def test_diagnostics_do_not_change_business_command_identity() -> None:
+    intent = _intent()
+
+    first = fixed_income_book_cost_disposal_replay_event(
+        intent,
+        correlation_id="correlation-1",
+        traceparent=None,
+    )
+    second = fixed_income_book_cost_disposal_replay_event(
+        intent,
+        correlation_id="correlation-2",
+        traceparent="00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+    )
+
+    assert first.command_id == second.command_id == intent.command_id
+
+
+def test_mapping_rejects_command_identity_that_does_not_bind_payload() -> None:
+    event = fixed_income_book_cost_disposal_replay_event(
+        _intent(),
+        correlation_id=None,
+        traceparent=None,
+    )
+
+    with pytest.raises(
+        ConflictingFixedIncomeBookCostReplayCommandError,
+        match="does not match",
+    ):
+        map_fixed_income_book_cost_disposal_replay_event(
+            event.model_copy(update={"command_id": "c" * 64})
+        )

--- a/tests/unit/services/portfolio_transaction_processing_service/delivery/kafka/test_fixed_income_book_cost_authority_consumer.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/delivery/kafka/test_fixed_income_book_cost_authority_consumer.py
@@ -59,7 +59,13 @@ def _message(*, payload: object | None = None, key: bytes | None = None) -> Magi
         if key is not None
         else b"TENANT_SG|BOOK_SG_PB|AMORT_PORTFOLIO|AMORT_BOND_001|AMORT_LOT_001"
     )
-    message.headers.return_value = [("correlation_id", b"corr-book-cost-001")]
+    message.headers.return_value = [
+        ("correlation_id", b"corr-book-cost-001"),
+        (
+            "traceparent",
+            b"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+        ),
+    ]
     return message
 
 
@@ -80,6 +86,10 @@ async def test_valid_event_and_exact_partition_key_invoke_atomic_handler() -> No
     event = use_case.execute.await_args.args[0]
     assert event.authority.authority_type == "POLICY_ASSIGNMENT"
     assert event.authority.header.source.source_version == 1
+    assert use_case.execute.await_args.kwargs == {
+        "correlation_id": "corr-book-cost-001",
+        "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+    }
     use_case.execute.assert_awaited_once()
 
 

--- a/tests/unit/services/portfolio_transaction_processing_service/domain/fixed_income_book_cost/test_correction_replay.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/domain/fixed_income_book_cost/test_correction_replay.py
@@ -1,0 +1,152 @@
+"""Verify deterministic fixed-income correction replay intent identity."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, date, datetime, timedelta, timezone
+
+import pytest
+
+from services.portfolio_transaction_processing_service.app.domain.fixed_income_book_cost import (
+    AffectedLotDisposalReplayAnchor,
+    AmortizedCostEligibilityReason,
+    FixedIncomeBookCostCorrectionReplayIntent,
+    FixedIncomeBookCostProfileDecisionEvidence,
+    LotBookCostAuthorityScope,
+)
+
+_HASH_A = "a" * 64
+_HASH_B = "b" * 64
+_HASH_C = "c" * 64
+
+
+def _scope() -> LotBookCostAuthorityScope:
+    return LotBookCostAuthorityScope(
+        tenant_id="tenant-1",
+        legal_book_id="book-1",
+        portfolio_id="portfolio-1",
+        security_id="security-1",
+        lot_id="lot-1",
+    )
+
+
+def _decision(
+    effective_date: date = date(2026, 1, 1),
+    *,
+    profile_id: str = "profile-1",
+    profile_version: int = 2,
+    authority_content_hash: str = _HASH_B,
+) -> FixedIncomeBookCostProfileDecisionEvidence:
+    return FixedIncomeBookCostProfileDecisionEvidence(
+        effective_date=effective_date,
+        profile_id=profile_id,
+        profile_version=profile_version,
+        authority_content_hash=authority_content_hash,
+        eligibility_reason=None,
+    )
+
+
+def _intent() -> FixedIncomeBookCostCorrectionReplayIntent:
+    return FixedIncomeBookCostCorrectionReplayIntent(
+        scope=_scope(),
+        earliest_affected_date=date(2026, 1, 1),
+        anchor=AffectedLotDisposalReplayAnchor(
+            transaction_id="sell-1",
+            transaction_timestamp=datetime(2026, 3, 1, 9, 30, tzinfo=UTC),
+        ),
+        source_authority_event_content_hash=_HASH_A,
+        profile_decisions=(_decision(),),
+    )
+
+
+def test_command_identity_is_stable_across_decision_order_and_timezone_offsets() -> None:
+    first = _intent()
+    later = _decision(
+        date(2026, 7, 1),
+        profile_id="profile-2",
+        profile_version=3,
+        authority_content_hash=_HASH_C,
+    )
+    offset = timezone(timedelta(hours=8))
+    equivalent = replace(
+        first,
+        anchor=AffectedLotDisposalReplayAnchor(
+            transaction_id="sell-1",
+            transaction_timestamp=datetime(2026, 3, 1, 17, 30, tzinfo=offset),
+        ),
+        profile_decisions=(later, first.profile_decisions[0]),
+    )
+    canonical = replace(first, profile_decisions=(first.profile_decisions[0], later))
+
+    assert equivalent.profile_decisions == canonical.profile_decisions
+    assert equivalent.command_id == canonical.command_id
+    assert len(canonical.command_id) == 64
+
+
+@pytest.mark.parametrize(
+    "changed",
+    (
+        {"source_authority_event_content_hash": _HASH_C},
+        {"earliest_affected_date": date(2026, 2, 1)},
+        {
+            "anchor": AffectedLotDisposalReplayAnchor(
+                transaction_id="sell-2",
+                transaction_timestamp=datetime(2026, 3, 1, 9, 30, tzinfo=UTC),
+            )
+        },
+        {"profile_decisions": (_decision(profile_version=3),)},
+    ),
+)
+def test_command_identity_changes_with_business_replay_evidence(changed: dict[str, object]) -> None:
+    original = _intent()
+
+    assert replace(original, **changed).command_id != original.command_id
+
+
+def test_profile_decision_preserves_fail_closed_eligibility_evidence() -> None:
+    decision = replace(
+        _decision(),
+        eligibility_reason=AmortizedCostEligibilityReason.ASSIGNMENT_CONFLICTING,
+    )
+
+    intent = replace(_intent(), profile_decisions=(decision,))
+
+    assert intent.profile_decisions[0].eligibility_reason is (
+        AmortizedCostEligibilityReason.ASSIGNMENT_CONFLICTING
+    )
+    assert len(intent.command_id) == 64
+
+
+def test_anchor_requires_aware_timestamp() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        AffectedLotDisposalReplayAnchor(
+            transaction_id="sell-1",
+            transaction_timestamp=datetime(2026, 3, 1, 9, 30),
+        )
+
+
+def test_intent_rejects_anchor_before_affected_boundary() -> None:
+    with pytest.raises(ValueError, match="cannot precede"):
+        replace(
+            _intent(),
+            earliest_affected_date=date(2026, 4, 1),
+        )
+
+
+def test_intent_rejects_empty_or_duplicate_profile_decisions() -> None:
+    with pytest.raises(ValueError, match="must not be empty"):
+        replace(_intent(), profile_decisions=())
+
+    with pytest.raises(ValueError, match="unique effective dates"):
+        replace(
+            _intent(),
+            profile_decisions=(
+                _decision(),
+                _decision(profile_id="profile-2", profile_version=3),
+            ),
+        )
+
+
+def test_intent_rejects_malformed_evidence_hash() -> None:
+    with pytest.raises(ValueError, match="SHA-256"):
+        replace(_intent(), source_authority_event_content_hash="not-a-hash")

--- a/tests/unit/services/portfolio_transaction_processing_service/infrastructure/fixed_income_book_cost/test_correction_replay_repository.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/infrastructure/fixed_income_book_cost/test_correction_replay_repository.py
@@ -1,0 +1,149 @@
+"""Verify bounded SQL selection and transactional staging for correction replay."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from portfolio_common.outbox_repository import OutboxRepository
+from sqlalchemy.dialects import postgresql
+
+from services.portfolio_transaction_processing_service.app.domain.fixed_income_book_cost import (
+    AffectedLotDisposalReplayAnchor,
+    FixedIncomeBookCostCorrectionReplayIntent,
+    FixedIncomeBookCostProfileDecisionEvidence,
+    LotBookCostAuthorityScope,
+)
+from services.portfolio_transaction_processing_service.app.infrastructure.fixed_income_book_cost.correction_replay_repository import (  # noqa: E501
+    SqlAlchemyFixedIncomeBookCostCorrectionReplayRepository,
+    _earliest_affected_disposal_statement,
+)
+
+
+def _scope() -> LotBookCostAuthorityScope:
+    return LotBookCostAuthorityScope(
+        tenant_id="tenant-1",
+        legal_book_id="book-1",
+        portfolio_id="portfolio-1",
+        security_id="security-1",
+        lot_id="lot-1",
+    )
+
+
+def _intent() -> FixedIncomeBookCostCorrectionReplayIntent:
+    return FixedIncomeBookCostCorrectionReplayIntent(
+        scope=_scope(),
+        earliest_affected_date=date(2026, 1, 1),
+        anchor=AffectedLotDisposalReplayAnchor(
+            transaction_id="sell-1",
+            transaction_timestamp=datetime(2026, 3, 1, 9, 30, tzinfo=UTC),
+        ),
+        source_authority_event_content_hash="a" * 64,
+        profile_decisions=(
+            FixedIncomeBookCostProfileDecisionEvidence(
+                effective_date=date(2026, 1, 1),
+                profile_id="profile-1",
+                profile_version=2,
+                authority_content_hash="b" * 64,
+                eligibility_reason=None,
+            ),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_finds_earliest_affected_disposal_anchor() -> None:
+    session = AsyncMock()
+    result = MagicMock()
+    result.first.return_value = SimpleNamespace(
+        transaction_id="sell-1",
+        transaction_date=datetime(2026, 3, 1, 9, 30, tzinfo=UTC),
+    )
+    session.execute.return_value = result
+    repository = SqlAlchemyFixedIncomeBookCostCorrectionReplayRepository(
+        session,
+        topic="fixed_income.book_cost.disposal_replay.requested",
+    )
+
+    anchor = await repository.find_earliest_affected_disposal(
+        _scope(),
+        effective_date=date(2026, 1, 1),
+    )
+
+    assert anchor == AffectedLotDisposalReplayAnchor(
+        transaction_id="sell-1",
+        transaction_timestamp=datetime(2026, 3, 1, 9, 30, tzinfo=UTC),
+    )
+    session.execute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_no_current_disposal_uses_source_lot() -> None:
+    session = AsyncMock()
+    result = MagicMock()
+    result.first.return_value = None
+    session.execute.return_value = result
+    repository = SqlAlchemyFixedIncomeBookCostCorrectionReplayRepository(
+        session,
+        topic="fixed_income.book_cost.disposal_replay.requested",
+    )
+
+    assert (
+        await repository.find_earliest_affected_disposal(
+            _scope(),
+            effective_date=date(2026, 1, 1),
+        )
+        is None
+    )
+
+
+def test_anchor_query_is_latest_active_exact_scope_ordered_and_bounded() -> None:
+    statement = _earliest_affected_disposal_statement(
+        _scope(),
+        effective_date=date(2026, 1, 1),
+    )
+
+    sql = str(
+        statement.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+
+    assert "max(lot_disposal_receipts.receipt_version)" in sql
+    assert "lot_disposal_receipts.status = 'ACTIVE'" in sql
+    assert "portfolios.tenant_id = 'tenant-1'" in sql
+    assert "portfolios.legal_book_id = 'book-1'" in sql
+    assert "lot_disposal_allocations.source_lot_id = 'lot-1'" in sql
+    assert "transactions.transaction_date >= '2026-01-01 00:00:00+00:00'" in sql
+    assert "ORDER BY transactions.transaction_date ASC, transactions.transaction_id ASC" in sql
+    assert "LIMIT 1" in sql
+
+
+@pytest.mark.asyncio
+async def test_stages_one_source_lot_keyed_outbox_event() -> None:
+    session = AsyncMock()
+    outbox = AsyncMock(spec=OutboxRepository)
+    repository = SqlAlchemyFixedIncomeBookCostCorrectionReplayRepository(
+        session,
+        topic=" fixed_income.book.cost.replay ",
+        outbox_repository=outbox,
+    )
+    intent = _intent()
+
+    await repository.stage_replay_intent(
+        intent,
+        correlation_id="correlation-1",
+        traceparent="00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+    )
+
+    outbox.create_outbox_event.assert_awaited_once()
+    call = outbox.create_outbox_event.await_args.kwargs
+    assert call["aggregate_id"] == intent.command_id
+    assert call["event_type"] == "fixed_income.book_cost.disposal_replay.requested"
+    assert call["topic"] == "fixed_income.book.cost.replay"
+    assert call["partition_key"] == "tenant-1|book-1|portfolio-1|security-1|lot-1"
+    assert call["payload"]["command_id"] == intent.command_id
+    assert call["correlation_id"] == "correlation-1"

--- a/tests/unit/services/portfolio_transaction_processing_service/infrastructure/fixed_income_book_cost/test_unit_of_work.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/infrastructure/fixed_income_book_cost/test_unit_of_work.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, AsyncSessionTransaction
 
 from services.portfolio_transaction_processing_service.app.infrastructure.fixed_income_book_cost import (  # noqa: E501
     SqlAlchemyFixedIncomeBookCostAuthorityUnitOfWork,
+    SqlAlchemyFixedIncomeBookCostCorrectionReplayRepository,
     SqlAlchemyLotAmortizedCostAuthorityRepository,
     SqlAlchemyLotAmortizedCostProfileRepository,
 )
@@ -32,8 +33,13 @@ async def test_builds_both_adapters_on_one_session_and_commits_once() -> None:
     async with unit_of_work as entered:
         assert isinstance(entered.authority, SqlAlchemyLotAmortizedCostAuthorityRepository)
         assert isinstance(entered.profiles, SqlAlchemyLotAmortizedCostProfileRepository)
+        assert isinstance(
+            entered.correction_replay,
+            SqlAlchemyFixedIncomeBookCostCorrectionReplayRepository,
+        )
         assert entered.authority._session is session
         assert entered.profiles._session is session
+        assert entered.correction_replay._session is session
         await entered.commit()
 
     transaction.start.assert_awaited_once_with()
@@ -65,6 +71,8 @@ async def test_rejects_adapter_access_before_entry_and_second_commit() -> None:
         _ = unit_of_work.authority
     with pytest.raises(RuntimeError, match="profiles adapter is not initialized"):
         _ = unit_of_work.profiles
+    with pytest.raises(RuntimeError, match="correction replay adapter is not initialized"):
+        _ = unit_of_work.correction_replay
 
     async with unit_of_work:
         await unit_of_work.commit()

--- a/tests/unit/services/portfolio_transaction_processing_service/runtime/test_dependency_composition.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/runtime/test_dependency_composition.py
@@ -157,6 +157,16 @@ def test_fixed_income_authority_builder_uses_fresh_unit_of_work_and_governed_cat
     assert isinstance(second, SqlAlchemyFixedIncomeBookCostAuthorityUnitOfWork)
     assert first is not second
     assert first._session_factory is second._session_factory is session_factory
+    assert use_case._correction_replay_enabled is False
     assert tuple(
         (identity.policy_id, identity.policy_version) for identity in use_case._policies.identities
     ) == (("IFRS9_EIR_LOCAL", 1), ("STRAIGHT_LINE_LOCAL", 1))
+
+
+def test_fixed_income_authority_builder_requires_explicit_replay_activation() -> None:
+    use_case = build_fixed_income_book_cost_authority_use_case(
+        session_factory=MagicMock(spec=lambda: AsyncSession()),
+        correction_replay_enabled=True,
+    )
+
+    assert use_case._correction_replay_enabled is True


### PR DESCRIPTION
## Summary
- add a domain-owned deterministic fixed-income disposal replay intent and strict `fixed_income.book_cost.disposal_replay.requested@1.0.0` contract
- select the earliest affected active disposal in one bounded query and stage one source-lot-keyed command through the existing transactional outbox
- wire authority/profile/outbox work into one SQL unit of work while keeping both replay emission and the replay topic fail-closed until the consumer and suffix-rebuild acceptance proof are complete

## Why
- #903 requires durable correction-triggered replay before amortized-disposal economics can be activated
- this independently tested foundation preserves domain/event/UoW contracts without exposing an unconsumed production command path

## Scope
- [x] Single issue slice: partial foundation for #903; does not close #903
- [x] No unrelated refactors mixed in

## Validation (local)
- [x] 157 focused replay/event/UoW/config tests warning-strict
- [x] final default-off/topic-inactive cohort: 70 passed warning-strict
- [x] `make lint typecheck architecture-guard event-runtime-contract-guard event-contract-test-pack-guard test-unit`
- [x] full unit manifest: 6,924 passed, 12 deselected in 491.52s
- [x] all nine commits signed; exact-head diff hygiene and clean worktree passed

## CI Expectations
- [x] Quality Baseline green at exact head before ready transition; ready-transition rerun active
- [x] Remote Feature Lane implementation suites green at exact head
- [x] Pull Request Merge Gate unit/DB/integration/lifecycle/transaction suites green at exact head
- [ ] combined coverage and final ready-state checks green

## Governance/Docs
- [x] No public API/OpenAPI, schema/migration, existing topic/key, transaction vocabulary, or runtime activation change
- [x] No documentation/wiki source change: this slice is fail-closed and introduces no operator-supported behavior; #903 remains the durable execution record for consumer, recovery/poison, downstream, and load proof
- [x] No runtime split: domain/application/adapter modules stay inside portfolio transaction processing

## Compatibility and remaining work
- correction replay is disabled by default and cannot query or emit in production composition
- the dedicated command topic is inactive and excluded from runtime provisioning/active partition maps
- the amortized-disposal production overlay remains disabled
- #903 remains open for the dedicated consumer, atomic idempotent suffix rebuild, crash/poison/duplicate/no-op/reversal/void proof, bounded-load proof, historical catch-up posture, and activation decision

## Post-Merge Hygiene
- [ ] Delete remote feature branch
- [ ] Delete local feature branch
- [ ] Sync local main with origin/main (`local = remote = main`)

Related: #903