### PR TITLE
test: release leases in readiness fixtures

### DIFF
--- a/tests/integration/services/valuation_orchestrator_service/test_readiness_outbox_sequence_fence.py
+++ b/tests/integration/services/valuation_orchestrator_service/test_readiness_outbox_sequence_fence.py
@@ -83,6 +83,14 @@ async def _read_job(session: AsyncSession) -> PortfolioValuationJob:
     ).scalar_one()
 
 
+def _mark_job_complete(job: PortfolioValuationJob) -> None:
+    """Model the atomic terminal transition required by the lease invariant."""
+    job.status = "COMPLETE"
+    job.valuation_lease_owner = None
+    job.valuation_claim_token = None
+    job.valuation_lease_expires_at = None
+
+
 async def _apply_readiness(session: AsyncSession, *, outbox_id: int) -> None:
     await ValuationJobRepository(session).upsert_position_readiness_job(
         portfolio_id=PORTFOLIO_ID,
@@ -204,7 +212,7 @@ async def test_new_sequence_rearms_completed_job_and_redelivery_is_idempotent(
     await async_db_session.commit()
     await _seed_pending_job(async_db_session)
     job = await _read_job(async_db_session)
-    job.status = "COMPLETE"
+    _mark_job_complete(job)
     job.claimed_readiness_outbox_id = covered_id
     await async_db_session.commit()
 
@@ -246,7 +254,7 @@ async def test_unverified_high_transport_sequence_cannot_poison_claimed_authorit
     await _seed_pending_job(async_db_session)
     await ValuationRepository(async_db_session).find_and_claim_eligible_jobs(1)
     job = await _read_job(async_db_session)
-    job.status = "COMPLETE"
+    _mark_job_complete(job)
     await async_db_session.commit()
 
     unverified_high_id = covered_id + 1_000_000
@@ -254,7 +262,7 @@ async def test_unverified_high_transport_sequence_cannot_poison_claimed_authorit
     claimed = await ValuationRepository(async_db_session).find_and_claim_eligible_jobs(1)
     assert claimed[0].claimed_readiness_outbox_id == covered_id
     claimed_job = await _read_job(async_db_session)
-    claimed_job.status = "COMPLETE"
+    _mark_job_complete(claimed_job)
     await async_db_session.commit()
 
     legitimate = await _stage_readiness(async_db_session)


### PR DESCRIPTION
## Summary
- fix the exact-main Integration Full failure by making readiness-sequence fixtures perform the complete terminal lease release
- centralize the test-only terminal transition so status, owner, token, and expiry cannot drift apart

## Failure evidence
Main Releasability run 31528969345 failed 1 of 1,115 integration tests:
`test_unverified_high_transport_sequence_cannot_poison_claimed_authority` set a claimed valuation row to `COMPLETE` while retaining owner/token/expiry. Database constraint `ck_portfolio_valuation_jobs_processing_lease_state` correctly rejected that impossible state. The other 1,114 tests and every other mainline lane passed.

## Scope and compatibility
- One integration-test fixture file, one signed commit.
- Runtime implementation, database schema/migration, API/OpenAPI, event contracts, financial calculations, dependencies, topology, context, docs, and wiki are unchanged.
- No new issue: this is the same #487 lease-invariant closure pattern found by exact-main CI.

## Validation
- [x] Focused real-PostgreSQL readiness-sequence file: 12 passed in 107.05s
- [x] Scoped Ruff check/format and `git diff --check`
- [x] Full `make test-integration-all`: 1,115 passed in 1,831.35s
- [ ] Remote Feature Lane and protected PR Merge Gate
- [ ] replacement exact-main Main Releasability

## Documentation/wiki decision
No change: this fixes invalid test setup and does not change product, operator, contract, schema, runtime, or governance truth. Existing lease documentation remains correct. No wiki publication is required for this PR.

Contributes to #487
