### PR TITLE
test(migrations): restore exact-main rollback coverage

### DIFF
--- a/tests/integration/services/query_control_plane_service/test_control_plane_app.py
+++ b/tests/integration/services/query_control_plane_service/test_control_plane_app.py
@@ -307,7 +307,7 @@ async def test_openapi_describes_operations_support_parameters(async_test_client
     corporate_action_parameters = {
         parameter["name"]: parameter for parameter in corporate_actions["parameters"]
     }
-    assert corporate_action_parameters["X-Tenant-Id"]["in"] == "header"
+    assert corporate_action_parameters["x-tenant-id"]["in"] == "header"
     assert corporate_action_parameters["tenant_id"]["required"] is True
     assert corporate_action_parameters["legal_book_id"]["required"] is True
     assert corporate_action_parameters["limit"]["schema"]["maximum"] == 100

--- a/tests/integration/test_lot_amortized_cost_profile_migration.py
+++ b/tests/integration/test_lot_amortized_cost_profile_migration.py
@@ -56,6 +56,14 @@ CORPORATE_ACTION_GRAPH_MIGRATION = (
     / "versions"
     / "c152b2c3d519_feat_add_corporate_action_event_graph.py"
 )
+CORPORATE_ACTION_DEPENDENT_MIGRATIONS = tuple(
+    Path(__file__).resolve().parents[2] / "alembic" / "versions" / filename
+    for filename in (
+        "c155b2c3d522_fix_forward_corporate_action_authority.py",
+        "c154b2c3d521_perf_index_corporate_action_support.py",
+        "c153b2c3d520_feat_add_corporate_action_execution_releases.py",
+    )
+)
 
 PROFILE_INSERT = text(
     """
@@ -179,6 +187,12 @@ def _downgrade_later_revisions(connection) -> list[dict[str, Any]]:
     """Remove dependent revisions newest-first before exercising the profile schema."""
 
     later_migrations: list[dict[str, Any]] = []
+    if inspect(connection).has_table("corporate_action_execution_releases"):
+        for migration_path in CORPORATE_ACTION_DEPENDENT_MIGRATIONS:
+            later_migration = runpy.run_path(str(migration_path))
+            _bind_operations(later_migration, connection)
+            later_migration["downgrade"]()
+            later_migrations.append(later_migration)
     for table_name, marker_column, migration_path in (
         ("corporate_action_events", None, CORPORATE_ACTION_GRAPH_MIGRATION),
         ("lot_basis_transfer_allocations", None, BASIS_TRANSFER_MIGRATION),

--- a/tests/integration/test_portfolio_valuation_book_scope_migration.py
+++ b/tests/integration/test_portfolio_valuation_book_scope_migration.py
@@ -62,6 +62,14 @@ CORPORATE_ACTION_GRAPH_MIGRATION = (
     / "versions"
     / "c152b2c3d519_feat_add_corporate_action_event_graph.py"
 )
+CORPORATE_ACTION_DEPENDENT_MIGRATIONS = tuple(
+    Path(__file__).resolve().parents[2] / "alembic" / "versions" / filename
+    for filename in (
+        "c155b2c3d522_fix_forward_corporate_action_authority.py",
+        "c154b2c3d521_perf_index_corporate_action_support.py",
+        "c153b2c3d520_feat_add_corporate_action_execution_releases.py",
+    )
+)
 
 PORTFOLIO_INSERT = text(
     """
@@ -107,6 +115,13 @@ def _downgrade_dependent_schema(connection) -> list[dict[str, Any]]:
 
     dependent_migrations: list[dict[str, Any]] = []
     inspector = inspect(connection)
+    if inspector.has_table("corporate_action_execution_releases"):
+        for migration_path in CORPORATE_ACTION_DEPENDENT_MIGRATIONS:
+            dependent_migration = runpy.run_path(str(migration_path))
+            _bind_operations(dependent_migration, connection)
+            dependent_migration["downgrade"]()
+            dependent_migrations.append(dependent_migration)
+        inspector = inspect(connection)
     if inspector.has_table("corporate_action_events"):
         corporate_action_graph_migration: dict[str, Any] = runpy.run_path(
             str(CORPORATE_ACTION_GRAPH_MIGRATION)


### PR DESCRIPTION
## Objective
Restore exact-main releasability after PR #935 by keeping historical migration rollback tests aligned with the new corporate-action revision chain and with generated OpenAPI truth.

## Change
- downgrade c155, c154, and c153 newest-first before c152 in both affected historical rollback proofs;
- assert the canonical generated OpenAPI header name `x-tenant-id`;
- no production runtime, migration, API, dependency, image, or topology change.

## Evidence
- exact three previously failing tests: 3 passed in 66.57s;
- scoped Ruff and format checks passed;
- signed commit `cbdef0e8e`.

## Compatibility
Test-only correction. Runtime and persisted contracts are unchanged.