### PR TITLE
fix(runtime): restore exact-main restart resilience

### DIFF
--- a/src/services/portfolio_transaction_processing_service/app/runtime/corporate_action_release_worker.py
+++ b/src/services/portfolio_transaction_processing_service/app/runtime/corporate_action_release_worker.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 _RETRYABLE_DATABASE_ERRORS = (
     SQLAlchemyError,
+    ConnectionError,
     PostgresConnectionError,
     CannotConnectNowError,
     AdminShutdownError,

--- a/src/services/portfolio_transaction_processing_service/app/runtime/corporate_action_release_worker.py
+++ b/src/services/portfolio_transaction_processing_service/app/runtime/corporate_action_release_worker.py
@@ -7,7 +7,13 @@ import logging
 from collections.abc import Callable
 from time import monotonic
 
-from asyncpg import OperatorInterventionError, PostgresConnectionError, TooManyConnectionsError
+from asyncpg import (
+    AdminShutdownError,
+    CannotConnectNowError,
+    CrashShutdownError,
+    PostgresConnectionError,
+    TooManyConnectionsError,
+)
 from sqlalchemy.exc import SQLAlchemyError
 
 from ..application import (
@@ -26,7 +32,9 @@ logger = logging.getLogger(__name__)
 _RETRYABLE_DATABASE_ERRORS = (
     SQLAlchemyError,
     PostgresConnectionError,
-    OperatorInterventionError,
+    CannotConnectNowError,
+    AdminShutdownError,
+    CrashShutdownError,
     TooManyConnectionsError,
 )
 

--- a/src/services/portfolio_transaction_processing_service/app/runtime/corporate_action_release_worker.py
+++ b/src/services/portfolio_transaction_processing_service/app/runtime/corporate_action_release_worker.py
@@ -7,6 +7,7 @@ import logging
 from collections.abc import Callable
 from time import monotonic
 
+from asyncpg import OperatorInterventionError, PostgresConnectionError, TooManyConnectionsError
 from sqlalchemy.exc import SQLAlchemyError
 
 from ..application import (
@@ -21,6 +22,13 @@ from ..ports.corporate_action_release_observability import (
 )
 
 logger = logging.getLogger(__name__)
+
+_RETRYABLE_DATABASE_ERRORS = (
+    SQLAlchemyError,
+    PostgresConnectionError,
+    OperatorInterventionError,
+    TooManyConnectionsError,
+)
 
 
 class CorporateActionReleaseWorker:
@@ -62,7 +70,7 @@ class CorporateActionReleaseWorker:
                 )
                 await self._wait(self._retry_backoff_seconds)
                 continue
-            except SQLAlchemyError:
+            except _RETRYABLE_DATABASE_ERRORS:
                 self._observe_cycle(
                     CorporateActionReleaseCycleOutcome.DATABASE_ERROR,
                     started_at,

--- a/tests/integration/test_lot_amortized_cost_profile_migration.py
+++ b/tests/integration/test_lot_amortized_cost_profile_migration.py
@@ -187,8 +187,28 @@ def _downgrade_later_revisions(connection) -> list[dict[str, Any]]:
     """Remove dependent revisions newest-first before exercising the profile schema."""
 
     later_migrations: list[dict[str, Any]] = []
-    if inspect(connection).has_table("corporate_action_execution_releases"):
-        for migration_path in CORPORATE_ACTION_DEPENDENT_MIGRATIONS:
+    for migration_path, revision_is_present in (
+        (
+            CORPORATE_ACTION_DEPENDENT_MIGRATIONS[0],
+            connection.scalar(
+                text("SELECT to_regprocedure('enforce_ca_manifest_payload_book_scope()')")
+            )
+            is not None,
+        ),
+        (
+            CORPORATE_ACTION_DEPENDENT_MIGRATIONS[1],
+            inspect(connection).has_table("corporate_action_events")
+            and any(
+                index["name"] == "ix_ca_event_book_scope_updated"
+                for index in inspect(connection).get_indexes("corporate_action_events")
+            ),
+        ),
+        (
+            CORPORATE_ACTION_DEPENDENT_MIGRATIONS[2],
+            inspect(connection).has_table("corporate_action_execution_releases"),
+        ),
+    ):
+        if revision_is_present:
             later_migration = runpy.run_path(str(migration_path))
             _bind_operations(later_migration, connection)
             later_migration["downgrade"]()

--- a/tests/integration/test_portfolio_valuation_book_scope_migration.py
+++ b/tests/integration/test_portfolio_valuation_book_scope_migration.py
@@ -114,14 +114,33 @@ def _downgrade_dependent_schema(connection) -> list[dict[str, Any]]:
     """Downgrade later schema that deliberately references valuation-book scope."""
 
     dependent_migrations: list[dict[str, Any]] = []
-    inspector = inspect(connection)
-    if inspector.has_table("corporate_action_execution_releases"):
-        for migration_path in CORPORATE_ACTION_DEPENDENT_MIGRATIONS:
+    for migration_path, revision_is_present in (
+        (
+            CORPORATE_ACTION_DEPENDENT_MIGRATIONS[0],
+            connection.scalar(
+                text("SELECT to_regprocedure('enforce_ca_manifest_payload_book_scope()')")
+            )
+            is not None,
+        ),
+        (
+            CORPORATE_ACTION_DEPENDENT_MIGRATIONS[1],
+            inspect(connection).has_table("corporate_action_events")
+            and any(
+                index["name"] == "ix_ca_event_book_scope_updated"
+                for index in inspect(connection).get_indexes("corporate_action_events")
+            ),
+        ),
+        (
+            CORPORATE_ACTION_DEPENDENT_MIGRATIONS[2],
+            inspect(connection).has_table("corporate_action_execution_releases"),
+        ),
+    ):
+        if revision_is_present:
             dependent_migration = runpy.run_path(str(migration_path))
             _bind_operations(dependent_migration, connection)
             dependent_migration["downgrade"]()
             dependent_migrations.append(dependent_migration)
-        inspector = inspect(connection)
+    inspector = inspect(connection)
     if inspector.has_table("corporate_action_events"):
         corporate_action_graph_migration: dict[str, Any] = runpy.run_path(
             str(CORPORATE_ACTION_GRAPH_MIGRATION)

--- a/tests/unit/services/portfolio_transaction_processing_service/runtime/test_corporate_action_release_worker.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/runtime/test_corporate_action_release_worker.py
@@ -74,10 +74,16 @@ async def test_stop_allows_in_flight_member_to_finish_before_exit() -> None:
     "database_error",
     [
         SQLAlchemyError("database unavailable"),
+        ConnectionRefusedError("database socket unavailable"),
         CannotConnectNowError("database is restarting"),
         ConnectionDoesNotExistError("database connection was interrupted"),
     ],
-    ids=("sqlalchemy", "postgres-restart", "postgres-connection-loss"),
+    ids=(
+        "sqlalchemy",
+        "socket-refused",
+        "postgres-restart",
+        "postgres-connection-loss",
+    ),
 )
 async def test_database_failure_retries_without_terminating_runtime(
     database_error: Exception,

--- a/tests/unit/services/portfolio_transaction_processing_service/runtime/test_corporate_action_release_worker.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/runtime/test_corporate_action_release_worker.py
@@ -7,6 +7,7 @@ import pytest
 from asyncpg import (
     CannotConnectNowError,
     ConnectionDoesNotExistError,
+    QueryCanceledError,
     UniqueViolationError,
 )
 from sqlalchemy.exc import SQLAlchemyError
@@ -100,12 +101,22 @@ async def test_database_failure_retries_without_terminating_runtime(
 
 
 @pytest.mark.asyncio
-async def test_non_transient_driver_error_terminates_worker() -> None:
+@pytest.mark.parametrize(
+    "database_error",
+    [
+        UniqueViolationError("constraint violation"),
+        QueryCanceledError("statement cancelled"),
+    ],
+    ids=("integrity-error", "query-cancelled"),
+)
+async def test_non_transient_driver_error_terminates_worker(
+    database_error: Exception,
+) -> None:
     use_case = AsyncMock()
-    use_case.execute.side_effect = UniqueViolationError("constraint violation")
+    use_case.execute.side_effect = database_error
     worker = CorporateActionReleaseWorker(use_case)
 
-    with pytest.raises(UniqueViolationError, match="constraint violation"):
+    with pytest.raises(type(database_error), match=str(database_error)):
         await worker.run()
 
 

--- a/tests/unit/services/portfolio_transaction_processing_service/runtime/test_corporate_action_release_worker.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/runtime/test_corporate_action_release_worker.py
@@ -4,6 +4,11 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from asyncpg import (
+    CannotConnectNowError,
+    ConnectionDoesNotExistError,
+    UniqueViolationError,
+)
 from sqlalchemy.exc import SQLAlchemyError
 
 from src.services.portfolio_transaction_processing_service.app.application import (
@@ -64,10 +69,21 @@ async def test_stop_allows_in_flight_member_to_finish_before_exit() -> None:
 
 
 @pytest.mark.asyncio
-async def test_database_failure_retries_without_terminating_runtime() -> None:
+@pytest.mark.parametrize(
+    "database_error",
+    [
+        SQLAlchemyError("database unavailable"),
+        CannotConnectNowError("database is restarting"),
+        ConnectionDoesNotExistError("database connection was interrupted"),
+    ],
+    ids=("sqlalchemy", "postgres-restart", "postgres-connection-loss"),
+)
+async def test_database_failure_retries_without_terminating_runtime(
+    database_error: Exception,
+) -> None:
     use_case = AsyncMock()
     use_case.execute.side_effect = [
-        SQLAlchemyError("database unavailable"),
+        database_error,
         CorporateActionReleaseWorkerResult(CorporateActionReleaseWorkerStatus.IDLE),
     ]
     worker = CorporateActionReleaseWorker(
@@ -81,6 +97,16 @@ async def test_database_failure_retries_without_terminating_runtime() -> None:
     worker.stop()
 
     await asyncio.wait_for(task, timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_non_transient_driver_error_terminates_worker() -> None:
+    use_case = AsyncMock()
+    use_case.execute.side_effect = UniqueViolationError("constraint violation")
+    worker = CorporateActionReleaseWorker(use_case)
+
+    with pytest.raises(UniqueViolationError, match="constraint violation"):
+        await worker.run()
 
 
 async def _wait_for_calls(mock: AsyncMock, *, minimum: int) -> None:


### PR DESCRIPTION
## Objective

Restore exact-main releasability after run 31477663874 exposed two deterministic failures: historical migration tests used the wrong revision-presence marker, and the new corporate-action background worker terminated transaction processing during a governed PostgreSQL restart.

## Measurable improvement

- c155 is normalized only when its authority function exists;
- c154 is normalized only when its support index exists;
- c153 is normalized only when its release table exists;
- raw asyncpg restart, administrator/crash shutdown, connection-loss, and capacity errors are retried like SQLAlchemy database errors;
- non-transient driver integrity errors remain terminal;
- the exact PostgreSQL rollback failures and the worker restart path have focused regression proof.

## Compatibility

No API, OpenAPI, schema, immutable migration, event, dependency, image, or deployment-topology change. The runtime remains on the mature Python/asyncpg/SQLAlchemy/PostgreSQL stack. No new technology or package is introduced.

Docs/wiki no-change decision: this repairs conformance to the already documented durable-worker behavior; no operator command, public contract, or support claim changed.

## Validation

- exact failing PostgreSQL tests: 2 passed in 63.43s
- populated c152 upgrade followed by both rollback tests: 3 passed in 73.01s
- corporate-action release worker resilience: 8 passed
- mypy: 318 source files, no issues
- full architecture guard: passed
- Ruff check/format and `git diff --check`: passed
- signed commits: `92dbd42e580a421f6a132c96c3b1b043803caeaf`, `d57ac98fcee8863b0a00f680421f1622dc26c396`, `e81f2e8b9c6aea6d57149240679feb1ac16e2929`, `cc9d00451edcbaf32a9b8a26b35c4816872ddedd`

## Evidence and closure

- failed exact-main run: https://github.com/sgajbi/lotus-core/actions/runs/31477663874
- #720 retains release-certification ownership
- #480 is reopened until this PR is merged and fresh exact-main Integration Full and E2E Full pass

No issue is auto-closed by this PR; verified closure follows exact-main evidence.



