### PR TITLE
test(openapi): select redemption conditions semantically

### DIFF
--- a/tests/integration/services/ingestion_service/test_ingestion_main_app_contract.py
+++ b/tests/integration/services/ingestion_service/test_ingestion_main_app_contract.py
@@ -1,3 +1,4 @@
+import re
 from time import time
 from unittest.mock import MagicMock, patch
 
@@ -904,16 +905,31 @@ async def test_openapi_describes_transaction_core_shared_schema(async_test_clien
     )
     gross_amount_property = transaction["properties"]["gross_transaction_amount"]
     assert gross_amount_property["anyOf"][0] == {"minimum": 0.0, "type": "number"}
-    gross_amount_condition = transaction["allOf"][-1]
-    assert gross_amount_condition["if"] == {
-        "properties": {
-            "transaction_type": {
-                "enum": ["CALL_REDEMPTION", "MATURITY_REDEMPTION", "PARTIAL_REDEMPTION"]
-            },
-            "price": {"const": 0},
-        },
-        "required": ["transaction_type", "price"],
-    }
+    gross_amount_conditions = [
+        clause
+        for clause in transaction["allOf"]
+        if clause.get("if", {}).get("properties", {}).get("price") == {"const": 0}
+    ]
+    assert len(gross_amount_conditions) == 1
+    gross_amount_condition = gross_amount_conditions[0]
+    gross_amount_if = gross_amount_condition["if"]
+    assert gross_amount_if["required"] == ["transaction_type", "price"]
+    assert gross_amount_if["properties"]["price"] == {"const": 0}
+    transaction_type_patterns = [
+        alternative["pattern"]
+        for alternative in gross_amount_if["properties"]["transaction_type"]["anyOf"]
+    ]
+    assert len(transaction_type_patterns) == 3
+    for transaction_type in (
+        "CALL_REDEMPTION",
+        "MATURITY_REDEMPTION",
+        "PARTIAL_REDEMPTION",
+    ):
+        assert any(
+            re.fullmatch(pattern, f" {transaction_type.lower()} ")
+            for pattern in transaction_type_patterns
+        )
+    assert not any(re.fullmatch(pattern, "BUY") for pattern in transaction_type_patterns)
     assert gross_amount_condition["then"]["properties"]["gross_transaction_amount"] == {
         "minimum": 0
     }

--- a/tests/integration/services/ingestion_service/test_ingestion_main_app_contract.py
+++ b/tests/integration/services/ingestion_service/test_ingestion_main_app_contract.py
@@ -8,6 +8,7 @@ import pytest_asyncio
 from portfolio_common.domain.transaction.numeric_policy import (
     TRANSACTION_COMMAND_DECIMAL_FIELDS,
 )
+from portfolio_common.domain.transaction.type_registry import TRANSACTION_TYPE_CODES
 from portfolio_common.enterprise_readiness import (
     _enterprise_auth_context_signature,
     _normalize_headers,
@@ -920,16 +921,21 @@ async def test_openapi_describes_transaction_core_shared_schema(async_test_clien
         for alternative in gross_amount_if["properties"]["transaction_type"]["anyOf"]
     ]
     assert len(transaction_type_patterns) == 3
-    for transaction_type in (
+    redemption_transaction_types = {
         "CALL_REDEMPTION",
         "MATURITY_REDEMPTION",
         "PARTIAL_REDEMPTION",
-    ):
+    }
+    for transaction_type in redemption_transaction_types:
         assert any(
             re.fullmatch(pattern, f" {transaction_type.lower()} ")
             for pattern in transaction_type_patterns
         )
-    assert not any(re.fullmatch(pattern, "BUY") for pattern in transaction_type_patterns)
+    for transaction_type in TRANSACTION_TYPE_CODES - redemption_transaction_types:
+        assert not any(
+            re.fullmatch(pattern, f" {transaction_type.lower()} ")
+            for pattern in transaction_type_patterns
+        )
     assert gross_amount_condition["then"]["properties"]["gross_transaction_amount"] == {
         "minimum": 0
     }


### PR DESCRIPTION
## Objective
Fix the exact-main integration failure caused by positional selection of an OpenAPI allOf clause.

## Measurable improvement
- selects the unique zero-price redemption condition by semantic predicate instead of list position
- validates normalized redemption transaction-type patterns and rejects unrelated BUY
- removes the only remaining positional allOf condition lookup found in the test suite

## Compatibility impact
Test-only. No runtime, API, schema, database, Kafka, documentation, or wiki truth changes.

## Validation
- 34 ingestion main-app integration contract tests passed with warnings as errors
- 100 transaction-model unit tests passed with warnings as errors
- targeted Ruff passed
- git diff check passed

## Evidence
Fixes the deterministic failure in exact-main run 31253739726 at merge SHA f905828eb77a7d4eae164b9c2a5bed519e3fb8a3. No new issue: this is direct completion work for merged PR #916 and issues #911, #912, #913.

## Documentation/wiki
Explicit no-change decision: only test selection semantics changed; published product/operator truth remains accurate.