### PR TITLE
fix(runtime): restore exact-main migration and settlement convergence

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -2762,8 +2762,10 @@ Most relevant current governance:
      transaction epoch, and full transaction-payload fingerprint; claims use PostgreSQL-clock
      leases and monotonic fences so expired workers can be recovered without permitting stale
      progress. Live transaction intake requires transaction type plus complete
-     event/group/parent/role identity before manifest parking: absent identity preserves the
-     ordinary compatibility path, while partial identity fails closed. READY observation or
+     event/group/parent/role identity before manifest parking. Manifest-specific
+     `parent_event_reference` or `child_role` opts a transaction into that path; shared
+     `economic_event_id` and `linked_transaction_group_id` alone remain ordinary settlement or
+     fee/tax linkage. Once opted in, partial identity fails closed. READY observation or
      manifest transitions materialize the immutable release in the same lightweight UoW. The
      existing transaction-processing deployable uses short claim/load/progress transactions,
      revalidates the frozen payload fingerprint, processes outside the lease transaction under a

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -1,5 +1,18 @@
 # Codebase Review Ledger
 
+CR-1683 manifest-arrival discriminator addendum (2026-08-11): exact-main E2E run `31484915013`
+proved that an upstream-provided `ADJUSTMENT` cash settlement carrying ordinary economic-event and
+linked-transaction-group references was misclassified as a partially identified corporate-action
+manifest child, rejected terminally, and sent to the DLQ. Manifest parking now opts in only when
+the manifest-specific `parent_event_reference` or `child_role` is populated; after opt-in, the
+complete event/group/parent/role quartet remains mandatory and fail-closed. The same-pattern guard
+covers ordinary `ADJUSTMENT`, `FEE`, and `TAX` linkage, and the application test proves that shared
+settlement linkage bypasses graph persistence. The correction is an O(1) pure domain predicate on
+the existing Python/FastAPI/PostgreSQL/Kafka stack; it adds no dependency, schema, I/O, timeout, or
+topology. Validation: 22 focused tests, scoped Ruff, MyPy across 318 sources, and the architecture
+guard. Repository context changed; OpenAPI, migrations, API contracts, and capability wiki truth
+did not change, so no wiki source update is required.
+
 CR-1683 protected-review reconciliation addendum (2026-08-11): PR #935 review identified four
 production-significant authority gaps. The branch had edited already-applied migration `c152`,
 legacy child observations could retain a null transaction-payload fingerprint, the minimum

--- a/src/services/portfolio_transaction_processing_service/app/domain/transaction/corporate_action/arrival.py
+++ b/src/services/portfolio_transaction_processing_service/app/domain/transaction/corporate_action/arrival.py
@@ -24,11 +24,16 @@ def corporate_action_manifest_child(
         raise TypeError("transaction must be a BookedTransaction")
     if not is_manifest_governed_corporate_action(transaction.transaction_type):
         return None
+    manifest_identity_values = (
+        transaction.parent_event_reference,
+        transaction.child_role,
+    )
+    if not any(_present(value) for value in manifest_identity_values):
+        return None
     identity_values = (
         transaction.economic_event_id,
         transaction.linked_transaction_group_id,
-        transaction.parent_event_reference,
-        transaction.child_role,
+        *manifest_identity_values,
     )
     populated_identity_count = sum(_present(value) for value in identity_values)
     if populated_identity_count == 0:

--- a/tests/integration/test_lot_amortized_cost_profile_migration.py
+++ b/tests/integration/test_lot_amortized_cost_profile_migration.py
@@ -191,9 +191,18 @@ def _downgrade_later_revisions(connection) -> list[dict[str, Any]]:
         (
             CORPORATE_ACTION_DEPENDENT_MIGRATIONS[0],
             connection.scalar(
-                text("SELECT to_regprocedure('enforce_ca_manifest_payload_book_scope()')")
-            )
-            is not None,
+                text(
+                    """
+                    SELECT EXISTS (
+                        SELECT 1
+                        FROM pg_trigger
+                        WHERE tgname = 'trg_ca_manifest_payload_book_scope'
+                          AND tgrelid = to_regclass('corporate_action_manifest_versions')
+                          AND NOT tgisinternal
+                    )
+                    """
+                )
+            ),
         ),
         (
             CORPORATE_ACTION_DEPENDENT_MIGRATIONS[1],
@@ -233,6 +242,48 @@ def _downgrade_later_revisions(connection) -> list[dict[str, Any]]:
         later_migration["downgrade"]()
         later_migrations.append(later_migration)
     return later_migrations
+
+
+def test_historical_normalization_does_not_infer_c155_from_an_orphaned_function(
+    db_engine,
+    clean_db,
+) -> None:
+    connection = db_engine.connect()
+    transaction = connection.begin()
+    try:
+        connection.execute(
+            text(
+                """
+                CREATE OR REPLACE FUNCTION enforce_ca_manifest_payload_book_scope()
+                RETURNS trigger
+                LANGUAGE plpgsql
+                AS $$
+                BEGIN
+                    RETURN NEW;
+                END;
+                $$
+                """
+            )
+        )
+        connection.execute(
+            text(
+                "DROP TRIGGER IF EXISTS trg_ca_manifest_payload_book_scope "
+                "ON corporate_action_manifest_versions"
+            )
+        )
+        assert (
+            connection.scalar(
+                text("SELECT to_regprocedure('enforce_ca_manifest_payload_book_scope()')")
+            )
+            is not None
+        )
+
+        downgraded = _downgrade_later_revisions(connection)
+
+        assert "c155b2c3d522" not in {migration["revision"] for migration in downgraded}
+    finally:
+        transaction.rollback()
+        connection.close()
 
 
 def _seed_source_lot(connection) -> None:

--- a/tests/integration/test_portfolio_valuation_book_scope_migration.py
+++ b/tests/integration/test_portfolio_valuation_book_scope_migration.py
@@ -118,9 +118,18 @@ def _downgrade_dependent_schema(connection) -> list[dict[str, Any]]:
         (
             CORPORATE_ACTION_DEPENDENT_MIGRATIONS[0],
             connection.scalar(
-                text("SELECT to_regprocedure('enforce_ca_manifest_payload_book_scope()')")
-            )
-            is not None,
+                text(
+                    """
+                    SELECT EXISTS (
+                        SELECT 1
+                        FROM pg_trigger
+                        WHERE tgname = 'trg_ca_manifest_payload_book_scope'
+                          AND tgrelid = to_regclass('corporate_action_manifest_versions')
+                          AND NOT tgisinternal
+                    )
+                    """
+                )
+            ),
         ),
         (
             CORPORATE_ACTION_DEPENDENT_MIGRATIONS[1],

--- a/tests/unit/services/portfolio_transaction_processing_service/application/test_corporate_action_arrival.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/application/test_corporate_action_arrival.py
@@ -1,5 +1,6 @@
 """Specify live child parking before corporate-action financial execution."""
 
+from dataclasses import replace
 from datetime import UTC, datetime
 from decimal import Decimal
 
@@ -135,6 +136,28 @@ async def test_ordinary_transaction_bypasses_graph_persistence() -> None:
     )
 
     result = await use_case.execute(_command(transaction_type="BUY"))
+
+    assert result.disposition is CorporateActionArrivalDisposition.ORDINARY
+    assert unit_of_work.event_graph.observations == []
+    assert not unit_of_work.committed
+
+
+@pytest.mark.asyncio
+async def test_shared_settlement_linkage_bypasses_manifest_graph_persistence() -> None:
+    use_case, unit_of_work = _use_case(
+        _decision(corporate_action.CorporateActionManifestReadinessStatus.AWAITING_MANIFEST)
+    )
+    command = _command(transaction_type="ADJUSTMENT")
+    command = replace(
+        command,
+        transaction=replace(
+            command.transaction,
+            parent_event_reference=None,
+            child_role=None,
+        ),
+    )
+
+    result = await use_case.execute(command)
 
     assert result.disposition is CorporateActionArrivalDisposition.ORDINARY
     assert unit_of_work.event_graph.observations == []

--- a/tests/unit/services/portfolio_transaction_processing_service/domain/transaction/corporate_action/test_arrival.py
+++ b/tests/unit/services/portfolio_transaction_processing_service/domain/transaction/corporate_action/test_arrival.py
@@ -87,21 +87,37 @@ def test_non_corporate_action_type_remains_on_ordinary_processing_path(
 
 
 @pytest.mark.parametrize("transaction_type", ("ADJUSTMENT", "FEE", "TAX"))
-def test_ordinary_charge_or_adjustment_without_graph_identity_is_not_parked(
+def test_ordinary_charge_or_adjustment_with_shared_linkage_is_not_parked(
     transaction_type: str,
 ) -> None:
     assert (
         corporate_action_manifest_child(
             _transaction(
                 transaction_type=transaction_type,
-                economic_event_id=None,
-                linked_transaction_group_id=None,
                 parent_event_reference=None,
                 child_role=None,
             )
         )
         is None
     )
+
+
+@pytest.mark.parametrize("manifest_field", ("parent_event_reference", "child_role"))
+def test_manifest_specific_identity_still_requires_complete_authority(
+    manifest_field: str,
+) -> None:
+    identity = {
+        "parent_event_reference": None,
+        "child_role": None,
+    }
+    identity[manifest_field] = "MANIFEST-IDENTITY"
+    transaction = replace(
+        _transaction(),
+        **identity,
+    )
+
+    with pytest.raises(IncompleteCorporateActionManifestIdentityError, match="fully populated"):
+        corporate_action_manifest_child(transaction)
 
 
 def test_non_domain_value_is_rejected() -> None:


### PR DESCRIPTION
## Objective
Restore exact-main releasability after run `31484915013` exposed two bounded correctness defects:

- historical migration tests inferred c155 from an orphaned function even when its trigger was absent;
- ordinary upstream settlement linkage was misclassified as partial corporate-action manifest identity and DLQ'd.

## Measurable improvement

- Historical c155 detection now uses the installed non-internal trigger on `corporate_action_manifest_versions`.
- Shared settlement/fee/tax event and cohort linkage bypasses manifest parking unless manifest-specific parent or child-role identity opts in.
- True manifest opt-in remains fail-closed unless all four event/group/parent/role fields are present.
- The classification predicate remains O(1) and adds no I/O, dependency, image, datastore, or topology.

## Compatibility

No OpenAPI, database schema, migration, Kafka contract, response contract, or capability change. Ordinary `ADJUSTMENT`, `FEE`, and `TAX` processing compatibility is restored; corporate-action manifest strictness is preserved.

## Validation

- 3 real-PostgreSQL historical migration tests passed.
- 22 corporate-action arrival domain/application tests passed.
- Scoped Ruff format/check passed.
- MyPy passed across 318 source files.
- Architecture guard passed.
- `git diff --check` passed.
- Both commits carry verified ED25519 signatures.

## Documentation and wiki

Repository context and the codebase review ledger record the corrected discriminator and exact-main evidence. OpenAPI, migrations, API contracts, and capability wiki truth did not change; explicit no-wiki-change decision is recorded.

Related: #480
Diagnostic evidence: #730