### PR TITLE
test(migrations): restore dependent graph rollback proof

### DIFF
--- a/tests/integration/test_lot_amortized_cost_profile_migration.py
+++ b/tests/integration/test_lot_amortized_cost_profile_migration.py
@@ -50,6 +50,12 @@ BASIS_TRANSFER_MIGRATION = (
     / "versions"
     / "c146b2c3d513_feat_add_lot_basis_transfer_receipts.py"
 )
+CORPORATE_ACTION_GRAPH_MIGRATION = (
+    Path(__file__).resolve().parents[2]
+    / "alembic"
+    / "versions"
+    / "c152b2c3d519_feat_add_corporate_action_event_graph.py"
+)
 
 PROFILE_INSERT = text(
     """
@@ -174,6 +180,7 @@ def _downgrade_later_revisions(connection) -> list[dict[str, Any]]:
 
     later_migrations: list[dict[str, Any]] = []
     for table_name, marker_column, migration_path in (
+        ("corporate_action_events", None, CORPORATE_ACTION_GRAPH_MIGRATION),
         ("lot_basis_transfer_allocations", None, BASIS_TRANSFER_MIGRATION),
         ("position_lot_state", "amortized_cost_profile_id", RESIDUAL_CARRY_MIGRATION),
         ("lot_disposal_allocations", "amortized_cost_profile_id", DISPOSAL_EVIDENCE_MIGRATION),

--- a/tests/integration/test_portfolio_valuation_book_scope_migration.py
+++ b/tests/integration/test_portfolio_valuation_book_scope_migration.py
@@ -56,6 +56,12 @@ BASIS_TRANSFER_MIGRATION = (
     / "versions"
     / "c146b2c3d513_feat_add_lot_basis_transfer_receipts.py"
 )
+CORPORATE_ACTION_GRAPH_MIGRATION = (
+    Path(__file__).resolve().parents[2]
+    / "alembic"
+    / "versions"
+    / "c152b2c3d519_feat_add_corporate_action_event_graph.py"
+)
 
 PORTFOLIO_INSERT = text(
     """
@@ -101,6 +107,14 @@ def _downgrade_dependent_schema(connection) -> list[dict[str, Any]]:
 
     dependent_migrations: list[dict[str, Any]] = []
     inspector = inspect(connection)
+    if inspector.has_table("corporate_action_events"):
+        corporate_action_graph_migration: dict[str, Any] = runpy.run_path(
+            str(CORPORATE_ACTION_GRAPH_MIGRATION)
+        )
+        _bind_operations(corporate_action_graph_migration, connection)
+        corporate_action_graph_migration["downgrade"]()
+        dependent_migrations.append(corporate_action_graph_migration)
+        inspector = inspect(connection)
     if inspector.has_table("lot_basis_transfer_allocations"):
         basis_transfer_migration: dict[str, Any] = runpy.run_path(str(BASIS_TRANSFER_MIGRATION))
         _bind_operations(basis_transfer_migration, connection)


### PR DESCRIPTION
## Objective

Restore exact-main full-integration rollback proof after PR #932 introduced `fk_ca_event_book_scope`, which correctly depends on `uq_portfolios_book_scope_identity`.

Contributes to #450 closure; does not close #933.

## Measurable improvement

- fixes both and only both migration harnesses that drop the portfolio book-scope unique constraint;
- downgrades the current corporate-action graph migration before exercising older rollback boundaries;
- reapplies the graph migration last, preserving the original database state inside the transactional tests;
- turns the observed mainline result from 2 failures / 1,092 passes into 2/2 focused PostgreSQL passes locally.

## Compatibility

Test-harness-only change. No application code, migration DDL, API/OpenAPI, Kafka, dependency, image, pool, topology, calculation, or operator contract changes.

## Validation

Exact signed head `7a0fece9bf192ac5d8f23f668a37d79b1d9ca80e`:

- reproduced exact-main Integration Full failure in run `31440552163`, job `93629405150`;
- focused real-PostgreSQL rollback proof: 2/2 passed in 37.58s;
- same-pattern search found no additional integration rollback harness dropping `uq_portfolios_book_scope_identity`;
- repository Ruff/format, migration smoke, and `git diff --check` passed.

## Documentation and wiki

Explicit no-change decision: this restores test dependency ordering and does not change architecture, operator behavior, or authored wiki truth.